### PR TITLE
Bump selenium version to 2.45.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <selenium.version>2.44.0</selenium.version>
+    <selenium.version>2.45.0</selenium.version>
     <aether.version>0.9.0.v20140226</aether.version>
     <maven.version>3.1.0</maven.version>
     <groovy.version>2.3.1</groovy.version>


### PR DESCRIPTION
When I am trying to run test harness with Firefox 36, I am getting:

```
org.openqa.selenium.firefox.NotConnectedException: Unable to connect to host 127.0.0.1 on port 7055 after 45000 ms.
...
```

Latest selenium version 2.45.0 fixes this problem for me.

Changelog is here: http://selenium.googlecode.com/git/java/CHANGELOG