### PR TITLE
Added feature to run ATH against Selenium Grid instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Java system property takes precedence over environment variable.
 * [Obtaining a report of plugins that were exercised](docs/EXERCISEDPLUGINSREPORTER.md)
 * [Testing unreleased plugin](docs/LOCALPLUGIN.md)
 * [Investigation](docs/INVESTIGATION.md)
+* [Running tests against Selenium Grid] (docs/SELENIUM-GRID.md)
 * Selecting tests based on plugins they cover (TODO)
 
 ### Writing tests

--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -9,7 +9,8 @@ by using the `BROWSER` environment variable. The following values are available:
  * `safari`
  * `htmlunit`
  * `phantomjs`
-
+ * `seleniumGrid`
+ 
 Therefore, to run tests with Safari, you'd execute:
 
     export BROWSER=safari

--- a/docs/SELENIUM-GRID.md
+++ b/docs/SELENIUM-GRID.md
@@ -1,0 +1,30 @@
+#Running ATH tests against Selenium Grid
+
+This feature enables us to test ATH against Selenium Grid
+
+##Requirements
+* JENKINS_URL must be accessible for the Selenium hub
+* If running against existing Jenkins instance using Jenkins Under Test (JUT) =EXISTING, A running Jenkins instance with pre-installed [Form-Element-Path plugin](https://wiki.jenkins-ci.org/display/JENKINS/Form+Element+Path+Plugin)
+* Selenium hub running, with at least one node registered to it. Can be modified with parameter [gridHubURL](../src/main/resources/seleniumGrid.properties#L1) <br/ >
+Refer this link for detailed information about [Selenium Grid] (http://www.seleniumhq.org/docs/07_selenium_grid.jsp)
+* Browser (Make sure that the Selenium node supports the browser of your choice). Can be modified with parameter [browserval](../src/main/resources/seleniumGrid.properties#L3)
+
+## (Optional) Configuring additional capabilities
+
+Additional capabilities supported by your node can be configured and passed to [FallbackConfig.java](../src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java#L127-L139) <br />
+as following:
+
+```java
+case "seleniumgrid":
+cap.setBrowserName(properties.getProperty( /* capability or key-value pairs */ ));
+```
+In case you are giving browser specific capabilities, such as `"Firefox","30"` then replace this capability instead of [browserval](../src/main/resources/seleniumGrid.properties#L3)
+
+## Running tests
+
+Set BROWSER=seleniumGrid. Refer to [BROWSER.md](BROWSER.md) for more information about different browser types. <br />
+
+Example:
+`TYPE=existing BROWSER=seleniumGrid JENKINS_URL=http://localhost:8080/jenkins/ mvn clean install`
+
+

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -1,14 +1,9 @@
 package org.jenkinsci.test.acceptance;
 
-import javax.inject.Named;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
+import com.cloudbees.sdk.extensibility.ExtensionList;
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -28,12 +23,13 @@ import org.jenkinsci.test.acceptance.slave.SlaveProvider;
 import org.jenkinsci.test.acceptance.utils.ElasticTime;
 import org.jenkinsci.test.acceptance.utils.IOUtil;
 import org.jenkinsci.test.acceptance.utils.SauceLabsConnection;
+import org.jenkinsci.test.acceptance.utils.SeleniumGridConnection;
 import org.jenkinsci.test.acceptance.utils.aether.ArtifactResolverUtil;
 import org.jenkinsci.test.acceptance.utils.mail.MailService;
 import org.jenkinsci.test.acceptance.utils.mail.Mailtrap;
+import org.jenkinsci.test.acceptance.utils.pluginreporter.ConsoleExercisedPluginReporter;
 import org.jenkinsci.test.acceptance.utils.pluginreporter.ExercisedPluginsReporter;
 import org.jenkinsci.test.acceptance.utils.pluginreporter.TextFileExercisedPluginReporter;
-import org.jenkinsci.test.acceptance.utils.pluginreporter.ConsoleExercisedPluginReporter;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.UnsupportedCommandException;
@@ -49,10 +45,15 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 
-import com.cloudbees.sdk.extensibility.ExtensionList;
-import com.google.inject.AbstractModule;
-import com.google.inject.Injector;
-import com.google.inject.Provides;
+import javax.inject.Named;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The default configuration for running tests.
@@ -123,6 +124,20 @@ public class FallbackConfig extends AbstractModule {
             capabilities.setCapability(LANGUAGE_SELECTOR, "en");
             capabilities.setCapability(LANGUAGE_SELECTOR_PHANTOMJS, "en");
             return new PhantomJSDriver(capabilities);
+
+        case "seleniumgrid":
+                DesiredCapabilities cap = new DesiredCapabilities();
+
+                //Get selenium grid properties
+                Properties properties = new Properties();
+                try {
+                    properties.load(new FileInputStream("src/main/resources/seleniumGrid.properties"));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                cap.setBrowserName(properties.getProperty("browserval"));
+
+                return new SeleniumGridConnection().createWebDriver(cap);
 
         default:
             throw new Error("Unrecognized browser type: "+browser);

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/SeleniumGridConnection.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/SeleniumGridConnection.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.test.acceptance.utils;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Properties;
+
+/**
+ * Created by adini121 on 24/11/15.
+ * This class enables us to create a remotewebdriver instance
+ */
+public class SeleniumGridConnection {
+    public WebDriver createWebDriver (DesiredCapabilities cap) throws MalformedURLException {
+        Properties prop = new Properties();
+        try {
+            prop.load(new FileInputStream("src/main/resources/seleniumGrid.properties"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        String url = prop.getProperty("gridHubURL");
+        RemoteWebDriver remoteWebDriver = new RemoteWebDriver(new URL(url), cap);
+        return remoteWebDriver;
+    }
+}

--- a/src/main/resources/seleniumGrid.properties
+++ b/src/main/resources/seleniumGrid.properties
@@ -1,0 +1,4 @@
+gridHubURL=http://yourGridURL:gridPort/wd/hub
+#example: gridHubURL=http://192.168.10.10:4444/wd/hub
+browserval=firefox
+


### PR DESCRIPTION
Configured Jenkins ATH to run tests against a Selenium grid instance (hub). Tested locally as well as against Existing and tomcat controllers. Requirement: If the grid is running on different machine/host than the one running Jenkins instance, Jenkins URL needs to be made accessible to the grid. Much easier to do with "Existing" controller by setting JENKINS_URL (But requires Form-Element-Path plugin installed). 

Please let me know if this feature is helpful or needs modifications. 
