### PR TITLE
[FIXED JENKINS-31031] incorrect matcher in GradlePluginTest.

### DIFF
--- a/src/test/java/plugins/GradlePluginTest.java
+++ b/src/test/java/plugins/GradlePluginTest.java
@@ -49,8 +49,7 @@ public class GradlePluginTest extends AbstractJUnitTest {
 
         job.startBuild().shouldSucceed()
                 .shouldContainsConsoleOutput("Hello world!")
-                //reg expression gradle[\w\\/"]* --quiet
-                .shouldContainsConsoleOutput("gradle[\\w\\\\/\"]* --quiet")
+                .shouldContainsConsoleOutput("gradle.* --quiet")
         ;
     }
 

--- a/src/test/java/plugins/GradlePluginTest.java
+++ b/src/test/java/plugins/GradlePluginTest.java
@@ -49,7 +49,8 @@ public class GradlePluginTest extends AbstractJUnitTest {
 
         job.startBuild().shouldSucceed()
                 .shouldContainsConsoleOutput("Hello world!")
-                .shouldContainsConsoleOutput("gradle --quiet")
+                //reg expression gradle[\w\\/"]* --quiet
+                .shouldContainsConsoleOutput("gradle[\\w\\\\/\"]* --quiet")
         ;
     }
 


### PR DESCRIPTION
GradlePluginTest class contains a regular expression that is gradle --quiet but under some circumstances the output does not contain gradle --quiet but _ "..../gradle\" --quiet hello put quotes because of white space in the path. For this reason a new regular expression should be provided to fix this possibility.

@reviewbybees 