### PR TITLE
[FIXED JENKINS-31431] Warning Axis Test refresh browser

### DIFF
--- a/src/test/java/plugins/WarningsPluginTest.java
+++ b/src/test/java/plugins/WarningsPluginTest.java
@@ -112,7 +112,7 @@ public class WarningsPluginTest extends AbstractAnalysisTest<WarningsAction> {
             assertThat(driver, hasContent(title + ": " + warningsPerAxis.get(axis.name)));
         }
 
-        // sometimes the details is not refreshed yet (https://cloudbees.atlassian.net/browse/CJP-3668) 
+        // sometimes the details is not refreshed yet (https://issues.jenkins-ci.org/browse/JENKINS-31431) 
         // so let's add an sleep and a refresh 
 
         try {

--- a/src/test/java/plugins/WarningsPluginTest.java
+++ b/src/test/java/plugins/WarningsPluginTest.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 import org.jenkinsci.test.acceptance.junit.SmokeTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
@@ -111,6 +112,15 @@ public class WarningsPluginTest extends AbstractAnalysisTest<WarningsAction> {
             assertThat(driver, hasContent(title + ": " + warningsPerAxis.get(axis.name)));
         }
 
+        // sometimes the details is not refreshed yet (https://cloudbees.atlassian.net/browse/CJP-3668) 
+        // so let's add an sleep and a refresh 
+
+        try {
+            TimeUnit.SECONDS.sleep(1);
+        } catch (InterruptedException e) {
+            //we can ignore this.
+        }
+        driver.navigate().refresh();
         assertThatConfigurationTabIsCorrectlyFilled(job);
         assertThatFoldersTabIsCorrectlyFilled(job);
         assertThatFilesTabIsCorrectlyFilled(job);

--- a/src/test/java/plugins/WarningsPluginTest.java
+++ b/src/test/java/plugins/WarningsPluginTest.java
@@ -13,6 +13,7 @@ import org.jenkinsci.test.acceptance.plugins.warnings.WarningsAction;
 import org.jenkinsci.test.acceptance.plugins.warnings.WarningsBuildSettings;
 import org.jenkinsci.test.acceptance.plugins.warnings.WarningsColumn;
 import org.jenkinsci.test.acceptance.po.Build;
+import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.ListView;
@@ -115,11 +116,7 @@ public class WarningsPluginTest extends AbstractAnalysisTest<WarningsAction> {
         // sometimes the details is not refreshed yet (https://issues.jenkins-ci.org/browse/JENKINS-31431) 
         // so let's add an sleep and a refresh 
 
-        try {
-            TimeUnit.SECONDS.sleep(1);
-        } catch (InterruptedException e) {
-            //we can ignore this.
-        }
+        sleep(1000);
         driver.navigate().refresh();
         assertThatConfigurationTabIsCorrectlyFilled(job);
         assertThatFoldersTabIsCorrectlyFilled(job);


### PR DESCRIPTION
WarningPluginTest fails when showing the axis of all warning in the details section. In summary section you can see that there is 12 warnings but in the details section only 11 are shown. If you execute this test locally it works, so probably it can be a problem of refresh.

https://issues.jenkins-ci.org/browse/JENKINS-31431

@reviewbybees 