### PR TITLE
[JENKINS-29976] Create an attribute to set Dockerfile in @DockerFixture 

### DIFF
--- a/docs/FIXTURES.md
+++ b/docs/FIXTURES.md
@@ -75,12 +75,8 @@ publicclass TestContainer extends DockerContainer {
 }
 ```
 
-In this case the docker file must be located at `org/ame/fixture/test` instead of the default location.
+In this case the docker file must be located at classpath and in `org/ame/fixture/test` instead of the default location.
 
-dockerfile attribute can contain three kind of values:
-* File based: file:///tmp/fixture/test which resolves Dockerfile from file location.
-* Classpath based: `classpath://org/acme/fixture/test which resolves Dockerfile from classpath location.
-* No schema provided which by default uses the classpath ones.
 
 
 

--- a/docs/FIXTURES.md
+++ b/docs/FIXTURES.md
@@ -63,4 +63,24 @@ The `@DockerFixture` bindIp allows you to bind the accessible ports of the docke
 A fixture also needs to define `Dockerfile` in the resources directory. If a fixture class is
 `org/acme/FooContainer.java`, then the docker file must be located at `org/acme/FooContainer/Dockerfile`.
 
+In case of inner classes, dollar sign ( $ ) is replaced with a slash ( / ).
+
+You can also set custom location of `Dockerfile` by using `dockerfile` attribute from`@DockerFixture` annotation.
+A simple example might be:
+
+```java
+@DockerFixture(id="test", ports="8080", dockerfile="org/acme/fixture/test")
+publicclass TestContainer extends DockerContainer {
+//...
+}
+```
+
+In this case the docker file must be located at `org/ame/fixture/test` instead of the default location.
+
+dockerfile attribute can contain three kind of values:
+* File based: file:///tmp/fixture/test which resolves Dockerfile from file location.
+* Classpath based: `classpath://org/acme/fixture/test which resolves Dockerfile from classpath location.
+* No schema provided which by default uses the classpath ones.
+
+
 

--- a/docs/FIXTURES.md
+++ b/docs/FIXTURES.md
@@ -65,11 +65,11 @@ A fixture also needs to define `Dockerfile` in the resources directory. If a fix
 
 In case of inner classes, dollar sign ( $ ) is replaced with a slash ( / ).
 
-You can also set custom location of `Dockerfile` by using `dockerfile` attribute from`@DockerFixture` annotation.
+You can also set custom location of `Dockerfile` by using `dockerfileFolder` attribute from`@DockerFixture` annotation.
 A simple example might be:
 
 ```java
-@DockerFixture(id="test", ports="8080", dockerfile="org/acme/fixture/test")
+@DockerFixture(id="test", ports="8080", dockerfileFolder="org/acme/fixture/test")
 publicclass TestContainer extends DockerContainer {
 //...
 }

