### PR TITLE
Download plugin by version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Java system property takes precedence over environment variable.
 * [Using a http proxy](docs/USING-A-HTTP-PROXY.md)
 * [Prelaunch JUT](docs/PRELAUNCH.md)
 * [Obtaining a report of plugins that were exercised](docs/EXERCISEDPLUGINSREPORTER.md)
-* [Testing unreleased plugin](docs/LOCALPLUGIN.md)
+* [Managing the versions of Jenkins and plugins](docs/SUT-VERSIONS.md)
 * [Investigation](docs/INVESTIGATION.md)
 * Selecting tests based on plugins they cover (TODO)
 

--- a/docs/CONTROLLER.md
+++ b/docs/CONTROLLER.md
@@ -15,16 +15,9 @@ For more sophisticated customization, see [WIRING.md](WIRING.md).
 ## Local family controllers
 All local controllers run both test harness and Jenkins under test on local machine. Common environment variables for local controllers:
 
-* `JENKINS_WAR` the path to `jenkins.war` to be tested. If not specified, the first of `WORKSPACE/jenkins.war` followed
-    by `$(pwd)/jenkins.war` that is a file will be selected.
-* `JENKINS_VERSION` specifies Jenkins core version to use. This is an alternative to `JENKINS_WAR`.
 * `JENKINS_JAVA_HOME` the JVM home to use for running Jenkins. If not specified, the first of `JAVA_HOME`, or the JVM
    used to launch the tests will be used.
 * `JENKINS_JAVA_OPTS` Adds additional options to the java process like `-Xms=XXm -Xmx=XXXm`.
-* `PLUGINS_DIR` a directory of plugins to be loaded on Jenkins startup. If this is not specified, the first existing
-    directory from the following list will be used: a `plugins` directory as a sibling to the resolved `jenkins.war`,
-    `WORKSPACE/plugins` and `$(pwd)/plugins`. If the environment variable `NEVER_REPLACE_EXISTING_PLUGINS` is set
-    then plugins will never be overwritten with newer versions during test.
 * `INTERACTIVE` keep browser session opened after failed scenario for interactive investigation.
 
 ### Winstone controller (TYPE=winstone)

--- a/docs/SUT-VERSIONS.md
+++ b/docs/SUT-VERSIONS.md
@@ -1,7 +1,21 @@
-# Testing Unreleased Plugin
+# Managing the versions of Jenkins and plugins
+
+## Jenkins
+
+Jenkins accepts `JENKINS_WAR` parameter to provide a local Jenkins war file to use. Alternatively, `JENKINS_VERSION` can be used to specify a version (like 1.625.3) to be downloaded and used instead.
+
+## Plugins
 
 When tests require the presence of plugins, by default the harness will install necessary plugins from
-the update center.
+the update center. There are several ways to override this:
+
+### Use custom plugin version
+
+Environment variables like `<ARTIFACT_ID>.version` can be used to specify what version will be installed:
+
+    $ env git.version=2.3 mvn test
+
+### Use custom plugin file
 
 When you are testing locally developed Jenkins plugin, you'd like the test harness to pick up your
 local version as opposed to download the plugin from update center. This can be done by instructing the harness
@@ -9,14 +23,13 @@ accordingly.
 
 One way to do so is to set the environment variable:
 
-    $ export ldap.jpi=/path/to/your/ldap.jpi
-    $ mvn test            // run the tests
+    $ env ldap.jpi=/path/to/your/ldap.jpi mvn test
 
 You can also do this from [the groovy wiring script](WIRING.md).
 
     envs['ldap.jpi'] = '/path/to/your.ldap.jpi'
 
-TODO: provide a better binding for this
+### Install plugins from local maven repository
 
 As a convenience, you can also run with the variable `LOCAL_SNAPSHOTS=true`.
 This will override any plugin in the update center with a locally built `SNAPSHOT` version (if newer than the released one).
@@ -35,3 +48,7 @@ For example, you add to your `~/.m2/settings.xml` a profile like
     </profile>
 
 and then `mvn -DskipTests install` on Jenkins core or any plugin before running acceptance tests.
