### PR TITLE
[JENKINS-32477] Stop using deprecated methods and test fix

### DIFF
--- a/src/test/java/plugins/SubversionPluginTest.java
+++ b/src/test/java/plugins/SubversionPluginTest.java
@@ -1,7 +1,11 @@
 package plugins;
 
 import com.google.inject.Inject;
+
+import java.util.regex.Pattern;
+
 import org.hamcrest.CoreMatchers;
+import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.test.acceptance.docker.DockerContainerHolder;
 import org.jenkinsci.test.acceptance.docker.fixtures.SvnContainer;
 import org.jenkinsci.test.acceptance.junit.*;
@@ -9,6 +13,7 @@ import org.jenkinsci.test.acceptance.plugins.subversion.SubversionPluginTestExce
 import org.jenkinsci.test.acceptance.plugins.subversion.SubversionScm;
 import org.jenkinsci.test.acceptance.plugins.subversion.SubversionSvmAdvanced;
 import org.jenkinsci.test.acceptance.plugins.subversion.SvnRepositoryBrowserWebSvn;
+import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.Changes;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.junit.Test;
@@ -23,7 +28,7 @@ import static org.junit.Assert.*;
  *
  * @author Matthias Karl
  */
-@WithPlugins("subversion@2.3")
+@WithPlugins("subversion@2.5.7")
 @WithDocker
 public class SubversionPluginTest extends AbstractJUnitTest {
     @Inject
@@ -49,7 +54,8 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.addShellStep("test -d .svn");
         f.save();
 
-        f.startBuild().shouldSucceed().shouldContainsConsoleOutput("test -d .svn");
+        Build b = f.startBuild().shouldSucceed();
+        assertThat(b.getConsole(), Matchers.containsRegexp("test -d .svn", Pattern.MULTILINE));
     }
 
     /**
@@ -70,7 +76,8 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.useScm(SubversionScm.class).url.set(svnContainer.getUrlUnsaveRepoAtRevision(revision));
         f.save();
 
-        f.startBuild().shouldSucceed().shouldContainsConsoleOutput("At revision " + revision);
+        Build b = f.startBuild().shouldSucceed();
+        assertThat(b.getConsole(), Matchers.containsRegexp("At revision " + revision, Pattern.MULTILINE));
     }
 
     /**
@@ -96,8 +103,8 @@ public class SubversionPluginTest extends AbstractJUnitTest {
 
         f.startBuild().shouldSucceed();
 
-        f.startBuild().shouldSucceed()
-                .shouldContainsConsoleOutput("Checking out " + svnContainer.getUrlUnsaveRepo());
+        Build b = f.startBuild().shouldSucceed();
+        assertThat(b.getConsole(), Matchers.containsRegexp("Checking out " + svnContainer.getUrlUnsaveRepo(), Pattern.MULTILINE));
     }
 
     /**
@@ -125,7 +132,8 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         subversionScm.credentials.select(SvnContainer.USER);
         f.save();
 
-        f.startBuild().shouldSucceed().shouldContainsConsoleOutput("test -d .svn");
+        Build b = f.startBuild().shouldSucceed();
+        assertThat(b.getConsole(), Matchers.containsRegexp("test -d .svn", Pattern.MULTILINE));
     }
 
 
@@ -153,7 +161,8 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         subversionScm.credentials.select(SvnContainer.USER);
         f.save();
 
-        f.startBuild().shouldSucceed().shouldContainsConsoleOutput("test -d .svn");
+        Build b = f.startBuild().shouldSucceed();
+        assertThat(b.getConsole(), Matchers.containsRegexp("test -d .svn", Pattern.MULTILINE));
     }
 
 
@@ -185,6 +194,8 @@ public class SubversionPluginTest extends AbstractJUnitTest {
 
         f.configure();
         f.removeFirstBuildStep();
+        // Sleep for 500ms to give time to DOM to regenerate
+        f.elasticSleep(500);
         f.addShellStep("! test -f unversioned.txt");
         f.save();
         f.startBuild().shouldSucceed();

--- a/src/test/java/plugins/SubversionPluginTest.java
+++ b/src/test/java/plugins/SubversionPluginTest.java
@@ -3,6 +3,7 @@ package plugins;
 import com.google.inject.Inject;
 
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
 import org.jenkinsci.test.acceptance.docker.DockerContainerHolder;
 import org.jenkinsci.test.acceptance.docker.fixtures.SvnContainer;
 import org.jenkinsci.test.acceptance.junit.*;
@@ -52,7 +53,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.save();
 
         Build b = f.startBuild().shouldSucceed();
-        assertTrue(b.getConsole().contains("test -d .svn"));
+        assertThat(b.getConsole(), Matchers.containsString("test -d .svn"));
     }
 
     /**
@@ -74,7 +75,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.save();
 
         Build b = f.startBuild().shouldSucceed();
-        assertTrue(b.getConsole().contains("At revision " + revision));
+        assertThat(b.getConsole(), Matchers.containsString("At revision " + revision));
     }
 
     /**
@@ -101,7 +102,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.startBuild().shouldSucceed();
 
         Build b = f.startBuild().shouldSucceed();
-        assertTrue(b.getConsole().contains("Checking out " + svnContainer.getUrlUnsaveRepo()));
+        assertThat(b.getConsole(), Matchers.containsString("Checking out " + svnContainer.getUrlUnsaveRepo()));
     }
 
     /**
@@ -130,7 +131,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.save();
 
         Build b = f.startBuild().shouldSucceed();
-        assertTrue(b.getConsole().contains("test -d .svn"));
+        assertThat(b.getConsole(), Matchers.containsString("test -d .svn"));
     }
 
 
@@ -159,7 +160,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.save();
 
         Build b = f.startBuild().shouldSucceed();
-        assertTrue(b.getConsole().contains("test -d .svn"));
+        assertThat(b.getConsole(), Matchers.containsString("test -d .svn"));
     }
 
 

--- a/src/test/java/plugins/SubversionPluginTest.java
+++ b/src/test/java/plugins/SubversionPluginTest.java
@@ -2,10 +2,7 @@ package plugins;
 
 import com.google.inject.Inject;
 
-import java.util.regex.Pattern;
-
 import org.hamcrest.CoreMatchers;
-import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.test.acceptance.docker.DockerContainerHolder;
 import org.jenkinsci.test.acceptance.docker.fixtures.SvnContainer;
 import org.jenkinsci.test.acceptance.junit.*;
@@ -28,7 +25,7 @@ import static org.junit.Assert.*;
  *
  * @author Matthias Karl
  */
