### PR TITLE
[JENKINS-25977] Reflect analysis-core configuration page modifications

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/analysis_core/AnalysisSettings.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/analysis_core/AnalysisSettings.java
@@ -33,10 +33,10 @@ public abstract class AnalysisSettings extends PageAreaImpl implements PostBuild
     protected Control buildFailedTotalLow = control("failedTotalLow");
 
     protected Control canComputeNew = control("canComputeNew");
-    protected Control newWarningsThresholdFailed = control("canComputeNew/failedNewAll");
-    protected Control newWarningsThresholdUnstable = control("canComputeNew/unstableNewAll");
-    protected Control useDeltaValues = control("canComputeNew/useDeltaValues");
-    protected Control usePreviousBuild = control("canComputeNew/usePreviousBuildAsReference");
+    protected Control newWarningsThresholdFailed = control("failedNewAll");
+    protected Control newWarningsThresholdUnstable = control("unstableNewAll");
+    protected Control useDeltaValues = control("useDeltaValues");
+    protected Control usePreviousBuild = control("usePreviousBuildAsReference");
 
     /**
      * Creates a new instance of {@link AnalysisSettings}.

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/analysis_core/AnalysisSettings.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/analysis_core/AnalysisSettings.java
@@ -33,10 +33,10 @@ public abstract class AnalysisSettings extends PageAreaImpl implements PostBuild
     protected Control buildFailedTotalLow = control("failedTotalLow");
 
     protected Control canComputeNew = control("canComputeNew");
-    protected Control newWarningsThresholdFailed = control("failedNewAll");
-    protected Control newWarningsThresholdUnstable = control("unstableNewAll");
-    protected Control useDeltaValues = control("useDeltaValues");
-    protected Control usePreviousBuild = control("usePreviousBuildAsReference");
+    protected Control newWarningsThresholdFailed = control("failedNewAll", "canComputeNew/failedNewAll");
+    protected Control newWarningsThresholdUnstable = control("unstableNewAll", "canComputeNew/unstableNewAll");
+    protected Control useDeltaValues = control("useDeltaValues", "canComputeNew/useDeltaValues");
+    protected Control usePreviousBuild = control("usePreviousBuildAsReference", "canComputeNew/usePreviousBuildAsReference");
 
     /**
      * Creates a new instance of {@link AnalysisSettings}.

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/tasks/AbstractTaskScannerBuildSettings.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/tasks/AbstractTaskScannerBuildSettings.java
@@ -28,15 +28,15 @@ public abstract class AbstractTaskScannerBuildSettings extends AnalysisSettings 
 
     protected Control shouldDetectModules = control("shouldDetectModules");
 
-    protected Control buildUnstableNewAll = control("unstableNewAll");
-    protected Control buildUnstableNewHigh = control("unstableNewHigh");
-    protected Control buildUnstableNewNormal = control("unstableNewNormal");
-    protected Control buildUnstableNewLow = control("unstableNewLow");
-    protected Control buildFailedNewHigh = control("failedNewHigh");
-    protected Control buildFailedNewNormal = control("failedNewNormal");
-    protected Control buildFailedNewLow = control("failedNewLow");
+    protected Control buildUnstableNewAll = control("unstableNewAll", "canComputeNew/unstableNewAll");
+    protected Control buildUnstableNewHigh = control("unstableNewHigh", "canComputeNew/unstableNewHigh");
+    protected Control buildUnstableNewNormal = control("unstableNewNormal", "canComputeNew/unstableNewNormal");
+    protected Control buildUnstableNewLow = control("unstableNewLow", "canComputeNew/unstableNewLow");
+    protected Control buildFailedNewHigh = control("failedNewHigh", "canComputeNew/failedNewHigh");
+    protected Control buildFailedNewNormal = control("failedNewNormal", "canComputeNew/failedNewNormal");
+    protected Control buildFailedNewLow = control("failedNewLow", "canComputeNew/failedNewLow");
 
-    protected Control useStableBuildAsReference = control("useStableBuildAsReference");
+    protected Control useStableBuildAsReference = control("useStableBuildAsReference", "canComputeNew/useStableBuildAsReference");
 
     public AbstractTaskScannerBuildSettings(Job parent, String path) { super(parent, path); }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/tasks/AbstractTaskScannerBuildSettings.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/tasks/AbstractTaskScannerBuildSettings.java
@@ -28,15 +28,15 @@ public abstract class AbstractTaskScannerBuildSettings extends AnalysisSettings 
 
     protected Control shouldDetectModules = control("shouldDetectModules");
 
-    protected Control buildUnstableNewAll = control("canComputeNew/unstableNewAll");
-    protected Control buildUnstableNewHigh = control("canComputeNew/unstableNewHigh");
-    protected Control buildUnstableNewNormal = control("canComputeNew/unstableNewNormal");
-    protected Control buildUnstableNewLow = control("canComputeNew/unstableNewLow");
-    protected Control buildFailedNewHigh = control("canComputeNew/failedNewHigh");
-    protected Control buildFailedNewNormal = control("canComputeNew/failedNewNormal");
-    protected Control buildFailedNewLow = control("canComputeNew/failedNewLow");
+    protected Control buildUnstableNewAll = control("unstableNewAll");
+    protected Control buildUnstableNewHigh = control("unstableNewHigh");
+    protected Control buildUnstableNewNormal = control("unstableNewNormal");
+    protected Control buildUnstableNewLow = control("unstableNewLow");
+    protected Control buildFailedNewHigh = control("failedNewHigh");
+    protected Control buildFailedNewNormal = control("failedNewNormal");
+    protected Control buildFailedNewLow = control("failedNewLow");
 
-    protected Control useStableBuildAsReference = control("canComputeNew/useStableBuildAsReference");
+    protected Control useStableBuildAsReference = control("useStableBuildAsReference");
 
     public AbstractTaskScannerBuildSettings(Job parent, String path) { super(parent, path); }
 


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/analysis-core-plugin/pull/31

The configuration page for any Analysis Core derived plugin has now a different HTML selector for everything under the old section ```canComputeNew```. This intermediate selector level has been removed as ```inline="true"``` [has been added in the jelly file](https://github.com/jenkinsci/analysis-core-plugin/pull/31/files#r35576335).

@reviewbybees 