+
+### Provide full plugins collection
+
+Contrary to previous ways to alter the plugin versions used, `PLUGINS_DIR` environment variable specifies a path to a directory with plugins that will all be installed into Jenkins for every test. If test require some plugin that is not part of the collection, it will be installed from update center. This is useful to verify whether particular set of plugins works as expected.

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -158,10 +158,10 @@ public class PluginManager extends ContainerPageObject {
             }
             List<PluginMetadata> pluginToBeInstalled = ucmd.get().transitiveDependenciesOf(jenkins.getVersion(), candidates);
             for (PluginMetadata newPlugin : pluginToBeInstalled) {
-                final String name = newPlugin.name;
+                final String name = newPlugin.getName();
                 String claimedVersion = candidates.get(name);
                 if (claimedVersion == null) { // a dependency
-                    claimedVersion = newPlugin.version;
+                    claimedVersion = newPlugin.getVersion();
                 }
                 final String currentSpec = StringUtils.isNotEmpty(claimedVersion)
                     ? name + "@" + claimedVersion
@@ -170,7 +170,7 @@ public class PluginManager extends ContainerPageObject {
                 InstallationStatus status = installationStatus(currentSpec);
                 if (status != InstallationStatus.UP_TO_DATE) {
                     try {
-                        newPlugin.uploadTo(jenkins, injector, newPlugin.version);
+                        newPlugin.uploadTo(jenkins, injector, newPlugin.getVersion());
                         changed = true;
                         restartRequired |= status == InstallationStatus.OUTDATED;
                         try {

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/CachedUpdateCenterMetadataLoader.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/CachedUpdateCenterMetadataLoader.java
@@ -45,7 +45,7 @@ public class CachedUpdateCenterMetadataLoader implements Provider<UpdateCenterMe
             }
             return metadata;
         } catch (IOException e) {
-            throw new AssertionError("Failed to parse update center data of "+url+" at "+cache);
+            throw new AssertionError("Failed to parse update center data of "+url+" at "+cache, e);
         }
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/DownloadOverrideUpdateCenterMetadataDecorator.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/DownloadOverrideUpdateCenterMetadataDecorator.java
@@ -1,0 +1,28 @@
+package org.jenkinsci.test.acceptance.update_center;
+
+import com.cloudbees.sdk.extensibility.Extension;
+import java.util.Map;
+import javax.inject.Inject;
+
+import org.jenkinsci.test.acceptance.utils.aether.ArtifactResolverUtil;
+
+/**
+ * Download particular plugin version based on environement variable.
+ */
+@Extension
+public class DownloadOverrideUpdateCenterMetadataDecorator implements UpdateCenterMetadataDecorator {
+    @Inject ArtifactResolverUtil resolver;
+
+    @Override
+    public void decorate(UpdateCenterMetadata ucm) {
+        for (Map.Entry<String,String> e : System.getenv().entrySet()) {
+            String key = e.getKey();
+            if (key.endsWith(".version")) {
+                String name = key.substring(0, key.length() - 8);
+                String version = e.getValue();
+                PluginMetadata plugin = ucm.plugins.get(name).versionOf(version);
+                ucm.plugins.put(name, plugin);
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/DownloadOverrideUpdateCenterMetadataDecorator.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/DownloadOverrideUpdateCenterMetadataDecorator.java
@@ -20,8 +20,9 @@ public class DownloadOverrideUpdateCenterMetadataDecorator implements UpdateCent
             if (key.endsWith(".version")) {
                 String name = key.substring(0, key.length() - 8);
                 String version = e.getValue();
-                PluginMetadata plugin = ucm.plugins.get(name).versionOf(version);
-                ucm.plugins.put(name, plugin);
+
+                PluginMetadata original = ucm.plugins.get(name);
+                ucm.plugins.put(name, original.withVersion(version));
             }
         }
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/LocalOverrideUpdateCenterMetadataDecoratorImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/LocalOverrideUpdateCenterMetadataDecoratorImpl.java
@@ -2,11 +2,7 @@ package org.jenkinsci.test.acceptance.update_center;
 
 import com.cloudbees.sdk.extensibility.Extension;
 import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Map;
-import java.util.jar.Attributes;
-import java.util.jar.JarFile;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.Version;
@@ -44,7 +40,7 @@ public class LocalOverrideUpdateCenterMetadataDecoratorImpl implements UpdateCen
                                 File hpi = new File(new File(artifactDir, version), gav[1] + "-" + version + ".hpi");
                                 if (hpi.isFile()) {
                                     System.err.println("Overriding " + entry.getKey() + " " + ucVersion + " with local build of " + version);
-                                    PluginMetadata m = parseMetadata(hpi);
+                                    PluginMetadata m = new PluginMetadata(hpi);
                                     ucm.plugins.put(m.name, m);
                                 }
                             }
@@ -57,58 +53,9 @@ public class LocalOverrideUpdateCenterMetadataDecoratorImpl implements UpdateCen
         }
         for (Map.Entry<String,String> e : System.getenv().entrySet()) {
             if (e.getKey().endsWith(".jpi")) {
-                PluginMetadata m = parseMetadata(new File(e.getValue()));
+                PluginMetadata m = new PluginMetadata(new File(e.getValue()));
                 ucm.plugins.put(m.name, m);
             }
         }
     }
-
-    /**
-     * Looks at the manifest of a plugin jpi file and parses that into {@link PluginMetadata} format.
-     */
-    private PluginMetadata parseMetadata(File jpi) {
-        PluginMetadata m = new PluginMetadata();
-        m.dependencies = new ArrayList<Dependency>();
-        try (JarFile j = new JarFile(jpi)) {
-            Attributes main = j.getManifest().getMainAttributes();
-            m.name = main.getValue("Short-Name");
-            m.version = main.getValue("Plugin-Version");
-            m.requiredCore = main.getValue("Jenkins-Version");
-            m.gav = main.getValue("Group-Id")+":"+m.name+":"+m.version;
-            m.override = jpi;
-            String dep = main.getValue("Plugin-Dependencies");
-            if (dep!=null) {
-                for (String token : dep.split(",")) {
-                    Dependency d = new Dependency();
-                    d.optional = token.endsWith(OPTIONAL);
-                    if(d.optional)
-                        token = token.substring(0, token.length()-OPTIONAL.length());
-                    String[] tokens = token.split(":");
-                    if (tokens.length != 2) {
-                        System.err.println("Bad token ‘" + token + "’ from ‘" + dep + "’ in " + jpi);
-                        continue;
-                    }
-                    d.name = tokens[0];
-                    d.version = tokens[1];
-                    m.dependencies.add(d);
-                }
-            }
-            tidyUpVersion(m);
-        } catch (IOException e) {
-            throw new AssertionError("Failed to parse metadata of "+jpi,e);
-        }
-        return m;
-    }
-
-    /**
-     * Snapshot builds often look like "Plugin-Version: 1.0-SNAPSHOT (private-08/21/2014 15:21-kohsuke)"
-     * so trim off the build ID portion and just get "1.0-SNAPSHOT"
-     */
-    private void tidyUpVersion(PluginMetadata m) {
-        int idx = m.version.indexOf(" ");
-        if (idx>0)
-            m.version = m.version.substring(0,idx);
-    }
-
-    private static final String OPTIONAL = ";resolution:=optional";
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginMetadata.java
@@ -5,6 +5,7 @@ import hudson.util.VersionNumber;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -18,15 +19,14 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.utils.aether.ArtifactResolverUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.inject.Injector;
 
 import static org.apache.http.entity.ContentType.*;
@@ -37,15 +37,26 @@ import static org.apache.http.entity.ContentType.*;
  * @author Kohsuke Kawaguchi
  */
 public class PluginMetadata {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PluginMetadata.class);
-    public String name, version, gav;
-    public String requiredCore;
-    public List<Dependency> dependencies;
+    private final String name;
+    private final String version;
+    private final String gav;
+    private final String requiredCore;
+    private final List<Dependency> dependencies;
 
-    /**
-     * If non-null, use this file instead of the one pointed by {@link #gav}.
-     */
-    public File override;
+    @JsonCreator
+    public PluginMetadata(
+            @JsonProperty("name") String name,
+            @JsonProperty("gav") String gav,
+            @JsonProperty("version") String version,
+            @JsonProperty("requiredCore") String requiredCore,
+            @JsonProperty("dependencies") List<Dependency> dependencies
+    ) {
+        this.name = name;
+        this.gav = gav;
+        this.version = version;
+        this.requiredCore = requiredCore;
+        this.dependencies = dependencies;
+    }
 
     void init(UpdateCenterMetadata parent) {
         for (Dependency d : dependencies) {
@@ -53,70 +64,13 @@ public class PluginMetadata {
         }
     }
 
-    public PluginMetadata() {}
-
-    /**
-     * Extract plugin metadata from a jpi/hpi file.
-     */
-    public PluginMetadata(@Nonnull File jpi) {
-        final String OPTIONAL = ";resolution:=optional";
-
-        dependencies = new ArrayList<Dependency>();
-        try (JarFile j = new JarFile(jpi)) {
-            Attributes main = j.getManifest().getMainAttributes();
-            name = main.getValue("Short-Name");
-            version = trimVersion(main.getValue("Plugin-Version"));
-            requiredCore = main.getValue("Jenkins-Version");
-            gav = main.getValue("Group-Id")+":"+name+":"+version;
-            override = jpi;
-            String dep = main.getValue("Plugin-Dependencies");
-            if (dep!=null) {
-                for (String token : dep.split(",")) {
-                    Dependency d = new Dependency();
-                    d.optional = token.endsWith(OPTIONAL);
-                    if(d.optional)
-                        token = token.substring(0, token.length()-OPTIONAL.length());
-                    String[] tokens = token.split(":");
-                    if (tokens.length != 2) {
-                        System.err.println("Bad token ‘" + token + "’ from ‘" + dep + "’ in " + jpi);
-                        continue;
-                    }
-                    d.name = tokens[0];
-                    d.version = tokens[1];
-                    dependencies.add(d);
-                }
-            }
-        } catch (IOException e) {
-            throw new AssertionError("Failed to parse metadata of "+jpi,e);
-        }
-    }
-
-    /**
-     * Snapshot builds often look like "Plugin-Version: 1.0-SNAPSHOT (private-08/21/2014 15:21-kohsuke)"
-     * so trim off the build ID portion and just get "1.0-SNAPSHOT"
-     */
-    private String trimVersion(@Nonnull String version) {
-        int idx = version.indexOf(" ");
-        return idx > 0
-            ? version.substring(0, idx)
-            : version
-        ;
-    }
-
-    /**
-     * @param jenkins
-     * @param i
-     * @param version The version of the plugin you want to upload
-     * @throws ArtifactResolutionException
-     * @throws IOException
-     */
     public void uploadTo(Jenkins jenkins, Injector i, String version) throws ArtifactResolutionException, IOException {
         HttpClient httpclient = new DefaultHttpClient();
 
         HttpPost post = new HttpPost(jenkins.url("pluginManager/uploadPlugin").toExternalForm());
         File f = resolve(i, version);
         HttpEntity e = MultipartEntityBuilder.create()
-                .addBinaryBody("name", f, APPLICATION_OCTET_STREAM, name + ".jpi")
+                .addBinaryBody("name", f, APPLICATION_OCTET_STREAM, getName() + ".jpi")
                 .build();
         post.setEntity(e);
 
@@ -130,33 +84,127 @@ public class PluginMetadata {
     }
 
     public File resolve(Injector i, String version) {
-        if (override!=null) return override;
+        DefaultArtifact artifact = getDefaultArtifact();
+        if (version != null) {
+            artifact.setVersion(version);
+        }
 
-        RepositorySystem rs = i.getInstance(RepositorySystem.class);
-        RepositorySystemSession rss = i.getInstance(RepositorySystemSession.class);
-
-        ArtifactResolverUtil resolverUtil = new ArtifactResolverUtil(rs, rss);
-        ArtifactResult r = resolverUtil.resolve(gav, version);
+        ArtifactResolverUtil resolverUtil = i.getInstance(ArtifactResolverUtil.class);
+        ArtifactResult r = resolverUtil.resolve(artifact);
         return r.getArtifact().getFile();
+    }
+
+    public DefaultArtifact getDefaultArtifact() {
+        String[] t = gav.split(":");
+        String gavVersion;
+        if (getVersion() == null) {
+            gavVersion = t[2];
+        } else {
+            gavVersion = getVersion();
+        }
+        return new DefaultArtifact(t[0], t[1], "hpi", gavVersion);
     }
 
     public VersionNumber requiredCore() {
         return new VersionNumber(requiredCore);
     }
 
-    public PluginMetadata versionOf(String v) {
+    public PluginMetadata withVersion(@Nonnull String v) {
         if (v == null) throw new IllegalArgumentException();
 
-        PluginMetadata ret = new PluginMetadata();
-        ret.name = name;
-        ret.version = v;
-        ret.gav = gav;
-        ret.requiredCore = requiredCore;
-        return ret;
+        return new PluginMetadata(name, gav, v, requiredCore, dependencies);
     }
 
     @Override
     public String toString() {
-        return super.toString() + "[" + name + "," + version + "]";
+        return getClass().getSimpleName() + "[" + getName() + "," + getVersion() + "]";
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Dependency> getDependencies() {
+        return Collections.unmodifiableList(dependencies);
+    }
+
+    /**
+     * Use local file instead of what is configured.
+     *
+     * @author ogondza
+     */
+    public static final class LocalOverride extends PluginMetadata {
+        private static final String OPTIONAL = ";resolution:=optional";
+
+        private @Nonnull File override;
+
+        /**
+         * Extract plugin metadata from a jpi/hpi file.
+         */
+        public static LocalOverride create(@Nonnull File jpi) {
+
+            List<Dependency> dependencies = new ArrayList<Dependency>();
+            try (JarFile j = new JarFile(jpi)) {
+                Attributes main = j.getManifest().getMainAttributes();
+                String name = main.getValue("Short-Name");
+                String version = trimVersion(main.getValue("Plugin-Version"));
+                String requiredCore = main.getValue("Jenkins-Version");
+                String gav = main.getValue("Group-Id")+":"+name+":"+version;
+                String dep = main.getValue("Plugin-Dependencies");
+                if (dep!=null) {
+                    for (String token : dep.split(",")) {
+                        Dependency d = new Dependency();
+                        d.optional = token.endsWith(OPTIONAL);
+                        if(d.optional)
+                            token = token.substring(0, token.length()-OPTIONAL.length());
+                        String[] tokens = token.split(":");
+                        if (tokens.length != 2) {
+                            System.err.println("Bad token ‘" + token + "’ from ‘" + dep + "’ in " + jpi);
+                            continue;
+                        }
+                        d.name = tokens[0];
+                        d.version = tokens[1];
+                        dependencies.add(d);
+                    }
+                }
+
+                return new LocalOverride(name, gav, version, requiredCore, dependencies, jpi);
+            } catch (IOException e) {
+                throw new AssertionError("Failed to parse metadata of "+jpi,e);
+            }
+        }
+
+        public LocalOverride(
+                String name, String gav, String version, String requiredCore, List<Dependency> dependencies, File override
+        ) {
+            super(name, gav, version, requiredCore, dependencies);
+            this.override = override;
+        }
+
+        /**
+         * Snapshot builds often look like "Plugin-Version: 1.0-SNAPSHOT (private-08/21/2014 15:21-kohsuke)"
+         * so trim off the build ID portion and just get "1.0-SNAPSHOT"
+         */
+        private static String trimVersion(@Nonnull String version) {
+            int idx = version.indexOf(" ");
+            return idx > 0
+                ? version.substring(0, idx)
+                : version
+            ;
+        }
+
+        @Override
+        public File resolve(Injector i, String version) {
+            return override;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "[" + getName() + "," + override.getAbsolutePath() + "]";
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
@@ -77,20 +77,20 @@ public class UpdateCenterMetadata {
         return set;
     }
 
-    private void transitiveDependenciesOf(VersionNumber jenkins, PluginMetadata p, String v, List<PluginMetadata> set) {
-        for (Dependency d : p.dependencies) {
+    private void transitiveDependenciesOf(VersionNumber jenkins, PluginMetadata p, String v, List<PluginMetadata> result) {
+        for (Dependency d : p.getDependencies()) {
             if (d.optional) continue;
-            transitiveDependenciesOf(jenkins, plugins.get(d.name), d.version, set);
+            transitiveDependenciesOf(jenkins, plugins.get(d.name), d.version, result);
         }
 
-        if (!set.contains(p)) {
+        if (!result.contains(p)) {
             PluginMetadata use = p;
             if (use.requiredCore().isNewerThan(jenkins)) {
                 // If latest version is too new for current Jenkins, use the declared one
-                use = p.versionOf(v);
+                result.add(p.withVersion(v));
+            } else {
+                result.add(use);
             }
-
-            set.add(use);
         }
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/aether/ArtifactResolverUtil.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/aether/ArtifactResolverUtil.java
@@ -27,6 +27,10 @@ package org.jenkinsci.test.acceptance.utils.aether;
 import java.io.File;
 import java.util.Arrays;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
 import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
@@ -58,6 +62,7 @@ public class ArtifactResolverUtil {
     private RepositorySystem repoSystem;
     private RepositorySystemSession repoSystemSession;
 
+    @Inject
     public ArtifactResolverUtil(RepositorySystem rs, RepositorySystemSession rss) {
         repoSystem = rs;
         repoSystemSession = rss;
@@ -65,11 +70,11 @@ public class ArtifactResolverUtil {
 
     /**
      * @param gav The "groupId artifactId version" to be resolved
-     * @param version The version of the artifact you want to resolve
+     * @param version The version of the artifact you want to resolve, optional.
      *
      * @return artifact resolution result
      */
-    public ArtifactResult resolve(String gav, String version) {
+    public ArtifactResult resolve(@Nonnull String gav, @CheckForNull String version) {
         return resolve(makeArtifact(gav, version));
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/aether/ArtifactResolverUtil.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/aether/ArtifactResolverUtil.java
@@ -27,8 +27,6 @@ package org.jenkinsci.test.acceptance.utils.aether;
 import java.io.File;
 import java.util.Arrays;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
 import org.apache.maven.settings.Settings;
@@ -66,16 +64,6 @@ public class ArtifactResolverUtil {
     public ArtifactResolverUtil(RepositorySystem rs, RepositorySystemSession rss) {
         repoSystem = rs;
         repoSystemSession = rss;
-    }
-
-    /**
-     * @param gav The "groupId artifactId version" to be resolved
-     * @param version The version of the artifact you want to resolve, optional.
-     *
-     * @return artifact resolution result
-     */
-    public ArtifactResult resolve(@Nonnull String gav, @CheckForNull String version) {
-        return resolve(makeArtifact(gav, version));
     }
 
     /**
@@ -123,17 +111,6 @@ public class ArtifactResolverUtil {
         return r;
     }
 
-    private DefaultArtifact makeArtifact(String gav, String version) {
-        String[] t = gav.split(":");
-        String gavVersion;
-        if (version == null) {
-            gavVersion = t[2];
-        } else {
-            gavVersion = version;
-        }
-        return new DefaultArtifact(t[0], t[1], "hpi", gavVersion);
-    }
-
     /**
      * Converts Maven Proxy to Aether Proxy
      *
@@ -150,5 +127,4 @@ public class ArtifactResolverUtil {
         }
         return new Proxy(proxy.getProtocol(), proxy.getHost(), proxy.getPort(), auth);
     }
-
 }


### PR DESCRIPTION
User can suggest plugin version using for example `git.version=1.42` to override latest. Much like `git.jpi` works.