### PR TITLE
Improve reading of json from Gerrit API

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerJob.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerJob.java
@@ -53,7 +53,6 @@ public class GerritTriggerJob extends PageObject {
      * Saves harness' gerrit-trigger test-job configuration.
      */
     public void saveTestJobConfig() {
-        open();
         if(!event.resolve().isSelected()) event.click();
         server.select(this.getClass().getPackage().getName());
         advanced.click();

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerNewServer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerNewServer.java
@@ -47,9 +47,17 @@ public class GerritTriggerNewServer extends PageObject {
      * Does not matter if already configured; no-op with harmless error then.
      */
     public void saveNewTestServerConfigIfNone() {
+        avoidOccasional404FromNonReadyGerritUI();
         open();
         name.set(this.getClass().getPackage().getName());
         modeDefault.click();
         clickButton("OK");
+    }
+
+    private void avoidOccasional404FromNonReadyGerritUI() {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e1) {
+        }
     }
 }


### PR DESCRIPTION
The PR improves the way Gerrit API result json is queried so that
the test is more robust.

In addition, a potentially failing and unneccessary "open()" call
was removed.

Lastly, the use of ProcessBuilder was re-worked to improve debugging
for failed command executions.
