### PR TITLE
Trying to make WorkflowPluginTest.linearFlow less flaky

### DIFF
--- a/src/test/java/plugins/WorkflowPluginTest.java
+++ b/src/test/java/plugins/WorkflowPluginTest.java
@@ -102,6 +102,9 @@ public class WorkflowPluginTest extends AbstractJUnitTest {
         jenkins.restart();
         visit(build.getConsoleUrl());
         clickLink("Proceed");
+        // Default 120s timeout of Build.waitUntilFinished sometimes expires waiting for RetentionStrategy.Always to tick (after initial failure of CommandLauncher.launch: EOFException: unexpected stream termination):
+        slave.waitUntilOnline();
+        // Can also fail due to double loading of build as per JENKINS-22767:
         assertTrue(build.isSuccess() || build.isUnstable()); // tests in this project are currently designed to fail at random, so either is OK
         new Artifact(build, "target/simple-maven-project-with-tests-1.0-SNAPSHOT.jar").assertThatExists(true);
         build.open();


### PR DESCRIPTION
Observed that after the restart, the command launcher tries to reconnect the slave, but always fails with an `EOFException` (currently have no idea why). At some point `ComputerRetentionWork` kicks in and runs `RetentionStrategy.Always.check`. It seems like this should happen within one minute, but I have seen it take nearly two full minutes after startup before an attempt is made to reconnect. By that time the test timeout waiting for build completion may have expired.

@reviewbybees