### PR TITLE
[FIXED JENKINS-33520] make ATH work on windows and other issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,12 @@
       <version>2.2</version>
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <!--  same version as commons-configuration -->
+      <version>2.6</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>process-utils</artifactId>
       <version>1.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <selenium.version>2.48.2</selenium.version>
+    <selenium.version>2.52.0</selenium.version>
     <aether.version>0.9.0.v20140226</aether.version>
     <maven.version>3.1.0</maven.version>
     <groovy.version>2.3.1</groovy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <selenium.version>2.52.0</selenium.version>
+    <selenium.version>2.53.0</selenium.version>
     <aether.version>0.9.0.v20140226</aether.version>
     <maven.version>3.1.0</maven.version>
     <groovy.version>2.3.1</groovy.version>
@@ -160,8 +160,8 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-htmlunit-driver</artifactId>
-      <version>${selenium.version}</version>
+      <artifactId>htmlunit-driver</artifactId>
+      <version>2.20</version>
     </dependency>
     <dependency>
       <groupId>com.github.detro.ghostdriver</groupId>

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
@@ -70,7 +70,6 @@ public class DockerContainer implements Closeable {
             String out = Docker.cmd("port").add(cid, n).popen().verifyOrDieWith("docker port command failed").trim();
             if (out.isEmpty())  // expected to return single line like "0.0.0.0:55326"
                 throw new IllegalStateException(format("Port %d is not mapped for container %s", n, cid));
-
             return out.split(":")[0];
         } catch (IOException | InterruptedException e) {
             throw new AssertionError("Failed to figure out port map " + n, e);

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerFixture.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerFixture.java
@@ -20,6 +20,9 @@ import static java.lang.annotation.RetentionPolicy.*;
 @Indexed
 @Inherited
 public @interface DockerFixture {
+
+    public static final String DEFAULT_DOCKER_IP = "";
+    
     /**
      * Unique ID of this fixture. Used from cucumber, etc. to find this annotation.
      */
@@ -37,8 +40,12 @@ public @interface DockerFixture {
 
     /**
      * Ip address to bind to
+     * @deprecated this assumes you have network knowledge of the running ATH environment which you can not possibly have.
+     *             Docker may be running on a remote machine and as such any address (e.g. <code>127.0.0.5<code>)
+     *             you specify may not be reachable.
      */
-    String bindIp() default "127.0.0.1";
+    @Deprecated
+    String bindIp() default DEFAULT_DOCKER_IP;
 
     /**
      * Path of Dockerfile file.
@@ -53,4 +60,5 @@ public @interface DockerFixture {
      * </p>
      */
     String dockerfileFolder() default "";
+
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -2,10 +2,12 @@ package org.jenkinsci.test.acceptance.docker;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.SystemUtils;
+import org.jenkinsci.test.acceptance.junit.WithDocker;
 import org.jenkinsci.utils.process.CommandBuilder;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
 
 /**
@@ -17,16 +19,26 @@ public class DockerImage {
 
     public static final String DEFAULT_DOCKER_HOST = "127.0.0.1";
     public final String tag;
-    DockerHostResolver dockerHostResolver;
+    static DockerHostResolver dockerHostResolver = new DockerHostResolver();
 
     public DockerImage(String tag) {
         this.tag = tag;
-        dockerHostResolver = new DockerHostResolver();
     }
 
-    public <T extends DockerContainer> T start(Class<T> type, CommandBuilder options, CommandBuilder cmd,int portOffset) throws InterruptedException, IOException {
+    public <T extends DockerContainer> T start(Class<T> type, CommandBuilder options, CommandBuilder cmd, int portOffset) throws InterruptedException, IOException {
         DockerFixture f = type.getAnnotation(DockerFixture.class);
-        return start(type,f.ports(),portOffset,f.bindIp(),options,cmd);
+
+        String addr = f.bindIp();
+        if (!DockerFixture.DEFAULT_DOCKER_IP.equals(f.bindIp())) {
+            // specifying an address will only work if the docker host is on localhost.
+            if (InetAddress.getByName(getDockerHost()).isLoopbackAddress()) {
+                return start(type, f.ports(), portOffset, f.bindIp(), options, cmd);
+            }
+            else {
+                throw new AssertionError("Test would fail as docker requires local networks on a remote machine - Hint use `@WithDocker(localOnly=true)´ or do not specify a bindIp in " + type.getName());
+            }
+        }
+        return start(type, f.ports(), portOffset, getDockerHost(), options, cmd);
     }
 
     public <T extends DockerContainer> T start(Class<T> type, CommandBuilder options, CommandBuilder cmd) throws InterruptedException, IOException {
@@ -37,6 +49,7 @@ public class DockerImage {
     public <T extends DockerContainer> T start(Class<T> type, int[] ports, CommandBuilder options, CommandBuilder cmd) throws InterruptedException, IOException {
         return start(type,ports,0, getDockerHost(),options,cmd);
     }
+
     /**
      * Starts a container from this image.
      */
@@ -113,13 +126,16 @@ public class DockerImage {
         }
     }
 
-    // package for tests
-    String getDockerHost() {
+    /**
+     * Get the string representation of the docker host as set by DOCKER_HOST environment variable or the localhost address if it is not set (or is a socket).
+     * @return an IP Address or hostname of the docker host 
+     */
+    public static String getDockerHost() {
         final String dockerHostEnvironmentVariable = dockerHostResolver.getDockerHostEnvironmentVariable();
         return dockerHostEnvironmentVariable != null ? getIp(dockerHostEnvironmentVariable) : DEFAULT_DOCKER_HOST;
     }
 
-    private String getIp(String uri) {
+    private static String getIp(String uri) {
         final URI dockerHost = URI.create(uri);
         final String host = dockerHost.getHost();
         return host != null ? host : DEFAULT_DOCKER_HOST;

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.test.acceptance.docker;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.utils.process.CommandBuilder;
 
 import java.io.File;
@@ -65,7 +66,7 @@ public class DockerImage {
         File tmplog = File.createTempFile("docker", "log"); // initially create a log file here
 
         Process p = docker.build()
-                .redirectInput(new File("/dev/null"))
+                .redirectInput(new File(SystemUtils.IS_OS_WINDOWS ? "NUL" : "/dev/null"))
                 .redirectErrorStream(true)
                 .redirectOutput(tmplog)
                 .start();

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DynamicDockerContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DynamicDockerContainer.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.test.acceptance.docker;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
+
+/**
+ * A DockerContainer whose <code>Dockerfile</code> is not static but requires some knowledge of the environment it is going to run in.
+ *
+ * Before the image is created {@link #process(String)} will be called which can be used to replace place holders with given values or manipulate the docker file in anyother way.
+ */
+public class DynamicDockerContainer extends DockerContainer {
+
+    /**
+     * Reads the contents from the given file and passes the result to {@link #process(String)}, the result of which is then written back into the file.
+     * @param f the Dockerfile
+     * @throws IOException 
+     */
+    void process(File f) throws IOException {
+        String contents = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
+        contents = process(contents);
+        FileUtils.write(f, contents, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Manipulates the provided Dockerfile contents.
+     * This method replaces any occurrence of <code>@@DOCKER_HOST@@<code> with the ip address of the machine running docker.
+     * @param contents the original contents of the Dockerfile
+     * @return a String with the new contents of the Dockerfile
+     */
+    protected String process(String contents) {
+        return contents.replaceAll("@@DOCKER_HOST@@", DockerImage.getDockerHost());
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer.java
@@ -3,8 +3,8 @@ package org.jenkinsci.test.acceptance.docker.fixtures;
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
+import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
-import org.jenkinsci.test.acceptance.docker.DynamicDockerContainer;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -18,7 +18,7 @@ import java.io.IOException;
  * @author Tobias Meyer
  */
 @DockerFixture(id = "ftpd", ports = {21, 7050, 7051, 7052, 7053, 7054, 7055}, bindIp = "127.0.0.2")
-public class FtpdContainer extends DynamicDockerContainer implements IPasswordDockerContainer {
+public class FtpdContainer extends DockerContainer implements IPasswordDockerContainer {
     private FTPClient ftpClient;
 
     private final String username = "test";
@@ -58,7 +58,7 @@ public class FtpdContainer extends DynamicDockerContainer implements IPasswordDo
      */
     public Boolean ftpConnect() {
         try {
-            ftpClient.connect(getIpAddress(), port(21));
+            ftpClient.connect(ipBound(21), port(21));
             ftpClient.enterLocalPassiveMode();
             ftpClient.setRemoteVerificationEnabled(false);
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer.java
@@ -3,8 +3,10 @@ package org.jenkinsci.test.acceptance.docker.fixtures;
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
+import org.jenkinsci.test.acceptance.docker.Docker;
 import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
+import org.jenkinsci.test.acceptance.docker.DynamicDockerContainer;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -18,7 +20,7 @@ import java.io.IOException;
  * @author Tobias Meyer
  */
 @DockerFixture(id = "ftpd", ports = {21, 7050, 7051, 7052, 7053, 7054, 7055}, bindIp = "127.0.0.2")
-public class FtpdContainer extends DockerContainer implements IPasswordDockerContainer {
+public class FtpdContainer extends DynamicDockerContainer implements IPasswordDockerContainer {
     private FTPClient ftpClient;
 
     private final String username = "test";
@@ -58,7 +60,7 @@ public class FtpdContainer extends DockerContainer implements IPasswordDockerCon
      */
     public Boolean ftpConnect() {
         try {
-            ftpClient.connect(ipBound(21), port(21));
+            ftpClient.connect(getIpAddress(), port(21));
             ftpClient.enterLocalPassiveMode();
             ftpClient.setRemoteVerificationEnabled(false);
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer.java
@@ -3,8 +3,6 @@ package org.jenkinsci.test.acceptance.docker.fixtures;
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
-import org.jenkinsci.test.acceptance.docker.Docker;
-import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
 import org.jenkinsci.test.acceptance.docker.DynamicDockerContainer;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer.java
@@ -33,7 +33,7 @@ public class JiraContainer extends DockerContainer {
     private String token;
 
     public URL getURL() throws MalformedURLException {
-        return new URL("http://localhost:"+port(2990)+"/jira/");
+        return new URL("http://" + ipBound(2990) + ':' +port(2990)+"/jira/");
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer.java
@@ -14,7 +14,7 @@ import org.jenkinsci.test.acceptance.docker.DockerFixture;
 public class LdapContainer extends DockerContainer {
 
     public String getHost() {
-        return "127.0.0.1";
+        return ipBound(389);
     }
 
     public int getPort() {

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer.java
@@ -18,7 +18,7 @@ import static java.nio.file.attribute.PosixFilePermission.*;
  *
  * @author Kohsuke Kawaguchi
  */
-@DockerFixture(id = "sshd", ports = 22, bindIp = "127.0.0.5")
+@DockerFixture(id = "sshd", ports = 22)
 public class SshdContainer extends DockerContainer {
     private File privateKey;
     private File privateKeyEnc;

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.test.acceptance.docker.fixtures;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
 import org.jenkinsci.utils.process.CommandBuilder;
@@ -32,7 +33,9 @@ public class SshdContainer extends DockerContainer {
                 privateKey = File.createTempFile("ssh", "key");
                 privateKey.deleteOnExit();
                 FileUtils.copyURLToFile(resource("unsafe").url, privateKey);
-                Files.setPosixFilePermissions(privateKey.toPath(), EnumSet.of(OWNER_READ));
+                if (SystemUtils.IS_OS_UNIX) {
+                    Files.setPosixFilePermissions(privateKey.toPath(), EnumSet.of(OWNER_READ));
+                }
             } catch (IOException e) {
                 throw new RuntimeException("Not able to get the plaintext SSH key file. Missing file, wrong file permissions?!");
             }
@@ -49,7 +52,9 @@ public class SshdContainer extends DockerContainer {
                 privateKeyEnc = File.createTempFile("ssh_enc", "key");
                 privateKeyEnc.deleteOnExit();
                 FileUtils.copyURLToFile(resource("unsafe_enc_key").url, privateKeyEnc);
-                Files.setPosixFilePermissions(privateKeyEnc.toPath(), EnumSet.of(OWNER_READ));
+                if (SystemUtils.IS_OS_UNIX) {
+                    Files.setPosixFilePermissions(privateKeyEnc.toPath(), EnumSet.of(OWNER_READ));
+                }
             } catch (IOException e) {
                 throw new RuntimeException("Not able to get the encrypted SSH key file. Missing file, wrong file permissions?!");
             }

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SvnContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SvnContainer.java
@@ -44,7 +44,7 @@ public class SvnContainer extends DockerContainer {
      * @throws SubversionPluginTestException e
      */
     public URI getSvnUrl() throws SubversionPluginTestException {
-        String url = PROTOCOL_SVN + ipBound(80) + ':' + port(3690);
+        String url = PROTOCOL_SVN + ipBound(3690) + ':' + port(3690);
         return createUri(url);
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SvnContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SvnContainer.java
@@ -22,7 +22,6 @@ public class SvnContainer extends DockerContainer {
 
     private static final String PROTOCOL_HTTP = "http://";
     private static final String PROTOCOL_SVN = "svn://";
-    private static final String LOCALHOST = "localhost:";
     private static final String UNSAVE_REPO = "/svn";
     private static final String User_PWD_SAVE_REPO = "/svn_pwd";
     private static final String WEB_SVN = "/websvn/listing.php?repname=svn";
@@ -34,7 +33,7 @@ public class SvnContainer extends DockerContainer {
      * @throws SubversionPluginTestException e
      */
     public URL getHttpUrl() throws SubversionPluginTestException {
-        String url = PROTOCOL_HTTP + LOCALHOST + port(80);
+        String url = PROTOCOL_HTTP + ipBound(80) + ':' + port(80);
         return createUrl(url);
     }
 
@@ -45,7 +44,7 @@ public class SvnContainer extends DockerContainer {
      * @throws SubversionPluginTestException e
      */
     public URI getSvnUrl() throws SubversionPluginTestException {
-        String url = PROTOCOL_SVN + LOCALHOST + port(3690);
+        String url = PROTOCOL_SVN + ipBound(80) + ':' + port(3690);
         return createUri(url);
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/Native.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/Native.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.test.acceptance.junit;
 
+import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.utils.process.CommandBuilder;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.rules.TestRule;
@@ -46,8 +47,15 @@ public @interface Native {
                 private void verifyNativeCommandPresent(Native n) throws IOException, InterruptedException {
                     if (n==null)        return;
                     for (String cmd : n.value()) {
-                        if (new CommandBuilder("which",cmd).system()!=0) {
-                            throw new AssumptionViolatedException(cmd + " is needed for the test but doesn't exist in the system");
+                        if (SystemUtils.IS_OS_WINDOWS) {
+                            if (new CommandBuilder("where",cmd).system()!=0) {
+                                throw new AssumptionViolatedException(cmd + " is needed for the test but doesn't exist in the system");
+                            }
+                        }
+                        else {
+                            if (new CommandBuilder("which",cmd).system()!=0) {
+                                throw new AssumptionViolatedException(cmd + " is needed for the test but doesn't exist in the system");
+                            }
                         }
                     }
                 }

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/WithPlugins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/WithPlugins.java
@@ -22,12 +22,14 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
-
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Logger;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Indicates that a test requires the presence of the specified plugins.
@@ -91,6 +93,7 @@ public @interface WithPlugins {
                     restartRequired |= installPlugins(d.getTestClass().getAnnotation(WithPlugins.class), plugins);
                     LOGGER.info("for " + d + " asked to install " + plugins + "; restartRequired? " + restartRequired);
                     if (restartRequired) {
+                        assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
                         jenkins.restart();
                     }
                     for (String name : plugins) {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/BatchCommandBuildStep.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/BatchCommandBuildStep.java
@@ -1,0 +1,23 @@
+package org.jenkinsci.test.acceptance.po;
+
+import org.openqa.selenium.NoSuchElementException;
+
+/**
+ * BuildStep page object for a Windows Batch Command.
+ */
+@Describable("Execute Windows batch command")
+public class BatchCommandBuildStep extends AbstractStep implements BuildStep {
+
+    public BatchCommandBuildStep(Job parent, String path) {
+        super(parent, path);
+    }
+
+    public void command(String command) {
+        try {
+            control("command").set(command);
+        }
+        catch (NoSuchElementException e) {
+            new CodeMirror(this, "command").set(command);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/po/DumbSlave.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/DumbSlave.java
@@ -78,7 +78,7 @@ public class DumbSlave extends Slave {
                 }
             }
             else {
-                if (new CommandBuilder("powershell -command \"& { Invoke-WebRequest }\"").system() != 0) {
+                if (new CommandBuilder("powershell -command \"& { Invoke-WebRequest -?}\"").system() != 0) {
                     // Invoke-WebRequest was introduced in version 3.
                     throw new IllegalStateException("powershell version 3 or higher is required to run tests that run on local slaves.");
                 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
@@ -18,6 +18,7 @@ import com.google.inject.Injector;
 
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 /**
  * Top-level object that acts as an entry point to various systems.
@@ -113,6 +114,16 @@ public class Jenkins extends Node {
      */
     public PluginManager getPluginManager() {
         return new PluginManager(this);
+    }
+
+    /** 
+     * Some tests require they restart Jenkins - but depending on how the SUT is launched this is not always possible
+     * so tests that require this should wrap this call in an {@link org.junit.Assume#assumeTrue(String, boolean)}
+     * @return true if the Jenkins under test can restart itself.
+     */
+    public boolean canRestart() {
+        visit("restart");
+        return getElement(by.button("Yes")) != null;
     }
 
     public void restart() {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsConfig.java
@@ -72,4 +72,8 @@ public class JenkinsConfig extends PageObject {
     public void setJenkinsUrl(String url) {
         control("/jenkins-model-JenkinsLocationConfiguration/url").set(url);
     }
+    
+    public void setShell(String path) {
+        control("/hudson-tasks-Shell/shell").set(path);
+    }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -139,6 +139,12 @@ public class Job extends TopLevelItem {
         return step;
     }
 
+    public BatchCommandBuildStep addBatchStep(String batch) {
+        BatchCommandBuildStep step = addBuildStep(BatchCommandBuildStep.class);
+        step.command(batch);
+        return step;
+    }
+
     public <T extends BuildWrapper> T addBuildWrapper(Class<T> type) {
         ensureConfigPage();
         T wrapper = newInstance(type, this);

--- a/src/main/java/org/jenkinsci/test/acceptance/po/SlavesMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/SlavesMixIn.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.test.acceptance.po;
 
+import java.io.File;
+
 /**
  * Mix-in for slaves.
  *
@@ -42,13 +44,14 @@ public class SlavesMixIn extends MixIn {
     }
 
     private String remoteFs(String name) {
-        String base = "/tmp/";
+        String base = System.getProperty("java.io.tmpdir");
         if (System.getenv("SLAVE_FS_BASE") != null) {
             base = System.getenv("SLAVE_FS_BASE");
-            if (!base.endsWith("/")) {
-                base += "/";
-            }
         }
+        if (!(base.endsWith("\\") || base.endsWith("/"))) {
+            base += File.separatorChar;
+        }
+
         return base + name;
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/steps/PluginSteps.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/steps/PluginSteps.java
@@ -3,6 +3,8 @@ package org.jenkinsci.test.acceptance.steps;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 
+import static org.junit.Assume.assumeTrue;
+
 /**
  * @author Kohsuke Kawaguchi
  */
@@ -11,6 +13,7 @@ public class PluginSteps extends AbstractSteps {
     @Given("^I have installed the \"([^\"]*)\" plugin( from the update center)?$")
     public void I_have_installed_the_plugin(String name) throws Throwable {
         if (my.jenkins.getPluginManager().installPlugins(name)) {
+            assumeTrue("This test requires a restartable Jenkins", my.jenkins.canRestart());
             my.jenkins.restart();
         }
     }

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
@@ -20,6 +20,10 @@ RUN echo "rsa_cert_file=/etc/ssl/private/vsftpd.pem" >> /etc/myftp.conf
 RUN echo "pasv_enable=YES" >> /etc/myftp.conf
 RUN echo "pasv_min_port=7050" >> /etc/myftp.conf
 RUN echo "pasv_max_port=7055" >> /etc/myftp.conf
+# To enable passv mode through NAT (for remote docker) we need to set the 
+# passv_address to the address that docker will use to port forward
+RUN echo "pasv_address=@@DOCKER_HOST@@" >> /etc/myftpd.conf
+RUN echo "#James woz here" >> /etc/myftp.conf
 RUN mkdir -p /var/run/vsftpd/empty
 
 # create a test user

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
@@ -22,8 +22,8 @@ RUN echo "pasv_min_port=7050" >> /etc/myftp.conf
 RUN echo "pasv_max_port=7055" >> /etc/myftp.conf
 # To enable passv mode through NAT (for remote docker) we need to set the 
 # passv_address to the address that docker will use to port forward
-RUN echo "pasv_address=@@DOCKER_HOST@@" >> /etc/myftpd.conf
-RUN echo "#James woz here" >> /etc/myftp.conf
+# RUN echo "pasv_address=@@DOCKER_HOST@@" >> /etc/myftpd.conf
+# however DockerCOntainer has no way to specify the port offset so this will just not work..
 RUN mkdir -p /var/run/vsftpd/empty
 
 # create a test user

--- a/src/test/java/core/UninstallPluginTest.java
+++ b/src/test/java/core/UninstallPluginTest.java
@@ -31,6 +31,7 @@ import org.jenkinsci.test.acceptance.po.Slave;
 import org.jenkinsci.test.acceptance.slave.SlaveController;
 import org.junit.Test;
 import org.openqa.selenium.WebElement;
+
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assume.assumeTrue;
@@ -54,8 +55,7 @@ public class UninstallPluginTest extends AbstractJUnitTest {
         jenkins.getPluginManager().visit("installed");
         check(find(by.url("plugin/gerrit-trigger")), false);
         WebElement form = find(by.action("plugin/gerrit-trigger/uninstall"));
-        WebElement uninstall = form.findElement(by.input("Uninstall"));
-        uninstall.click();
+        form.submit();
         jenkins.restart();
         Slave s = slaves.install(jenkins).get();
         s.waitUntilOnline();

--- a/src/test/java/core/UninstallPluginTest.java
+++ b/src/test/java/core/UninstallPluginTest.java
@@ -33,6 +33,8 @@ import org.junit.Test;
 import org.openqa.selenium.WebElement;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assume.assumeTrue;
+
 /**
  * Feature: Uninstall plugin test
  * @author Orjan Percy <orjan.percy@sonymobile.com>
@@ -48,6 +50,7 @@ public class UninstallPluginTest extends AbstractJUnitTest {
      */
     @Test
     public void gerrit_uninstall_plugin() throws InterruptedException, ExecutionException {
+        assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         jenkins.getPluginManager().visit("installed");
         check(find(by.url("plugin/gerrit-trigger")), false);
         WebElement form = find(by.action("plugin/gerrit-trigger/uninstall"));

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/DynamicDockerContainerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/DynamicDockerContainerTest.java
@@ -1,0 +1,51 @@
+package org.jenkinsci.test.acceptance.docker;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.hamcrest.core.Is.is;
+
+/**
+ * Tests the 
+ * @author jnord
+ *
+ */
+public class DynamicDockerContainerTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+    
+    @Test
+    public void testFiltering() throws Exception {
+        String source = "# A dummy Dockerfile\n" + 
+                        "#\n" + 
+                        "\n" + 
+                        "FROM ubuntu\n" + 
+                        "\n" + 
+                        "# install SSHD\n" + 
+                        "RUN echo '@@DOCKER_HOST@@' >> /tmp/foo\n" + 
+                        "RUN echo $(date) >> /tmp/the_time\n"; 
+        String expected = "# A dummy Dockerfile\n" + 
+                          "#\n" + 
+                          "\n" + 
+                          "FROM ubuntu\n" + 
+                          "\n" + 
+                          "# install SSHD\n" + 
+                          "RUN echo '" + DockerImage.getDockerHost()+ "' >> /tmp/foo\n" + 
+                          "RUN echo $(date) >> /tmp/the_time\n";
+        File f = tmp.newFile();
+        FileUtils.write(f, source, StandardCharsets.UTF_8);
+        DynamicDockerContainer ddc = new DynamicDockerContainer();
+        ddc.process(f);
+        String actual = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
+        assertThat("File not transformed correctly", actual, is(expected));
+    }
+
+}

--- a/src/test/java/plugins/CIFSPublishPluginTest.java
+++ b/src/test/java/plugins/CIFSPublishPluginTest.java
@@ -41,7 +41,7 @@ public class CIFSPublishPluginTest extends GlobalPublishPluginTest<SMBContainer>
         CifsGlobalConfig.CifSite s = new CifsGlobalConfig(jenkins).addSite();
         {
             s.name.set(serverName);
-            s.hostname.set("localhost");
+            s.hostname.set(dock.ipBound(139));
             s.port.set(dock.port(139));
             if(dock instanceof IPasswordDockerContainer) {
                 s.username.set(((IPasswordDockerContainer)dock).getUsername());

--- a/src/test/java/plugins/CheckStylePluginTest.java
+++ b/src/test/java/plugins/CheckStylePluginTest.java
@@ -22,6 +22,7 @@ import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.ListView;
 import org.jenkinsci.test.acceptance.po.Node;
 import org.jenkinsci.test.acceptance.po.PageObject;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Issue;
@@ -31,6 +32,8 @@ import org.openqa.selenium.WebElement;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.jenkinsci.test.acceptance.Matchers.*;
+
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Acceptance tests for the CheckStyle plugin.
@@ -246,6 +249,7 @@ public class CheckStylePluginTest extends AbstractAnalysisTest<CheckStyleAction>
      */
     @Test @Issue("24940")
     public void should_report_new_and_fixed_warnings_in_consecutive_builds() {
+        assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         FreeStyleJob job = createFreeStyleJob();
         Build firstBuild = buildJobAndWait(job);
         editJob(FILE_FOR_2ND_RUN, false, job);

--- a/src/test/java/plugins/DeployPluginTest.java
+++ b/src/test/java/plugins/DeployPluginTest.java
@@ -1,15 +1,20 @@
 package plugins;
 
+import org.apache.commons.configuration.SystemConfiguration;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.test.acceptance.docker.DockerContainerHolder;
 import org.jenkinsci.test.acceptance.docker.fixtures.Tomcat7Container;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.jenkinsci.test.acceptance.junit.Native;
 import org.jenkinsci.test.acceptance.junit.WithDocker;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.deploy.DeployPublisher;
 import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+import org.jenkinsci.test.acceptance.po.JenkinsConfig;
 import org.jenkinsci.test.acceptance.po.ShellBuildStep;
+import org.jenkinsci.utils.process.CommandBuilder;
 import org.junit.Test;
 
 import javax.inject.Inject;
@@ -61,8 +66,19 @@ public class DeployPluginTest extends AbstractJUnitTest {
      * And docker tomcat7 fixture should show "Hello Jenkins" at "/test/"
      */
     @Test
-    public void deploy_sample_webapp_to_tomcat7() throws IOException {
-
+    @Native("bash")
+    public void deploy_sample_webapp_to_tomcat7() throws IOException, InterruptedException {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            // TODO move somewhere else...
+            String path = new CommandBuilder("where.exe", "bash.exe").popen().asText().trim();
+            // where will return all matches and we only want the first.
+            path = path.replaceAll("\r\n.*", "");
+            JenkinsConfig conf = jenkins.getConfigPage();
+            JenkinsConfig cp = jenkins.getConfigPage();
+            cp.configure();
+            cp.setShell(path);
+            cp.save();
+        }
         Tomcat7Container f = docker.get();
 
         FreeStyleJob j = jenkins.jobs.create();

--- a/src/test/java/plugins/FindBugsPluginTest.java
+++ b/src/test/java/plugins/FindBugsPluginTest.java
@@ -55,6 +55,8 @@ import org.xml.sax.SAXException;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.jenkinsci.test.acceptance.Matchers.*;
+import static org.junit.Assume.assumeTrue;
+
 
 /**
  * Acceptance tests for the FindBugs plugin.
@@ -216,6 +218,7 @@ public class FindBugsPluginTest extends AbstractAnalysisTest<FindBugsAction> {
      */
     @Test @Issue("24940")
     public void should_report_new_and_fixed_warnings_in_consecutive_builds() {
+        assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         FreeStyleJob job = createFreeStyleJob();
         Build firstBuild = buildJobAndWait(job);
         editJob("/findbugs_plugin/forSecondRun/findbugsXml.xml", false, job);

--- a/src/test/java/plugins/FtpPublishPluginTest.java
+++ b/src/test/java/plugins/FtpPublishPluginTest.java
@@ -1,8 +1,11 @@
 package plugins;
 
+import java.io.IOException;
+
 import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.fixtures.FtpdContainer;
 import org.jenkinsci.test.acceptance.docker.fixtures.IPasswordDockerContainer;
+import org.jenkinsci.test.acceptance.junit.WithDocker;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.publish_over.*;
 import org.jenkinsci.test.acceptance.plugins.publish_over.FtpGlobalConfig.FtpSite;
@@ -16,6 +19,7 @@ import org.jenkinsci.test.acceptance.po.FreeStyleJob;
  * @author Tobias Meyer
  */
 @WithPlugins("publish-over-ftp")
+@WithDocker(localOnly=true)
 public class FtpPublishPluginTest extends GlobalPublishPluginTest<FtpdContainer> {
 
     @Override
@@ -41,7 +45,14 @@ public class FtpPublishPluginTest extends GlobalPublishPluginTest<FtpdContainer>
         FtpSite s = new FtpGlobalConfig(jenkins).addSite();
         {
             s.name.set(serverName);
-            s.hostname.set(dock.ipBound(21));
+            try { 
+                //s.hostname.set(dock.getIpAddress());}
+                s.hostname.set(dock.ipBound(21));
+                if (false) throw new IOException("bogus");
+            }
+            catch (IOException ex) {
+                throw new AssertionError("Failed to obtain the docker containers IP address.", ex);
+            }
             s.port.set(dock.port(21));
             if(dock instanceof IPasswordDockerContainer) {
                 s.username.set(((IPasswordDockerContainer)dock).getUsername());

--- a/src/test/java/plugins/MailWatcherPluginTest.java
+++ b/src/test/java/plugins/MailWatcherPluginTest.java
@@ -38,6 +38,8 @@ import org.junit.Test;
 
 import com.google.inject.Inject;
 
+import static org.junit.Assume.assumeTrue;
+
 @WithPlugins("mail-watcher-plugin")
 public class MailWatcherPluginTest extends AbstractJUnitTest {
 
@@ -49,6 +51,7 @@ public class MailWatcherPluginTest extends AbstractJUnitTest {
 
     @Test
     public void notify_slave_on_restart() throws Exception {
+        assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         Future<Slave> futureSlave = slaveController.install(jenkins);
 
         mail.setup(jenkins);
@@ -70,6 +73,7 @@ public class MailWatcherPluginTest extends AbstractJUnitTest {
 
     @Test @Issue("JENKINS-20538") @Since("1.571") @WithPlugins("mail-watcher-plugin@1.7")
     public void notify_master_on_jenkins_restart() throws Exception {
+        assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         mail.setup(jenkins);
 
         jenkins.configure();

--- a/src/test/java/plugins/MavenPluginTest.java
+++ b/src/test/java/plugins/MavenPluginTest.java
@@ -136,7 +136,7 @@ public class MavenPluginTest extends AbstractJUnitTest {
         step.useLocalRepository();
         job.save();
 
-        job.startBuild().shouldSucceed().shouldContainsConsoleOutput("-Dmaven.repo.local=([^\\n]*)/.repository");
+        job.startBuild().shouldSucceed().shouldContainsConsoleOutput("-Dmaven.repo.local=([^\\n]*)[/\\\\].repository");
     }
 
     @Test

--- a/src/test/java/plugins/MavenPluginTest.java
+++ b/src/test/java/plugins/MavenPluginTest.java
@@ -120,7 +120,19 @@ public class MavenPluginTest extends AbstractJUnitTest {
 
     private String localMavenVersion() {
         final Pattern pattern = Pattern.compile("Apache Maven .*");
-        final Matcher matcher = pattern.matcher(jenkins.runScript("'mvn --version'.execute().text"));
+        String output = jenkins.runScript("try {\n"
+                                        + "  return 'mvn --version'.execute().text\n"
+                                        + "} catch (IOException ignored) {}\n"  
+                                        // mimic PATHEXT as BAT comes before CMD
+                                        + "try {\n"
+                                        + "  return 'mvn.bat --version'.execute().text\n"
+                                        + "} catch (IOException ignored) {}\n"
+                                        + "try {\n"
+                                        + "  return 'mvn.cmd --version'.execute().text\n"
+                                        + "} catch (IOException e) { throw e}\n"
+                                        );
+        System.out.println(output);
+        final Matcher matcher = pattern.matcher(output);
         matcher.find();
         return matcher.group(0);
     }

--- a/src/test/java/plugins/NodeLabelParameterPluginTest.java
+++ b/src/test/java/plugins/NodeLabelParameterPluginTest.java
@@ -2,6 +2,7 @@ package plugins;
 
 import com.google.inject.Inject;
 
+import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.test.acceptance.Matcher;
 import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
@@ -363,8 +364,12 @@ public class NodeLabelParameterPluginTest extends AbstractJUnitTest {
         p.runIfSuccess.check();
 
         //ensure the main build fails by using a shell exit command
-        j.addShellStep("exit 1");
-
+        if (SystemUtils.IS_OS_WINDOWS) {
+            j.addBatchStep("exit 1");
+        }
+        else {
+            j.addShellStep("exit 1");
+        }
         j.save();
 
         // select both slaves for this build

--- a/src/test/java/plugins/OpenstackCloudPluginTest.java
+++ b/src/test/java/plugins/OpenstackCloudPluginTest.java
@@ -57,6 +57,8 @@ import org.jvnet.hudson.test.Issue;
 
 import com.google.inject.Inject;
 
+import static org.junit.Assume.assumeTrue;
+
 @WithPlugins("openstack-cloud")
 @TestActivation({"ENDPOINT", "IDENTITY", "CREDENTIAL"})
 public class OpenstackCloudPluginTest extends AbstractJUnitTest {
@@ -206,6 +208,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
     @WithCredentials(credentialType = WithCredentials.USERNAME_PASSWORD, values = {MACHINE_USERNAME, "ath"})
     @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
     public void sshSlaveShouldSurviveRestart() {
+        assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         configureCloudInit("cloud-init");
         configureProvisioning("SSH", "label");
 

--- a/src/test/java/plugins/PmdPluginTest.java
+++ b/src/test/java/plugins/PmdPluginTest.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.WebElement;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.jenkinsci.test.acceptance.Matchers.*;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Acceptance tests for the PMD plugin.
@@ -228,6 +229,7 @@ public class PmdPluginTest extends AbstractAnalysisTest<PmdAction> {
      */
     @Test @Issue("24940")
     public void should_report_new_and_fixed_warnings_in_consecutive_builds() {
+        assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         FreeStyleJob job = createFreeStyleJob();
         Build firstBuild = buildJobAndWait(job);
         editJob(PLUGIN_ROOT + "forSecondRun/pmd-warnings.xml", false, job);

--- a/src/test/java/plugins/PrioritySorterPluginTest.java
+++ b/src/test/java/plugins/PrioritySorterPluginTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.jenkinsci.test.acceptance.po.Slave.runBuildsInOrder;
 
+import static org.junit.Assume.assumeTrue;
+
 /**
  * @author Kohsuke Kawaguchi
  */
@@ -34,6 +36,7 @@ public class PrioritySorterPluginTest extends AbstractJUnitTest {
 
     @Before
     public void setUp() throws Exception {
+        assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         jenkins.restart(); // Priority sorter plugin needs this
         slave = slaves.install(jenkins).get();
     }

--- a/src/test/java/plugins/WorkflowPluginTest.java
+++ b/src/test/java/plugins/WorkflowPluginTest.java
@@ -44,10 +44,13 @@ import org.jenkinsci.test.acceptance.po.DumbSlave;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
 import org.jenkinsci.test.acceptance.slave.SlaveController;
 import static org.junit.Assert.*;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
+
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Roughly follows <a href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md">the tutorial</a>.
@@ -69,6 +72,7 @@ public class WorkflowPluginTest extends AbstractJUnitTest {
 
     @WithPlugins({"workflow-aggregator@1.1", "junit@1.3", "git@2.3"})
     @Test public void linearFlow() throws Exception {
+        assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         MavenInstallation.installMaven(jenkins, "M3", "3.1.0");
         final DumbSlave slave = (DumbSlave) slaveController.install(jenkins).get();
         slave.configure(new Callable<Void>() {

--- a/src/test/resources/deploy_plugin/build-war.sh
+++ b/src/test/resources/deploy_plugin/build-war.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 [ -d my-webapp ] || mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-webapp -DarchetypeArtifactId=maven-archetype-webapp
 cd my-webapp
 mvn install


### PR DESCRIPTION
ATH was just so badly broken on windows :cry: 

[JENKINS-33520](https://issues.jenkins-ci.org/browse/JENKINS-33520)

I beleive I have fixed most of the issues.
There is an open issue of how to detect the OS if running Jenkins remotely (however the current situation assumes it is run on the same OS type with the same tools (@native looks on the system running the ATH not the Jenkins system) - so this is a longer issue - and would significantly add to the test run time for the case where the OS does not match) - so is considered out of scope.

Many tests are skipped as Jenkins will not restart itself when started locally on Windows.  LocalController could possibly be enhanced to do a "manual" restart by stopping Jenkins and then starting it again.

Current state: 

- [x] Maven seem like genuine test failures (Maven has not been correctly added to the path as it is trying to execute mvn.bat and failing) - ([JENKINS-33693](https://issues.jenkins-ci.org/browse/JENKINS-33693))
- [x] some tests are still trying to execute bash scripts on windows :-/
- [ ] ~~I seem to have broken docker portmap (Failed to figure out port map 80)~~ `-DreuseForks=false` fixes this.  Something to investigate later.
- [ ] Firefox driver is unreliable (upgraded driver but still has issues)
- [x] Incorrect assumptions Docker
- [x] Incorrect assumptions in Job page object
- [x] @Native should not require cygwin
- [x] CIFSPublishPluginTest
- [x] PublishOverSSHPluginTest
- [x] CompressArtifactsPluginTest
- [x] DeployPluginTest
- [x] JacocoPluginTest - (fixed by [JENKINS-33693](https://issues.jenkins-ci.org/browse/JENKINS-33693))
- [x] JavadocPluginTest (fixed by [JENKINS-33693](https://issues.jenkins-ci.org/browse/JENKINS-33693))
- [x] LdapPluginTest
- [x] MavenPluginTest
- [x] CopyArtifactPluginTest (fixed by [JENKINS-33693](https://issues.jenkins-ci.org/browse/JENKINS-33693))
- [ ] ~~NodeLabelParameterPluginTest~~  not an issue in windows - tests are genuinley failing on Linux too ([JENKINS-33746](https://issues.jenkins-ci.org/browse/JENKINS-33746)).
- [x] Subversion_Version154_PluginTest
- [x] TaskScannerPluginTest (fixed by [JENKINS-33693](https://issues.jenkins-ci.org/browse/JENKINS-33693))
- [x] JiraContainer was hard coded to localhost
- [x] [JENKINS-33693](https://issues.jenkins-ci.org/browse/JENKINS-33693) 
- [ ] Random test failures with Guice cleanup errors :cry:
jenkinsci/jenkins/pull/2148
```
java.lang.AssertionError: org.jenkinsci.test.acceptance.FallbackConfig$1@4393593c failed
        at org.jenkinsci.test.acceptance.guice.Cleaner.performCleanUp(Cleaner.java:56)
        at org.jenkinsci.test.acceptance.guice.TestCleaner.performCleanUp(TestCleaner.java:19)
        at org.jenkinsci.test.acceptance.guice.World.endTestScope(World.java:66)
        at org.jenkinsci.test.acceptance.junit.JenkinsAcceptanceTestRule$1.evaluate(JenkinsAcceptanceTestRule.java:72)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
Caused by: org.openqa.selenium.remote.UnreachableBrowserException: Error communicating with the remote browser. It may have died.
Build info: version: '2.52.0', revision: '4c2593cfc3689a7fcd7be52549167e5ccc93ad28', time: '2016-02-11 11:22:43'
System info: host: 'cb-james', ip: '192.168.137.1', os.name: 'Windows 10', os.arch: 'amd64', os.version: '10.0', java.version: '1.8.0_71'
Driver info: driver.version: EventFiringWebDriver
Capabilities [{applicationCacheEnabled=true, rotatable=false, handlesAlerts=true, databaseEnabled=true, version=45.0, platform=WINDOWS, nativeEvents=false, acceptSslCerts=true, webStorageEnabled=true, locationContextEnabled=true, browserName=firefox, takesScreenshot=true, javascriptEnabled=true, cssSelectorsEnabled=true}]
Session ID: 7d1711cd-d4c4-4130-bd75-94ac2b050851
        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:665)
        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:701)
        at org.openqa.selenium.remote.RemoteWebDriver.quit(RemoteWebDriver.java:526)
        at sun.reflect.GeneratedMethodAccessor23.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.openqa.selenium.support.events.EventFiringWebDriver$2.invoke(EventFiringWebDriver.java:103)
        at com.sun.proxy.$Proxy30.quit(Unknown Source)
        at org.openqa.selenium.support.events.EventFiringWebDriver.quit(EventFiringWebDriver.java:202)
        at org.jenkinsci.test.acceptance.FallbackConfig$1.evaluate(FallbackConfig.java:168)
        at org.jenkinsci.test.acceptance.guice.Cleaner.performCleanUp(Cleaner.java:54)
        at org.jenkinsci.test.acceptance.guice.TestCleaner.performCleanUp(TestCleaner.java:19)
        at org.jenkinsci.test.acceptance.guice.World.endTestScope(World.java:66)
        at org.jenkinsci.test.acceptance.junit.JenkinsAcceptanceTestRule$1.evaluate(JenkinsAcceptanceTestRule.java:72)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
Caused by: java.net.SocketException: Permission denied: connect
        at java.net.DualStackPlainSocketImpl.connect0(Native Method)
        at java.net.DualStackPlainSocketImpl.socketConnect(DualStackPlainSocketImpl.java:83)
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
        at java.net.PlainSocketImpl.connect(PlainSocketImpl.java:172)
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
        at java.net.Socket.connect(Socket.java:589)
        at org.apache.http.conn.socket.PlainConnectionSocketFactory.connectSocket(PlainConnectionSocketFactory.java:74)
        at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:134)
        at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:353)
        at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:380)
        at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)
        at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:184)
        at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:88)
        at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
        at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:71)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:55)
        at org.openqa.selenium.remote.internal.ApacheHttpClient.fallBackExecute(ApacheHttpClient.java:144)
        at org.openqa.selenium.remote.internal.ApacheHttpClient.execute(ApacheHttpClient.java:90)
        at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:142)
        at org.openqa.selenium.firefox.internal.NewProfileExtensionConnection.execute(NewProfileExtensionConnection.java:160)
        at org.openqa.selenium.firefox.FirefoxDriver$LazyCommandExecutor.execute(FirefoxDriver.java:380)
        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:644)
        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:701)
        at org.openqa.selenium.remote.RemoteWebDriver.quit(RemoteWebDriver.java:526)
        at sun.reflect.GeneratedMethodAccessor23.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.openqa.selenium.support.events.EventFiringWebDriver$2.invoke(EventFiringWebDriver.java:103)
        at com.sun.proxy.$Proxy30.quit(Unknown Source)
        at org.openqa.selenium.support.events.EventFiringWebDriver.quit(EventFiringWebDriver.java:202)
        at org.jenkinsci.test.acceptance.FallbackConfig$1.evaluate(FallbackConfig.java:168)
        at org.jenkinsci.test.acceptance.guice.Cleaner.performCleanUp(Cleaner.java:54)
        at org.jenkinsci.test.acceptance.guice.TestCleaner.performCleanUp(TestCleaner.java:19)
        at org.jenkinsci.test.acceptance.guice.World.endTestScope(World.java:66)
        at org.jenkinsci.test.acceptance.junit.JenkinsAcceptanceTestRule$1.evaluate(JenkinsAcceptanceTestRule.java:72)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
```