### PR TITLE
Do use declared version of plugin dependency if latest does not work …

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/LocalOverrideUpdateCenterMetadataDecoratorImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/LocalOverrideUpdateCenterMetadataDecoratorImpl.java
@@ -74,7 +74,6 @@ public class LocalOverrideUpdateCenterMetadataDecoratorImpl implements UpdateCen
             m.name = main.getValue("Short-Name");
             m.version = main.getValue("Plugin-Version");
             m.gav = main.getValue("Group-Id")+":"+m.name+":"+m.version;
-            m.url = jpi.toURL();
             m.override = jpi;
             String dep = main.getValue("Plugin-Dependencies");
             if (dep!=null) {

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginMetadata.java
@@ -1,8 +1,9 @@
 package org.jenkinsci.test.acceptance.update_center;
 
+import hudson.util.VersionNumber;
+
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
@@ -33,11 +34,11 @@ import static org.apache.http.entity.ContentType.*;
 public class PluginMetadata {
     private static final Logger LOGGER = LoggerFactory.getLogger(PluginMetadata.class);
     public String name, version, gav;
+    public String requiredCore;
     public List<Dependency> dependencies;
-    public URL url;
 
     /**
-     * If non-null, use this file instead of the one pointed by {@link #url} or {@link #gav}.
+     * If non-null, use this file instead of the one pointed by {@link #gav}.
      */
     public File override;
 
@@ -84,9 +85,23 @@ public class PluginMetadata {
         return r.getArtifact().getFile();
     }
 
+    public VersionNumber requiredCore() {
+        return new VersionNumber(requiredCore);
+    }
+
+    public PluginMetadata versionOf(String v) {
+        if (v == null) throw new IllegalArgumentException();
+
+        PluginMetadata ret = new PluginMetadata();
+        ret.name = name;
+        ret.version = v;
+        ret.gav = gav;
+        ret.requiredCore = requiredCore;
+        return ret;
+    }
+
     @Override
     public String toString() {
         return super.toString() + "[" + name + "," + version + "]";
     }
-
 }

--- a/src/test/java/plugins/OpenstackCloudPluginTest.java
+++ b/src/test/java/plugins/OpenstackCloudPluginTest.java
@@ -97,7 +97,6 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
     }
 
     @Test
-    @WithPlugins({"config-file-provider", "ssh-slaves"})
     @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {"root", "/openstack_plugin/unsafe"})
     @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
     public void provisionSshSlave() {
@@ -114,8 +113,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
     }
 
     // The test will fail when test host is not reachable from openstack machine for obvious reasons
-    @Test // @Since("openstack-cloud@1.9") JENKINS-29996
-    @WithPlugins({"config-file-provider", "ssh-slaves"})
+    @Test // @WithPlugins("openstack-cloud@1.9") JENKINS-29996
     @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {"root", "/openstack_plugin/unsafe"})
     @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
     public void provisionJnlpSlave() {
@@ -132,7 +130,6 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
     }
 
     @Test @Issue("JENKINS-29998")
-    @WithPlugins({"config-file-provider", "ssh-slaves"})
     @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {"root", "/openstack_plugin/unsafe"})
     @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
     public void scheduleMatrixWithoutLabel() {


### PR DESCRIPTION
…with core version under test

For instance `openstack-cloud` depends on `config-file-provider` its latest version does not work with jenkins 1.580 I use to run tests. Before the fix ATH silently installed latest version and caused failures at runtime. This fix causes that declared version of dependency will be used iff latest do not have core version requirement satisfied.