### PR TITLE
[JENKINS-27669] Demonstrate ClassCircularityError before fix

### DIFF
--- a/src/test/java/plugins/SupportCorePluginTest.java
+++ b/src/test/java/plugins/SupportCorePluginTest.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package plugins;
+
+import java.util.Collections;
+import java.util.logging.Level;
+import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.jenkinsci.test.acceptance.junit.WithPlugins;
+import org.jenkinsci.test.acceptance.po.JenkinsLogger;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+@WithPlugins("support-core") // TODO @2.22
+public class SupportCorePluginTest extends AbstractJUnitTest {
+
+    @Issue("JENKINS-27669")
+    @Test public void emptyLogger() throws Exception {
+        JenkinsLogger logger = jenkins.createLogger("test", Collections.singletonMap("", Level.ALL));
+        assertFalse(logger.isEmpty());
+    }
+
+}

--- a/src/test/java/plugins/SupportCorePluginTest.java
+++ b/src/test/java/plugins/SupportCorePluginTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-@WithPlugins("support-core") // TODO @2.22
+@WithPlugins("support-core@2.22")
 public class SupportCorePluginTest extends AbstractJUnitTest {
 
     @Issue("JENKINS-27669")

--- a/src/test/java/plugins/SupportCorePluginTest.java
+++ b/src/test/java/plugins/SupportCorePluginTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-@WithPlugins("support-core@2.22")
+@WithPlugins("support-core")
 public class SupportCorePluginTest extends AbstractJUnitTest {
 
     @Issue("JENKINS-27669")


### PR DESCRIPTION
Requires https://github.com/jenkinsci/support-core-plugin/pull/31 to be merged and released before this test can be expected to pass (without `LOCAL_SNAPSHOTS=true`).

@reviewbybees