### PR TITLE
[FIXED JENKINS-31081] Adding JUnit Attachment support to screen recorer

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/FailureDiagnostics.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/FailureDiagnostics.java
@@ -22,6 +22,8 @@ import com.google.inject.Inject;
 @TestScope
 public class FailureDiagnostics extends TestWatcher {
 
+    private static String JUNIT_ATTACHMENT = "[[ATTACHMENT|%s]]";
+
     private final File dir;
 
     @Inject
@@ -84,6 +86,19 @@ public class FailureDiagnostics extends TestWatcher {
                     FileUtils.deleteDirectory(dir);
                 } catch (IOException e) {
                     // Nah
+                }
+            }
+        }
+    }
+
+    @Override
+    public void failed(Throwable e, Description description) {
+        if (dir.exists()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    //https://wiki.jenkins-ci.org/display/JENKINS/JUnit+Attachments+Plugin#JUnitAttachmentsPlugin-ByprintingoutthefilenameinaformatthatJenkinswillunderstand
+                    System.out.println(String.format(JUNIT_ATTACHMENT, file.getAbsolutePath()));
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/test/acceptance/recorder/JUnitScreenRecorder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/recorder/JUnitScreenRecorder.java
@@ -15,6 +15,8 @@ import java.io.IOException;
  */
 public class JUnitScreenRecorder extends ScreenRecorder {
 
+    private static String JUNIT_ATTACHMENT = "[[ATTACHMENT|%s]]";
+
     private FailureDiagnostics diag;
     private Format format;
 
@@ -29,6 +31,8 @@ public class JUnitScreenRecorder extends ScreenRecorder {
     @Override
     protected File createMovieFile(Format fileFormat) throws IOException {
         final File f = generateOutput(fileFormat);
+        //https://wiki.jenkins-ci.org/display/JENKINS/JUnit+Attachments+Plugin#JUnitAttachmentsPlugin-ByprintingoutthefilenameinaformatthatJenkinswillunderstand
+        System.out.println(String.format(JUNIT_ATTACHMENT, f.getAbsolutePath()));
         return f;
     }
 


### PR DESCRIPTION
ScreenRecorder shall be JUnitAttachment aware by implementing https://wiki.jenkins-ci.org/display/JENKINS/JUnit+Attachments+Plugin#JUnitAttachmentsPlugin-ByprintingoutthefilenameinaformatthatJenkinswillunderstand so the videos could be got from any execution.

@reviewbybees 