--- a/docs/FIXTURES.md
+++ b/docs/FIXTURES.md
@@ -70,7 +70,7 @@ A simple example might be:
 
 ```java
 @DockerFixture(id="test", ports="8080", dockerfileFolder="org/acme/fixture/test")
-publicclass TestContainer extends DockerContainer {
+public class TestContainer extends DockerContainer {
 //...
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <aether.version>0.9.0.v20140226</aether.version>
     <maven.version>3.1.0</maven.version>
     <groovy.version>2.3.1</groovy.version>
+    <shrinkwrap.version>1.2.2</shrinkwrap.version>
     <cucumber.options />
   </properties>
 
@@ -375,6 +376,13 @@
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20080701</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-depchain</artifactId>
+      <version>${shrinkwrap.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -27,9 +27,13 @@ import java.util.jar.JarFile;
  * Use this subsystem by injecting this class into your test.
  *
  * @author Kohsuke Kawaguchi
+ * @author asotobueno
  */
 @Singleton
 public class Docker {
+
+    private static final String FILE_SCHEMA = "file://";
+    private static final String CLASSPATH_SCHEMA = "classpath://";
 
     /**
      * Command to invoke docker.
@@ -111,44 +115,7 @@ public class Docker {
             dir.delete();
             dir.mkdirs();
             try {
-                File jar = null;
-                try {
-                    jar = Which.jarFile(fixture);
-                } catch (IllegalArgumentException e) {
-                    // fall through
-                }
-
-                if (jar!=null && jar.isFile()) {
-                    // files are packaged into a war. extract them
-                    String prefix = fixture.getName().replace('.', '/') + "/";
-                    try (JarFile j = new JarFile(jar)) {
-                        Enumeration<JarEntry> e = j.entries();
-                        while (e.hasMoreElements()) {
-                            JarEntry je = e.nextElement();
-                            if (je.getName().startsWith(prefix)) {
-                                File dst = new File(dir, je.getName().substring(prefix.length()));
-                                if (je.isDirectory()) {
-                                    dst.mkdirs();
-                                } else {
-                                    try (InputStream in = j.getInputStream(je)) {
-                                        FileUtils.copyInputStreamToFile(in, dst);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    // Dockerfile is not packaged into a jar file, so copy locally
-                    URL resourceDir = classLoader.getResource(fixture.getName().replace('.', '/'));
-                    File dockerFileDir;
-                    try {
-                        dockerFileDir = new File(resourceDir.toURI());
-                    } catch (URISyntaxException e) {
-                        dockerFileDir = new File(resourceDir.getPath());
-                    }
-                    FileUtils.copyDirectory(dockerFileDir, dir);
-                }
-
+                copyDockerfileDirectory(fixture, f, dir);
                 return build("jenkins/" + f.id(), dir);
             } finally {
                 FileUtils.deleteDirectory(dir);
@@ -156,6 +123,107 @@ public class Docker {
         } catch (InterruptedException | IOException e) {
             throw new IOException("Failed to build image: " + fixture, e);
         }
+    }
+
+    //package scope for testing purposes. Ideally we should encapsulate Docker interactions so they can be mocked
+    // and call public method.
+    void copyDockerfileDirectory(Class<? extends DockerContainer> fixture, DockerFixture f, File dir)
+            throws IOException {
+        String dockerfilePath = resolveDockerfileLocation(fixture, f);
+
+        if(dockerfilePath.startsWith(FILE_SCHEMA)) {
+
+            String dockerfileLocation = dockerfilePath.substring(dockerfilePath.indexOf(FILE_SCHEMA) + FILE_SCHEMA.length());
+            copyDockerfileDirectoryFromDisk(dir, dockerfileLocation);
+
+        } else {
+
+            String dockerfileLocation = dockerfilePath;
+            if(dockerfilePath.startsWith(CLASSPATH_SCHEMA)) {
+                dockerfileLocation = dockerfilePath.substring(
+                        dockerfilePath.indexOf(CLASSPATH_SCHEMA) + CLASSPATH_SCHEMA.length());
+            }
+            copyDockerfileDirectoryFromClasspath(fixture, dockerfileLocation, dir);
+
+        }
+    }
+
+    private void copyDockerfileDirectoryFromDisk(File dir, String dockerfileLocation) throws IOException {
+        File dockerfileDirectory = new File(dockerfileLocation);
+
+        if(dockerfileDirectory.exists() && dockerfileDirectory.isDirectory()) {
+            copyFile(dir, dockerfileDirectory.toURI().toURL());
+        } else {
+            throw new IllegalArgumentException(
+                    String.format("Provided location %s does not exist or it is not a directory", dockerfileDirectory)
+            );
+        }
+    }
+
+    private void copyDockerfileDirectoryFromClasspath(Class<? extends DockerContainer> fixture, String dockerfileLocation, File dir) throws IOException {
+        File jar = null;
+        try {
+            jar = Which.jarFile(fixture);
+        } catch (IllegalArgumentException e) {
+            // fall through
+        }
+
+        if (jar!=null && jar.isFile()) {
+            // files are packaged into a jar/war. extract them
+            dockerfileLocation += "/";
+            copyDockerfileDirectoryFromPackaged(jar, dockerfileLocation, dir);
+        } else {
+            // Dockerfile is not packaged into a jar file, so copy locally
+            copyDockerfileDirectoryFromLocal(dockerfileLocation, dir);
+        }
+    }
+
+    private String resolveDockerfileLocation(Class<? extends DockerContainer> fixture, DockerFixture f) {
+        String prefix = null;
+        if(isSpecificDockerfileLocationSet(f)) {
+            prefix = f.dockerfile().replace('.', '/').replace('$', '/');
+        } else {
+            prefix = fixture.getName().replace('.', '/').replace('$', '/');
+        }
+        return prefix;
+    }
+
+    private boolean isSpecificDockerfileLocationSet(DockerFixture f) {
+        return f.dockerfile() != null && !"".equals(f.dockerfile().trim());
+    }
+
+    private void copyDockerfileDirectoryFromPackaged(File jar, String fixtureLocation, File outputDirectory) throws IOException {
+        try (JarFile j = new JarFile(jar)) {
+            Enumeration<JarEntry> e = j.entries();
+            while (e.hasMoreElements()) {
+                JarEntry je = e.nextElement();
+                if (je.getName().startsWith(fixtureLocation)) {
+                    File dst = new File(outputDirectory, je.getName().substring(fixtureLocation.length()));
+                    if (je.isDirectory()) {
+                        dst.mkdirs();
+                    } else {
+                        try (InputStream in = j.getInputStream(je)) {
+                            FileUtils.copyInputStreamToFile(in, dst);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void copyDockerfileDirectoryFromLocal(String fixtureLocation, File outputDirectory) throws IOException {
+        URL resourceDir = classLoader.getResource(fixtureLocation);
+        copyFile(outputDirectory, resourceDir);
+    }
+
+    private void copyFile(File outputDirectory, URL resourceDir) throws IOException {
+        File dockerFileDir;
+        try {
+            dockerFileDir = new File(resourceDir.toURI());
+        } catch (URISyntaxException e) {
+            dockerFileDir = new File(resourceDir.getPath());
+        }
+        FileUtils.copyDirectory(dockerFileDir, outputDirectory);
     }
 
     private String getDockerFileHash(File dockerFileDir) {

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -133,11 +133,11 @@ public class Docker {
     private String resolveDockerfileLocation(Class<? extends DockerContainer> fixture, DockerFixture f) {
         String prefix = null;
         if(isSpecificDockerfileLocationSet(f)) {
-            prefix = f.dockerfile().replace('.', '/').replace('$', '/');
+            prefix = f.dockerfile();
         } else {
-            prefix = fixture.getName().replace('.', '/').replace('$', '/');
+            prefix = fixture.getName();
         }
-        return prefix;
+        return prefix.replace('.', '/').replace('$', '/');
     }
 
     private void copyDockerfileDirectoryFromClasspath(Class<? extends DockerContainer> fixture, String dockerfileLocation, File dir) throws IOException {

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -159,7 +159,7 @@ public class Docker {
     }
 
     private boolean isSpecificDockerfileLocationSet(DockerFixture f) {
-        return f.dockerfile() != null && !"".equals(f.dockerfile().trim());
+        return !f.dockerfile().isEmpty();
     }
 
     private void copyDockerfileDirectoryFromPackaged(File jar, String fixtureLocation, File outputDirectory) throws IOException {

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -133,7 +133,7 @@ public class Docker {
     private String resolveDockerfileLocation(Class<? extends DockerContainer> fixture, DockerFixture f) {
         String prefix = null;
         if(isSpecificDockerfileLocationSet(f)) {
-            prefix = f.dockerfile();
+            prefix = f.dockerfileFolder();
         } else {
             prefix = fixture.getName();
         }
@@ -159,7 +159,7 @@ public class Docker {
     }
 
     private boolean isSpecificDockerfileLocationSet(DockerFixture f) {
-        return !f.dockerfile().isEmpty();
+        return !f.dockerfileFolder().isEmpty();
     }
 
     private void copyDockerfileDirectoryFromPackaged(File jar, String fixtureLocation, File outputDirectory) throws IOException {

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerFixture.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerFixture.java
@@ -48,9 +48,9 @@ public @interface DockerFixture {
      *  and at the same package as DockerContainer subtype.
      * </p>
      * <p>
-     *  If this attribute is present, Dockerfile file specified in the attribute
-     *  is used as Dockerfile fixture.
+     *  If this attribute is present, Dockerfile folder specified in the attribute
+     *  is used as Dockerfile fixture place.
      * </p>
      */
-    String dockerfile() default "";
+    String dockerfileFolder() default "";
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerFixture.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerFixture.java
@@ -13,6 +13,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  * Annotates {@link DockerContainer} subtype that exposes fixture-specific methods.
  *
  * @author Kohsuke Kawaguchi
+ * @author asotobueno
  */
 @Target(TYPE)
 @Retention(RUNTIME)
@@ -38,4 +39,23 @@ public @interface DockerFixture {
      * Ip address to bind to
      */
     String bindIp() default "127.0.0.1";
+
+    /**
+     * Path of Dockerfile file.
+     *
+     * <p>
+     *  By default Dockerfile fixture should be placed in the resource directory
+     *  and at the same package as DockerContainer subtype.
+     * </p>
+     * <p>
+     *  If this attribute is present, Dockerfile file specified in the attribute
+     *  is used as Dockerfile fixture.
+     * </p>
+     * <p>
+     *  The location can be expressed in terms of file location (file:///a/b/Dockerfile)
+     *  or classpath location (classpath://a/b/Dockerfile).
+     *  In case of not specifying schema, classpath schema is assumed.
+     * </p>
+     */
+    String dockerfile() default "";
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerFixture.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerFixture.java
@@ -51,11 +51,6 @@ public @interface DockerFixture {
      *  If this attribute is present, Dockerfile file specified in the attribute
      *  is used as Dockerfile fixture.
      * </p>
-     * <p>
-     *  The location can be expressed in terms of file location (file:///a/b/Dockerfile)
-     *  or classpath location (classpath://a/b/Dockerfile).
-     *  In case of not specifying schema, classpath schema is assumed.
-     * </p>
      */
     String dockerfile() default "";
 }

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/DockerFixtureTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/DockerFixtureTest.java
@@ -23,8 +23,6 @@
  */
 package org.jenkinsci.test.acceptance.docker;
 
-import org.apache.commons.io.FileUtils;
-import org.hamcrest.core.Is;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
@@ -35,11 +33,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -123,7 +118,7 @@ public class DockerFixtureTest {
         assertThat(new File(outputDir, "Dockerfile").exists(), is(true));
     }
 
-    @DockerFixture(id="test", ports = 8080, dockerfile = "test")
+    @DockerFixture(id="test", ports = 8080, dockerfileFolder = "test")
     public static class CustomTestContainer extends DockerContainer {
     }
 
@@ -135,7 +130,7 @@ public class DockerFixtureTest {
     public static class TestJarContainer extends DockerContainer {
     }
 
-    @DockerFixture(id="testjar", ports = 8080, dockerfile = "test")
+    @DockerFixture(id="testjar", ports = 8080, dockerfileFolder = "test")
     public static class CustomTestJarContainer extends DockerContainer {
     }
 }

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/DockerFixtureTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/DockerFixtureTest.java
@@ -45,9 +45,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 /**
+ *
+ * Tests for {@link DockerFixture}
+ *
  * @author asotobueno
  */
-public class DockerTest {
+public class DockerFixtureTest {
 
     @Rule
     public final TemporaryFolder folder = new TemporaryFolder();

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/DockerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/DockerTest.java
@@ -69,54 +69,6 @@ public class DockerTest {
     }
 
     @Test
-    public void should_load_fixture_from_location_when_using_classpath_schema() throws IOException {
-        File outputDir = folder.newFolder();
-        Docker docker = new Docker();
-        docker.copyDockerfileDirectory(CustomClasspathTestContainer.class, CustomClasspathTestContainer.class.getAnnotation(DockerFixture.class), outputDir);
-        assertThat(new File(outputDir, "Dockerfile").exists(), is(true));
-    }
-
-    @Test
-    public void should_load_fixture_from_location_when_using_file_schema() throws IOException {
-        final File dockerfileDirectory = folder.newFolder();
-        FileUtils.writeStringToFile(new File(dockerfileDirectory, "Dockerfile"), "FROM java:8-jre");
-
-        File outputDir = folder.newFolder();
-        Docker docker = new Docker();
-        DockerFixture annotation = new DockerFixture() {
-
-            @Override
-            public Class<? extends Annotation> annotationType() {
-                return DockerFixture.class;
-            }
-
-            @Override
-            public String id() {
-                return "test";
-            }
-
-            @Override
-            public int[] ports() {
-                return new int[]{8080};
-            }
-
-            @Override
-            public String bindIp() {
-                return "127.0.0.1";
-            }
-
-            @Override
-            public String dockerfile() {
-                return "file://" + dockerfileDirectory.getAbsolutePath();
-            }
-        };
-
-        docker.copyDockerfileDirectory(CustomFileTestContainer.class, annotation, outputDir);
-        assertThat(new File(outputDir, "Dockerfile").exists(), is(true));
-    }
-
-
-    @Test
     public void should_load_fixture_from_default_jar() throws IOException, ClassNotFoundException {
 
         //Creates a jar file with required content
@@ -166,14 +118,6 @@ public class DockerTest {
         Docker docker = new Docker();
         docker.copyDockerfileDirectory(clazz, CustomTestJarContainer.class.getAnnotation(DockerFixture.class), outputDir);
         assertThat(new File(outputDir, "Dockerfile").exists(), is(true));
-    }
-
-    @DockerFixture(id="test", ports = 8080, dockerfile = "classpath://test")
-    public static class CustomClasspathTestContainer extends DockerContainer {
-    }
-
-    @DockerFixture(id="test", ports = 8080, dockerfile = "file://calculateatruntime")
-    public static class CustomFileTestContainer extends DockerContainer {
     }
 
     @DockerFixture(id="test", ports = 8080, dockerfile = "test")

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/DockerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/DockerTest.java
@@ -1,0 +1,194 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.test.acceptance.docker;
+
+import org.apache.commons.io.FileUtils;
+import org.hamcrest.core.Is;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * @author asotobueno
+ */
+public class DockerTest {
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void should_load_fixture_from_default_location() throws IOException {
+        File outputDir = folder.newFolder();
+        Docker docker = new Docker();
+        docker.copyDockerfileDirectory(TestContainer.class, TestContainer.class.getAnnotation(DockerFixture.class), outputDir);
+        assertThat(new File(outputDir, "Dockerfile").exists(), is(true));
+    }
+
+    @Test
+     public void should_load_fixture_from_location() throws IOException {
+        File outputDir = folder.newFolder();
+        Docker docker = new Docker();
+        docker.copyDockerfileDirectory(CustomTestContainer.class, CustomTestContainer.class.getAnnotation(DockerFixture.class), outputDir);
+        assertThat(new File(outputDir, "Dockerfile").exists(), is(true));
+    }
+
+    @Test
+    public void should_load_fixture_from_location_when_using_classpath_schema() throws IOException {
+        File outputDir = folder.newFolder();
+        Docker docker = new Docker();
+        docker.copyDockerfileDirectory(CustomClasspathTestContainer.class, CustomClasspathTestContainer.class.getAnnotation(DockerFixture.class), outputDir);
+        assertThat(new File(outputDir, "Dockerfile").exists(), is(true));
+    }
+
+    @Test
+    public void should_load_fixture_from_location_when_using_file_schema() throws IOException {
+        final File dockerfileDirectory = folder.newFolder();
+        FileUtils.writeStringToFile(new File(dockerfileDirectory, "Dockerfile"), "FROM java:8-jre");
+
+        File outputDir = folder.newFolder();
+        Docker docker = new Docker();
+        DockerFixture annotation = new DockerFixture() {
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return DockerFixture.class;
+            }
+
+            @Override
+            public String id() {
+                return "test";
+            }
+
+            @Override
+            public int[] ports() {
+                return new int[]{8080};
+            }
+
+            @Override
+            public String bindIp() {
+                return "127.0.0.1";
+            }
+
+            @Override
+            public String dockerfile() {
+                return "file://" + dockerfileDirectory.getAbsolutePath();
+            }
+        };
+
+        docker.copyDockerfileDirectory(CustomFileTestContainer.class, annotation, outputDir);
+        assertThat(new File(outputDir, "Dockerfile").exists(), is(true));
+    }
+
+
+    @Test
+    public void should_load_fixture_from_default_jar() throws IOException, ClassNotFoundException {
+
+        //Creates a jar file with required content
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
+                .addClass(TestJarContainer.class)
+                .addClasses(DockerContainer.class, DockerFixture.class)
+                .addAsResource(
+                        new StringAsset("FROM java:8-jre"),
+                        "/org/jenkinsci/test/acceptance/docker/DockerTest/TestJarContainer/Dockerfile"
+                );
+        File jarDirectory = folder.newFolder();
+        File jarFile = new File(jarDirectory, "test.jar");
+        jar.as(ZipExporter.class).exportTo(jarFile);
+
+        //Creates a class loader that depends on the system one loading the jar. Jars are isolated from the test ones.
+        ClassLoader classloader = new URLClassLoader(new URL[]{jarFile.toURI().toURL()}, null);
+        Class<? extends DockerContainer> clazz = (Class<? extends DockerContainer>) Class.forName("org.jenkinsci.test.acceptance.docker.DockerTest$TestJarContainer", true, classloader);
+
+        //Executes the test
+        File outputDir = folder.newFolder();
+        Docker docker = new Docker();
+        docker.copyDockerfileDirectory(clazz, TestJarContainer.class.getAnnotation(DockerFixture.class), outputDir);
+        assertThat(new File(outputDir, "Dockerfile").exists(), is(true));
+    }
+
+    @Test
+    public void should_load_fixture_from_jar() throws IOException, ClassNotFoundException {
+
+        //Creates a jar file with required content
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
+                .addClass(CustomTestJarContainer.class)
+                .addClasses(DockerContainer.class, DockerFixture.class)
+                .addAsResource(
+                        new StringAsset("FROM java:8-jre"),
+                        "/test/Dockerfile"
+                );
+        File jarDirectory = folder.newFolder();
+        File jarFile = new File(jarDirectory, "test.jar");
+        jar.as(ZipExporter.class).exportTo(jarFile);
+
+        //Creates a class loader that depends on the system one loading the jar. Jars are isolated from the test ones.
+        ClassLoader classloader = new URLClassLoader(new URL[]{jarFile.toURI().toURL()}, null);
+        Class<? extends DockerContainer> clazz = (Class<? extends DockerContainer>) Class.forName("org.jenkinsci.test.acceptance.docker.DockerTest$CustomTestJarContainer", true, classloader);
+
+        //Executes the test
+        File outputDir = folder.newFolder();
+        Docker docker = new Docker();
+        docker.copyDockerfileDirectory(clazz, CustomTestJarContainer.class.getAnnotation(DockerFixture.class), outputDir);
+        assertThat(new File(outputDir, "Dockerfile").exists(), is(true));
+    }
+
+    @DockerFixture(id="test", ports = 8080, dockerfile = "classpath://test")
+    public static class CustomClasspathTestContainer extends DockerContainer {
+    }
+
+    @DockerFixture(id="test", ports = 8080, dockerfile = "file://calculateatruntime")
+    public static class CustomFileTestContainer extends DockerContainer {
+    }
+
+    @DockerFixture(id="test", ports = 8080, dockerfile = "test")
+    public static class CustomTestContainer extends DockerContainer {
+    }
+
+    @DockerFixture(id="test", ports = 8080)
+    public static class TestContainer extends DockerContainer {
+    }
+
+    @DockerFixture(id="testjar", ports = 8080)
+    public static class TestJarContainer extends DockerContainer {
+    }
+
+    @DockerFixture(id="testjar", ports = 8080, dockerfile = "test")
+    public static class CustomTestJarContainer extends DockerContainer {
+    }
+}

--- a/src/test/resources/org/jenkinsci/test/acceptance/docker/DockerTest/TestContainer/Dockerfile
+++ b/src/test/resources/org/jenkinsci/test/acceptance/docker/DockerTest/TestContainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM java:8-jre

--- a/src/test/resources/test/Dockerfile
+++ b/src/test/resources/test/Dockerfile
@@ -1,0 +1,1 @@
+FROM java:8-jre


### PR DESCRIPTION
Create an attribute to set Dockerfile in @DockerFixture. This PR also fixes one small issue [JENKINS-29984](https://issues.jenkins-ci.org/browse/JENKINS-29984) but since it was found while writing a test for [JENKINS-29976](https://issues.jenkins-ci.org/browse/JENKINS-29976) it was difficult to split at that stage to two different commits because the bug was at the same class that I touched for implementing this feature. Since it is an small bug fix (support for inner classes for DockerFixture), I decided to not overcomplicate the development by removing/copyback the code.

I paste here the description of the issue:

```
Create attribute to set Dockerfile location in @DockerFixture. By default Dockerfile fixture should be placed in the resource directory and at the same package as DockerContainer subtype.

A new optional attribute called dockerfile can be added at @DockerFixture, so if it is not present then default behaviour is the expected, but if the attribute is present, Dockerfile location is get from there. This allows save Dockerfile in places where they can be reused.

An example of the annotation might be:

@DockerFixture(id="jira", ports="2909", dockerfile="a/b")
public class JiraContainer ....

Classpath resolution will be based on class where annotation is defined.
```

@reviewbybees 

