### PR TITLE
Allow AbstractSteps to be used outside of ATH

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/steps/AbstractSteps.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/steps/AbstractSteps.java
@@ -20,13 +20,13 @@ public abstract class AbstractSteps extends CapybaraPortingLayerImpl {
      * Implicit contextual Jenkins instance.
      */
     @Inject
-    Jenkins jenkins;
+    protected Jenkins jenkins;
 
     /**
      * Contextual variables.
      */
     @Inject
-    Context my;
+    protected Context my;
 
     protected AbstractSteps() {
         super(null);


### PR DESCRIPTION
If ATH is used externally and a class extends AbstractSteps, then the class
should have access to 'jenkins'