-@WithPlugins("subversion@2.5.7")
+@WithPlugins("subversion@2.3")
 @WithDocker
 public class SubversionPluginTest extends AbstractJUnitTest {
     @Inject
@@ -55,7 +52,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.save();
 
         Build b = f.startBuild().shouldSucceed();
-        assertThat(b.getConsole(), Matchers.containsRegexp("test -d .svn", Pattern.MULTILINE));
+        assertTrue(b.getConsole().contains("test -d .svn"));
     }
 
     /**
@@ -77,7 +74,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.save();
 
         Build b = f.startBuild().shouldSucceed();
-        assertThat(b.getConsole(), Matchers.containsRegexp("At revision " + revision, Pattern.MULTILINE));
+        assertTrue(b.getConsole().contains("At revision " + revision));
     }
 
     /**
@@ -104,7 +101,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.startBuild().shouldSucceed();
 
         Build b = f.startBuild().shouldSucceed();
-        assertThat(b.getConsole(), Matchers.containsRegexp("Checking out " + svnContainer.getUrlUnsaveRepo(), Pattern.MULTILINE));
+        assertTrue(b.getConsole().contains("Checking out " + svnContainer.getUrlUnsaveRepo()));
     }
 
     /**
@@ -133,7 +130,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.save();
 
         Build b = f.startBuild().shouldSucceed();
-        assertThat(b.getConsole(), Matchers.containsRegexp("test -d .svn", Pattern.MULTILINE));
+        assertTrue(b.getConsole().contains("test -d .svn"));
     }
 
 
@@ -162,7 +159,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
         f.save();
 
         Build b = f.startBuild().shouldSucceed();
-        assertThat(b.getConsole(), Matchers.containsRegexp("test -d .svn", Pattern.MULTILINE));
+        assertTrue(b.getConsole().contains("test -d .svn"));
     }
 
 


### PR DESCRIPTION
[JENKINS-32477](https://issues.jenkins-ci.org/browse/JENKINS-32477)

* Stop using deprecated method <code>org.jenkinsci.test.acceptance.po.Build.shouldContainsConsoleOutput</code>
* Use <code>elasticSleep</code> method to fix test that fails. DOM tree is not regenerated fast enough.

@reviewbybees 