### PR TITLE
[JENKINS-28769] Allow Workflow tests to run with or without ACE

### DIFF
--- a/docs/INVESTIGATION.md
+++ b/docs/INVESTIGATION.md
@@ -4,6 +4,8 @@
 
 As an alternative to set a breakpoint, that would stop the test suite and kept Jenkins and browser tunning for manual investigation. There is a environment variable `INTERACTIVE=true` to pause the suite whenever test fails.
 
+You can also add a call to `InteractiveConsole.execute(this)` to your test method before the failure.
+
 ## diagnostic information
 
 ATH keeps track of test diagnostics information in /target/diagnostics/<TESTNAME> directory.


### PR DESCRIPTION
Hotfix incorporating parts of #54 but allowing the existing tests to run whether we are using 1.10.1 (plain text area) or 1.11-beta-3+ (ACE editor).

#54 should be adjusted to do this more cleanly somehow TBD, as well as add its tests specific to ACE using `@WithPlugins("workflow-aggregator@1.11")`.

@reviewbybees esp. @tfennelly