### PR TITLE
Resync EMMA test with updated JaCoCo test resource

### DIFF
--- a/src/test/java/plugins/EmmaPluginTest.java
+++ b/src/test/java/plugins/EmmaPluginTest.java
@@ -61,6 +61,8 @@ public class EmmaPluginTest extends AbstractJUnitTest {
 
         // In the maven build step an Emma goal is added to enable coverage reporting.
         MavenBuildStep mbs = job.addBuildStep(MavenBuildStep.class);
+        mbs.properties("jacoco.version=0.7.5.201505241946");
+
         mbs.targets.set("clean emma:emma package");
         EmmaPublisher ep = job.addPublisher(EmmaPublisher.class);
         ep.setReportingThresholds(100, 70, 80, 80, 80, 0, 0, 0, 0, 0);


### PR DESCRIPTION
e68e9583e8441899376096cf2fce2c4e98d4cf09 changed the resource in JaCoCo that the emma plugin uses.

That change means that the maven build execution now requires the `jacoco.version` property be defined.

This change defines a version (we don't care which as we are running `emma:emma` all we care is that it is a valid version that exists.

@reviewbybees 