### PR TITLE
Need to be able to specify the socket

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/server/PooledJenkinsController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/server/PooledJenkinsController.java
@@ -47,8 +47,12 @@ public class PooledJenkinsController extends JenkinsController implements LogLis
 
     @Inject
     public PooledJenkinsController(Injector i) {
+        this(i, JenkinsControllerPoolProcess.SOCKET);
+    }
+
+    public PooledJenkinsController(Injector i, File socket) {
         super(i);
-        this.socket = JenkinsControllerPoolProcess.SOCKET;
+        this.socket = socket;
     }
 
     @Override


### PR DESCRIPTION
I have tests that controls two jenkins masters at the same time, so there is a need to be able to specify what socket the controller should use.

@reviewbybees 