### PR TITLE
Create an Exercised Plugins Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ it's own sandboxed workspace.
 * [Running one test](docs/SINGLE-TEST.md)
 * [Using a http proxy](docs/USING-A-HTTP-PROXY.md)
 * [Prelaunch JUT](docs/PRELAUNCH.md)
+* [Obtaining a report of plugins that were exercised](docs/EXERCISEDPLUGINSREPORTER.md)
 * Selecting tests based on plugins they cover (TODO)
 
 ### Writing tests

--- a/docs/EXERCISEDPLUGINSREPORTER.md
+++ b/docs/EXERCISEDPLUGINSREPORTER.md
@@ -1,0 +1,28 @@
+# Exercised Plugins Report
+It is possible to create an **Exercised Plugins** Report by specifying the `EXERCISEDPLUGINREPORTER` environment variable.
+
+## Reporter Types
+The following types are available:
+
+ * `console` (default)
+ * `textfile`
+
+## Console Reporter
+The Console Reporter simply logs the plugin and its version to standard output.
+
+Here is an example:
+
+    Plugin ldap/1.20.2 is installed
+
+## Text File Reporter
+The Text File Reporter will create a properties file in the `target` folder containing a list of plugin names and their versions prefixed by the test name.
+
+Here is an example:
+
+	plugins.LdapPluginTest\:\:ldap = 1.10.2
+	plugins.ActiveDirectoryTest\:\:active-directory = 1.38
+
+This Reporter type can be very useful when you want to be able to see which plugins and their versions were tested with a particular version of Jenkins Core.
+
+	Note: The output file is re-created at the start of each test suite run.
+

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,11 @@
       <artifactId>jsch</artifactId>
       <version>0.1.51</version>
     </dependency>
+    <dependency>
+        <groupId>commons-configuration</groupId>
+        <artifactId>commons-configuration</artifactId>
+        <version>1.10</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.test.acceptance;
 
 import javax.inject.Named;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -29,6 +29,9 @@ import org.jenkinsci.test.acceptance.utils.SauceLabsConnection;
 import org.jenkinsci.test.acceptance.utils.aether.ArtifactResolverUtil;
 import org.jenkinsci.test.acceptance.utils.mail.MailService;
 import org.jenkinsci.test.acceptance.utils.mail.Mailtrap;
+import org.jenkinsci.test.acceptance.utils.pluginreporter.ExercisedPluginsReporter;
+import org.jenkinsci.test.acceptance.utils.pluginreporter.TextFileExercisedPluginReporter;
+import org.jenkinsci.test.acceptance.utils.pluginreporter.ConsoleExercisedPluginReporter;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
@@ -201,5 +204,30 @@ public class FallbackConfig extends AbstractModule {
     public boolean neverReplaceExistingPlugins() {
         return System.getenv("NEVER_REPLACE_EXISTING_PLUGINS") != null;
     }
+
+    /**
+     *  Provides a mechanism to create a report on which plugins were used
+     *  during the test execution
+     *
+     *  @return An ExercisedPluginReporter based on env var EXERCISEDPLUGINREPORTER
+     */
+     @Provides @Named("ExercisedPluginReporter")
+     public ExercisedPluginsReporter createExercisedPluginReporter() {
+         String reporter = System.getenv("EXERCISEDPLUGINREPORTER");
+         if (reporter==null) {
+             reporter = "console";
+         } else {
+             reporter = reporter.toLowerCase(Locale.ENGLISH);
+         }
+
+         switch (reporter) {
+         case "console":
+             return new ConsoleExercisedPluginReporter();
+         case "textfile":
+             return TextFileExercisedPluginReporter.getInstance();
+         default:
+             throw new AssertionError("Unrecognized Exercised Plugin Report type: "+reporter);
+         }
+     }
 }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/pluginreporter/ConsoleExercisedPluginReporter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/pluginreporter/ConsoleExercisedPluginReporter.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.test.acceptance.utils.pluginreporter;
+
+/**
+ * Exercised Plugin Reporter that logs to console
+ *
+ * @author scott.hebert@ericsson.com
+ */
+public class ConsoleExercisedPluginReporter implements ExercisedPluginsReporter {
+
+    @Override
+    public void log(String testName, String pluginName, String pluginVersion) {
+        System.out.println("Plugin " + pluginName + "/" + pluginVersion + " is installed");
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/pluginreporter/ExercisedPluginsReporter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/pluginreporter/ExercisedPluginsReporter.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.test.acceptance.utils.pluginreporter;
+
+import org.jenkinsci.test.acceptance.junit.WithPlugins;
+
+/**
+ * Interface for the ability to create a report to show plugins 
+ * and their versions that were exercised during the test suite run
+ *
+ * @author scott.hebert@ericsson.com
+ */
+public interface ExercisedPluginsReporter {
+    /**
+     * This method is called by {@link WithPlugins} to log and report
+     * the plugin and its version installed by the test
+     *
+     * @param testName Name of Test being executed
+     * @param pluginName Name of Plugin that was installed
+     * @param pluginVersion Version of Plugin that was installed
+     */
+    public void log(String testName, String pluginName, String pluginVersion);
+
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/pluginreporter/TextFileExercisedPluginReporter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/pluginreporter/TextFileExercisedPluginReporter.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.test.acceptance.utils.pluginreporter;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Exercised Plugin Reporter that logs to text file
+ * The contents are java properties.
+ *
+ * Properties will be stored as follows:
+ *
+ * <testName>::<pluginName> = <pluginVersion>
+ *
+ * @author scott.hebert@ericsson.com
+ */
+public class TextFileExercisedPluginReporter implements ExercisedPluginsReporter {
+
+    private static TextFileExercisedPluginReporter instance = null;
+    private static final Logger LOGGER = LoggerFactory.getLogger(TextFileExercisedPluginReporter.class);
+    private File file;
+
+    private TextFileExercisedPluginReporter() {
+        file = new File(System.getProperty("basedir") + "/target/exercised-plugins.properties");
+        if (file.exists()) {
+            LOGGER.info("Deleting " + file.getAbsolutePath());
+            file.delete();
+        }
+        try {
+            FileUtils.touch(file);
+         } catch (IOException e) {
+             LOGGER.error(e.getMessage());
+             return;
+         }
+
+    }
+    public static TextFileExercisedPluginReporter getInstance() {
+        if (instance == null) {
+            instance = new TextFileExercisedPluginReporter();
+        }
+        return instance;
+    }
+    @Override
+    public void log(String testName, String pluginName, String pluginVersion) {
+
+        PropertiesConfiguration config = null;
+        try {
+           config = new PropertiesConfiguration(file);
+        } catch (ConfigurationException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+
+        config.setProperty(testName + "::" + pluginName, pluginVersion);
+        try {
+            config.save();
+        } catch (ConfigurationException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+    }
+}


### PR DESCRIPTION
This feature permits the creation of a report that describes
which plugins were exercised and what versions were used.

Two reporter types are available. The default "Console" reporter and
the "Text File" reporter.

The Text File reporter creates a java properties file and is useful
when wanting to be able to see which plugins and their versions were
tested with a particular version of Jenkins Core.

[FIXED JENKINS-23754]
