### PR TITLE
Upgrade to surefire 2.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -460,7 +460,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
+        <version>2.18</version>
         <configuration>
           <includes>
             <include>**/CucumberTests.java</include>


### PR DESCRIPTION
Needed to support -Dsurefire.rerunFailingTestsCount. Doesn't work in 2.17.
https://maven.apache.org/components/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html

@reviewbybees 