### PR TITLE
[FIXED JENKINS-32569] - ArtifactManagement: Add a delay to the control cleanup cycle

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ArtifactManagement.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ArtifactManagement.java
@@ -46,8 +46,14 @@ public class ArtifactManagement extends PageAreaImpl {
 
     public void clear() {
         try {
-            while (true) {
+            while (control("artifactManagerFactories/repeatable-delete").exists()) {
                 control("artifactManagerFactories/repeatable-delete").click();
+                // We allow slow Javascripts to remove the deleted element before we click again (JENKINS-32569)
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException ex) {
+                    // just ignore and continue the cycle
+                }
             }
         } catch (NoSuchElementException ignored) {
             //done no more buttons to push


### PR DESCRIPTION
The change gives slow JS engines a chance to cleanup the previous control before we click on the button again.
It fixes ArtifactManager and ParameterizedTriggerTest::triggerWithNonStandardArchiver() on my machine.

https://issues.jenkins-ci.org/browse/JENKINS-32569

@reviewbybees 