### PR TITLE
Add posibility to use remote webdriver as a browser

### DIFF
--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -51,4 +51,15 @@ will go to a separate display. For example, on Ubuntu you can run `vncserver`, t
     ...
     New 'X' desktop is elf:1
     $ DISPLAY=elf:1 mvn test 
+    
+## Example on using remote web driver
+
+Non tested pseudo bash example
+
+    docker run -d -P selenium/standalone-firefox-debug > containerId.txt
+    export WEBDRIVER_CONTAINER_ID=$(cat containerId.txt)
+    export BROWSER=remote-webdriver-firefox
+    export REMOTE_WEBDRIVER_URL=http://$(docker port $WEBDRIVER_CONTAINER_ID 4444)/wd/hub
+    export JENKINS_LOCAL_HOSTNAME=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+    mvn test
 

--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -10,6 +10,9 @@ by using the `BROWSER` environment variable. The following values are available:
  * `htmlunit`
  * `phantomjs`
  * `saucelabs`
+ * `remote-webdriver-firefox` 
+        _(Needs `REMOTE_WEBDRIVER_URL` to also be set to the url of the remote, for example `http://0.0.0.0:32779/wd/hub`
+          when using something like [selenium/standalone-firefox-debug](https://hub.docker.com/r/selenium/standalone-firefox-debug/))_
 
 Therefore, to run tests with Safari, you'd execute:
 

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -4,11 +4,13 @@ import javax.inject.Named;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -46,6 +48,7 @@ import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 
@@ -123,6 +126,14 @@ public class FallbackConfig extends AbstractModule {
             capabilities.setCapability(LANGUAGE_SELECTOR, "en");
             capabilities.setCapability(LANGUAGE_SELECTOR_PHANTOMJS, "en");
             return new PhantomJSDriver(capabilities);
+        case "remote-webdriver-firefox":
+            String u = System.getenv("REMOTE_WEBDRIVER_URL");
+            if (StringUtils.isBlank(u)) {
+                throw new Error("remote-webdriver-firefox requires REMOTE_WEBDRIVER_URL to be set");
+            }
+            return new RemoteWebDriver(
+                    new URL(u), //http://192.168.99.100:4444/wd/hub
+                    DesiredCapabilities.firefox());
 
         default:
             throw new Error("Unrecognized browser type: "+browser);


### PR DESCRIPTION
For example the selenium/standalone-firefox-debug docker image.

@reviewbybees 