### PR TITLE
[FIXED JENKINS-31049] adds an sleep before toggle.

### DIFF
--- a/src/test/java/plugins/JUnitPluginTest.java
+++ b/src/test/java/plugins/JUnitPluginTest.java
@@ -120,6 +120,7 @@ public class JUnitPluginTest extends AbstractJUnitTest {
     }
 
     private void assertMessage(String test, String msg) {
+        elasticSleep(1000);
         toggle(test);
         elasticSleep(1000); // Try to wait a bit to ajax to fetch the content
         assertThat(driver, hasContent(msg));


### PR DESCRIPTION
In JunitPluginTest class test, the publish_rest_of_parameterized_tests test method fails because it complains that there is no tests to show when in reality there are some executions. Probably this is because of sync problem. Inspecting the code I have seen:

```java
        toggle(test);
        elasticSleep(1000); // Try to wait a bit to ajax to fetch the content
        assertThat(driver, hasContent(msg));
        toggle(test);
```

The test failure occurs in the first toggle, but as you can see there is an elasticSleep just after, so originally this test had some problems of sync. Probably we need to add an elasticSleep before first toggle as well.

@reviewbybees 