### PR TITLE
LocalController doesn't inherit http proxy settings from command line

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
@@ -1,5 +1,16 @@
 package org.jenkinsci.test.acceptance.controller;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
 import com.google.inject.Injector;
 
 import org.apache.commons.io.FileUtils;
@@ -13,16 +24,6 @@ import org.jenkinsci.utils.process.ProcessInputStream;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Named;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.lang.reflect.Field;
-import java.net.ServerSocket;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Logger;
 
 import static java.lang.System.*;
 
@@ -223,6 +224,23 @@ public abstract class LocalController extends JenkinsController implements LogLi
                 start();
             }
         }
+    }
+
+    private void addProxyProperty(ArrayList<String> properties, String proxyProperty) {
+        String prop = System.getProperty(proxyProperty);
+        if (prop != null) {
+            properties.add("-D" + proxyProperty + "=" + prop);
+        }
+    }
+
+    public ArrayList<String> getProxyProperties() {
+        ArrayList<String> properties = new ArrayList<String>();
+        addProxyProperty(properties, "http.proxyHost");
+        addProxyProperty(properties, "http.proxyPort");
+        addProxyProperty(properties, "https.proxyHost");
+        addProxyProperty(properties, "https.proxyPort");
+        addProxyProperty(properties, "http.nonProxyHosts");
+        return properties;
     }
 
     public File getJavaHome() {

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 
 import org.jenkinsci.utils.process.CommandBuilder;
 import org.jenkinsci.utils.process.ProcessInputStream;
@@ -30,12 +31,16 @@ public class WinstoneController extends LocalController {
     @Override
     public ProcessInputStream startProcess() throws IOException{
         File javaHome = getJavaHome();
+        ArrayList<String> proxyProperties = getProxyProperties();
         String java = javaHome == null ? "java" : String.format("%s/bin/java",javaHome.getAbsolutePath());
-        CommandBuilder cb = new CommandBuilder(java).add(
-                "-Duser.language=en",
-                "-jar", war,
-                "--ajp13Port=-1",
-                "--httpPort=" + httpPort);
+        CommandBuilder cb = new CommandBuilder(java).add("-DJENKINS_HOME=" + getJenkinsHome());
+        for (String proxyProp: proxyProperties) {
+            cb.add(proxyProp);
+        }
+        cb.add("-Duser.language=en");
+        cb.add("-jar", war);
+        cb.add("--ajp13Port=-1");
+        cb.add("--httpPort=" + httpPort);
         cb.env.putAll(commonLaunchEnv());
         System.out.println("Starting Jenkins: " + cb.toString());
         return cb.popen();


### PR DESCRIPTION
Certain tests require the HTTP proxy settings to be
specified in order to function correctly.

In particular, this fixes the GroovyPluginTest when run in a proxied-environment.

[FIXED JENKINS-23326]