### PR TITLE
Diagnosed failure in WorkflowPluginTest.linearFlow

### DIFF
--- a/src/test/java/plugins/WorkflowPluginTest.java
+++ b/src/test/java/plugins/WorkflowPluginTest.java
@@ -76,7 +76,9 @@ public class WorkflowPluginTest extends AbstractJUnitTest {
             "    echo \"Building version ${v}\"\n" +
             "  }\n" +
             "  def mvnHome = tool 'M3'\n" +
-            "  sh \"${mvnHome}/bin/mvn -B -Dmaven.test.failure.ignore verify\"\n" +
+            "  withEnv([\"PATH+MAVEN=${mvnHome}/bin\", \"M2_HOME=${mvnHome}\"]) {\n" +
+            "    sh 'mvn -B -Dmaven.test.failure.ignore verify'\n" +
+            "  }\n" +
             "  input 'Ready to go?'\n" +
             "  step([$class: 'ArtifactArchiver', artifacts: '**/target/*.jar', fingerprint: true])\n" +
             "  step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])\n" +


### PR DESCRIPTION
With #42 merged, I can see that the problem is a [weird Maven error](http://stackoverflow.com/q/29983683/12916); apparently the CI job is defining `M2_HOME`, so we are forced to override it. Using `withEnv` is more the [recommended idiom](https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#managing-the-environment) anyway.

@reviewbybees