### PR TITLE
[JENKINS-31772] Allow JenkinsAcceptanceTestRule to be used as a ClassRule.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractATHTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractATHTest.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.test.acceptance.junit;
+
+import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * Abstract base class factoring out common code for test classes using the {@link JenkinsAcceptanceTestRule}.
+ *
+ * @author Andres Rodriguez
+ */
+public abstract class AbstractATHTest extends CapybaraPortingLayerImpl {
+
+    protected AbstractATHTest() {
+        super(null);
+    }
+
+    /**
+     * @return finds an unused, available port on the test machine
+     */
+    public int findAvailablePort() {
+        // use port 65000 as fallback (but maybe there is something running)
+        int port = 65000;
+        try (ServerSocket s = new ServerSocket(0)) {
+            port = s.getLocalPort();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return port;
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractClassBasedJUnitTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractClassBasedJUnitTest.java
@@ -1,0 +1,51 @@
+package org.jenkinsci.test.acceptance.junit;
+
+import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
+import org.jenkinsci.test.acceptance.po.Jenkins;
+import org.junit.ClassRule;
+import org.openqa.selenium.WebDriver;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * Convenience base class to derive your plain-old JUnit tests from when using {@link JenkinsAcceptanceTestRule} as a {@link ClassRule}.
+ *
+ * @author Andres Rodriguez
+ */
+public class AbstractClassBasedJUnitTest extends CapybaraPortingLayerImpl {
+
+    @ClassRule
+    public static JenkinsAcceptanceTestRule rules = JenkinsAcceptanceTestRule.classRule();
+
+    /**
+     * Jenkins under test.
+     */
+    @Inject
+    public static Jenkins jenkins;
+
+    /**
+     * This field receives a valid web driver object you can use to talk to Jenkins.
+     */
+    @Inject
+    public static WebDriver driver;
+
+    public AbstractClassBasedJUnitTest() {
+        super(null);
+    }
+
+    /**
+     * @return finds an unused, available port on the test machine
+     */
+    public int findAvailablePort() {
+        // use port 65000 as fallback (but maybe there is something running)
+        int port = 65000;
+        try (ServerSocket s = new ServerSocket(0)) {
+            port = s.getLocalPort();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return port;
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractClassBasedJUnitTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractClassBasedJUnitTest.java
@@ -14,7 +14,7 @@ import java.net.ServerSocket;
  *
  * @author Andres Rodriguez
  */
-public class AbstractClassBasedJUnitTest extends CapybaraPortingLayerImpl {
+public class AbstractClassBasedJUnitTest extends AbstractATHTest {
 
     @ClassRule
     public static JenkinsAcceptanceTestRule rules = JenkinsAcceptanceTestRule.classRule();
@@ -32,20 +32,5 @@ public class AbstractClassBasedJUnitTest extends CapybaraPortingLayerImpl {
     public static WebDriver driver;
 
     public AbstractClassBasedJUnitTest() {
-        super(null);
-    }
-
-    /**
-     * @return finds an unused, available port on the test machine
-     */
-    public int findAvailablePort() {
-        // use port 65000 as fallback (but maybe there is something running)
-        int port = 65000;
-        try (ServerSocket s = new ServerSocket(0)) {
-            port = s.getLocalPort();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return port;
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
@@ -21,7 +21,7 @@ import java.net.ServerSocket;
 public class AbstractJUnitTest extends CapybaraPortingLayerImpl {
 
     @Rule
-    public JenkinsAcceptanceTestRule rules = new JenkinsAcceptanceTestRule();
+    public JenkinsAcceptanceTestRule rules = new JenkinsAcceptanceTestRule(this);
 
     /**
      * Jenkins under test.

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
@@ -18,7 +18,7 @@ import java.net.ServerSocket;
  *
  * @author Kohsuke Kawaguchi
  */
-public class AbstractJUnitTest extends CapybaraPortingLayerImpl {
+public class AbstractJUnitTest extends AbstractATHTest {
 
     @Rule
     public JenkinsAcceptanceTestRule rules = new JenkinsAcceptanceTestRule(this);
@@ -36,20 +36,5 @@ public class AbstractJUnitTest extends CapybaraPortingLayerImpl {
     public WebDriver driver;
 
     public AbstractJUnitTest() {
-        super(null);
-    }
-
-    /**
-     * @return finds an unused, available port on the test machine
-     */
-    public int findAvailablePort() {
-        // use port 65000 as fallback (but maybe there is something running)
-        int port = 65000;
-        try (ServerSocket s = new ServerSocket(0)) {
-            port = s.getLocalPort();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return port;
     }
 }

--- a/src/test/java/plugins/FolderPluginTest.java
+++ b/src/test/java/plugins/FolderPluginTest.java
@@ -26,21 +26,29 @@ package plugins;
 
 import org.hamcrest.MatcherAssert;
 import org.jenkinsci.test.acceptance.Matchers;
+import org.jenkinsci.test.acceptance.junit.AbstractClassBasedJUnitTest;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.po.FolderItem;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
 /**
  * Acceptance tests for the CloudBees Folder Plugins.
  */
 @WithPlugins("cloudbees-folder")
-public class FolderPluginTest extends AbstractJUnitTest {
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class FolderPluginTest extends AbstractClassBasedJUnitTest {
     /** Test folder name. */
     private static final String F01 = "F01";
     /** Test folder name. */
     private static final String F02 = "F02";
-    
+
+    /** First test folder. */;
+    private static FolderItem f01;
+
     /**
      * Checks that a folder exists and has the provided name.
      */
@@ -57,33 +65,32 @@ public class FolderPluginTest extends AbstractJUnitTest {
      * </ol>
      */
     @Test
-    public void createFolder() {
+    public void test001CreateFolder() {
         final FolderItem job = jenkins.jobs.create(FolderItem.class, F01);
         job.save();
         jenkins.open();
         checkFolder(job, F01);
+        f01 = job;
     }
     
     /**
-     * Simple folder hierarchy test scenario: Folder creation (JENKINS-31648).
+     * Simple folder hierarchy test scenario: Folder creation (JENKINS-31698).
      * <ol>
-     * <li>We create a folder named "F01".</li>
+     * <li>We start with the folder created in the previous test.</li>
      * <li>We check the folder exists and we can enter it.</li>
      * <li>We create a folder name "F02" inside "F01" and check it.</li>
      * <li>We visit "F01" and the root page, create a folder named "F01" inside the existing "F01" one and check it.
      * </ol>
      */
     @Test
-    public void createFolderHierarchy() {
-        final FolderItem parent = jenkins.jobs.create(FolderItem.class, F01);
-        parent.save();
-        checkFolder(parent, F01);
-        final FolderItem child1 = parent.jobs.create(FolderItem.class, F02);
+    public void test002CreateFolderHierarchy() {
+        Assert.assertNotNull(f01);
+        final FolderItem child1 = f01.jobs.create(FolderItem.class, F02);
         child1.save();
         checkFolder(child1, F02);
-        parent.open();
+        f01.open();
         jenkins.open();
-        final FolderItem child2 = parent.jobs.create(FolderItem.class, F01);
+        final FolderItem child2 = f01.jobs.create(FolderItem.class, F01);
         child2.save();
         checkFolder(child2, F01);
     }


### PR DESCRIPTION
[[JENKINS-31772]](https://issues.jenkins-ci.org/browse/JENKINS-31772)

Add support to using JenkinsAcceptanceTestRule as a ClassRule. PR scope:
* Change JenkinsAcceptanceTestRule to be a TestRule instead of MethodRule.
* Add support to use the rule as a ClassRule.
* Adapt the FolderPluginTest to use the ClassRule.

@reviewbybees 

