### PR TITLE
[JENKINS-28550] Test reviewed to work fine with the new proposal of side-panel and main-panel

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/emma/EmmaResultsPage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/emma/EmmaResultsPage.java
@@ -51,7 +51,7 @@ public class EmmaResultsPage extends PageObject {
         find(by.link("Coverage Report")).click();
 
         // Extract the result data and verify.
-        String content = find(by.css("div#main-panel-content")).getText();
+        String content = find(by.id("main-panel")).getText();
         Pattern p = Pattern.compile("\\d+(?:[,.]\\d+)");
         Matcher m = p.matcher(content);
         List<String> l = new ArrayList<String>(NO_RESULT_CELLS);


### PR DESCRIPTION
This [PR](https://github.com/jenkinsci/jenkins/pull/1717) have modified DOM tree in the main layout. These changes affect to `side-panel` and `main-panel`. From now on, `div#main-panel-content` won't exist.