### PR TITLE
Permit test harness to use http proxy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ it's own sandboxed workspace.
 * [Selecting browser](docs/BROWSER.md)
 * [Selecting how to launch Jenkins under test (JUT)](docs/CONTROLLER.md)
 * [Running one test](docs/SINGLE-TEST.md)
+* [Using a http proxy](docs/USING-A-HTTP-PROXY.md)
 * [Prelaunch JUT](docs/PRELAUNCH.md)
 * Selecting tests based on plugins they cover (TODO)
 

--- a/docs/USING-A-HTTP-PROXY.md
+++ b/docs/USING-A-HTTP-PROXY.md
@@ -1,0 +1,28 @@
+# Running with a http proxy
+If your environment requires a HTTP proxy, then you must configure your setup as follows:
+
+## Maven settings
+Ensure that your Maven user settings file contains the proxy information:
+
+```xml
+  <proxies>
+    <proxy>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>www-proxy.mycompany.com</host>
+      <port>8080</port>
+      <username></username>
+      <password></password>
+      <nonProxyHosts>127.0.0.1|localhost|*.mycompany.com</nonProxyHosts>
+    </proxy>
+  </proxies>
+```
+
+See [Maven Guide to Proxies](http://maven.apache.org/guides/mini/guide-proxies.html) for more details.
+
+## Command line arguments
+The following arguments are needed on the command line in order for the tests to install plugins:
+
+    mvn -Dtest=WarningsPluginTest -Dhttp.proxyHost=www-proxy.mycompany.com -Dhttp.proxyPort=8080 -Dhttps.proxyHost=www-proxy.mycompany.com -Dhttps.proxyPort=8080 -Dhttp.nonProxyHosts=*.mycompany.com test
+
+TODO: be able to tell the Browser spawned during the tests to use the proxy information specified via command line parameters.

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
       <artifactId>maven-aether-provider</artifactId>
       <version>${maven.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-settings-builder</artifactId>
+      <version>${maven.version}</version>
+    </dependency>
 
     <dependency><!-- to align the version of Guava that we use between jclouds and Aether -->
       <groupId>org.sonatype.sisu</groupId>

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -12,9 +12,6 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.resolution.ArtifactRequest;
-import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.jenkinsci.test.acceptance.controller.JenkinsController;
 import org.jenkinsci.test.acceptance.controller.JenkinsControllerFactory;
@@ -29,6 +26,7 @@ import org.jenkinsci.test.acceptance.slave.LocalSlaveProvider;
 import org.jenkinsci.test.acceptance.slave.SlaveProvider;
 import org.jenkinsci.test.acceptance.utils.ElasticTime;
 import org.jenkinsci.test.acceptance.utils.SauceLabsConnection;
+import org.jenkinsci.test.acceptance.utils.aether.ArtifactResolverUtil;
 import org.jenkinsci.test.acceptance.utils.mail.MailService;
 import org.jenkinsci.test.acceptance.utils.mail.Mailtrap;
 import org.junit.runners.model.Statement;
@@ -187,16 +185,9 @@ public class FallbackConfig extends AbstractModule {
      */
     @Named("form-element-path.hpi") @Provides
     public File getFormElementsPathFile(RepositorySystem repositorySystem, RepositorySystemSession repositorySystemSession) {
-        try {
-            ArtifactResult resolvedArtifact = repositorySystem.resolveArtifact(repositorySystemSession,
-                    new ArtifactRequest(new DefaultArtifact("org.jenkins-ci.plugins", "form-element-path", "hpi", "1.4"),
-                            Arrays.asList(new RemoteRepository.Builder("repo.jenkins-ci.org", "default", "http://repo.jenkins-ci.org/public/").build()),
-                            null));
-            return resolvedArtifact.getArtifact().getFile();
-        }
-        catch (ArtifactResolutionException e) {
-            throw new RuntimeException("Could not resolve form-element-path.hpi from Maven repository repo.jenkins-ci.org.", e);
-        }
+        ArtifactResolverUtil resolverUtil = new ArtifactResolverUtil(repositorySystem, repositorySystemSession);
+        ArtifactResult resolvedArtifact = resolverUtil.resolve(new DefaultArtifact("org.jenkins-ci.plugins", "form-element-path", "hpi", "1.4"));
+        return resolvedArtifact.getArtifact().getFile();
     }
 
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/aether/ArtifactResolverUtil.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/aether/ArtifactResolverUtil.java
@@ -1,0 +1,149 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.test.acceptance.utils.aether;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
+import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuilder;
+import org.apache.maven.settings.building.SettingsBuildingException;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RemoteRepository.Builder;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class to resolve artifacts with Aether
+ * with http proxy support
+ *
+ * @author scott.hebert@ericsson.com
+ */
+public class ArtifactResolverUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactResolverUtil.class);
+    private RepositorySystem repoSystem;
+    private RepositorySystemSession repoSystemSession;
+
+    public ArtifactResolverUtil(RepositorySystem rs, RepositorySystemSession rss) {
+        repoSystem = rs;
+        repoSystemSession = rss;
+    }
+
+    /**
+     * @param gav The "groupId artifactId version" to be resolved
+     * @param version The version of the artifact you want to resolve
+     *
+     * @return artifact resolution result
+     */
+    public ArtifactResult resolve(String gav, String version) {
+        return resolve(makeArtifact(gav, version));
+    }
+
+    /**
+     * @param artifact The artifact to be resolved
+     *
+     * @return artifact resolution result
+     */
+    public ArtifactResult resolve(DefaultArtifact artifact) {
+        Builder repoBuilder = new RemoteRepository.Builder(
+                "repo.jenkins-ci.org", "default",
+                "http://repo.jenkins-ci.org/public/");
+
+        DefaultSettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
+
+        File userHome = new File(System.getProperty("user.home"));
+        File userSettingsFile = new File(new File(userHome, ".m2"), "settings.xml");
+        request.setUserSettingsFile(userSettingsFile);
+
+        if (userSettingsFile.exists()) {
+            LOGGER.debug("Found maven settings file - " + userSettingsFile.getAbsolutePath());
+            SettingsBuilder settingsBuilder = new DefaultSettingsBuilderFactory().newInstance();
+
+            try {
+                Settings settings = settingsBuilder.build(request).getEffectiveSettings();
+                org.apache.maven.settings.Proxy mavenActiveproxy = settings.getActiveProxy();
+                if (mavenActiveproxy != null) {
+                    LOGGER.debug("Found maven proxy settings. Will use for artifact resolution");
+                    repoBuilder.setProxy(asProxy(mavenActiveproxy));
+                } else {
+                    LOGGER.debug("Did not find an active proxy in maven settings xml file");
+                }
+            } catch (SettingsBuildingException e) {
+                LOGGER.warn("Could not find or load settings.xml to attempt to user proxy settings.", e);
+            }
+        }
+
+        RemoteRepository repo = repoBuilder.build();
+        ArtifactResult r;
+        try {
+            r = repoSystem.resolveArtifact(repoSystemSession,new ArtifactRequest(artifact, Arrays.asList(repo), null));
+        } catch (ArtifactResolutionException e) {
+            throw new RuntimeException("Could not resolve " + artifact + " from Maven repository",e);
+        }
+        LOGGER.debug("Found " + r);
+        return r;
+    }
+
+    private DefaultArtifact makeArtifact(String gav, String version) {
+        String[] t = gav.split(":");
+        String gavVersion;
+        if (version == null) {
+            gavVersion = t[2];
+        } else {
+            gavVersion = version;
+        }
+        return new DefaultArtifact(t[0], t[1], "hpi", gavVersion);
+    }
+
+    /**
+     * Converts Maven Proxy to Aether Proxy
+     *
+     * @param proxy the Maven proxy to be converted
+     * @return Aether proxy equivalent
+     */
+    private static Proxy asProxy(org.apache.maven.settings.Proxy proxy) {
+        Authentication auth = null;
+        if (proxy.getUsername() != null && proxy.getPassword() != null) {
+            AuthenticationBuilder authBuilder = new AuthenticationBuilder();
+            authBuilder.addUsername(proxy.getUsername());
+            authBuilder.addPassword(proxy.getPassword());
+            auth = authBuilder.build();
+        }
+        return new Proxy(proxy.getProtocol(), proxy.getHost(), proxy.getPort(), auth);
+    }
+
+}


### PR DESCRIPTION
This pull request permits the test harness to use
http proxy settings from both maven settings
and command line arguments.

Artifact Resolution was refactored to be contained
in a single helper class ArtifactResolverUtil.java

[FIXED JENKINS-23113]
