### PR TITLE
More Jenkins 2.0 test fixes

### DIFF
--- a/src/main/groovy/org/jenkinsci/test/acceptance/po/users/AddUserPage.groovy
+++ b/src/main/groovy/org/jenkinsci/test/acceptance/po/users/AddUserPage.groovy
@@ -11,7 +11,7 @@ import org.kohsuke.randname.RandomNameGenerator
 class AddUserPage extends Page {
 
     static url = "securityRealm/addUser"
-    static at = { title == "Sign up [Jenkins]" }
+    static at = { title == "Create User [Jenkins]" }
     static content = {
         username { $("input[path='/username']") }
         password { $("input[path='/password1']") }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -76,7 +76,6 @@ public class JobsMixIn extends MixIn {
     public void copy(String from, String to) {
         visit("newJob");
         fillIn("name",to);
-        check(find(by.radioButton("copy")));
         fillIn("from",from);
         clickButton("OK");
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Slave.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Slave.java
@@ -142,7 +142,7 @@ public class Slave extends Node {
     public void launchSlaveAgent() {
         if (isOffline()) {
             open();
-            clickButton("Launch slave agent");
+            clickButton("Launch agent");
         }
     }
 }

--- a/src/test/java/plugins/OwnershipPluginTest.java
+++ b/src/test/java/plugins/OwnershipPluginTest.java
@@ -69,6 +69,7 @@ public class OwnershipPluginTest extends AbstractJUnitTest {
         FreeStyleJob job = jenkins.jobs.create();
         job.save();
 
+        elasticSleep(1000);
         assertThat(job, ownedBy(user));
     }
 


### PR DESCRIPTION
Attn @olivergondza 

The only test failure difference from my initial run against master is `SubversionPluginTest.clean_checkout:199`:

```
 SubversionPluginTest.clean_checkout:199 
Expected: Build result SUCCESS
     but: was FAILURE. Console output:
Started by user anonymous
Building in workspace /home/tfennelly/projects/acceptance-test-harness/target/jenkins8920358853420174796home/jobs/convenient_advertising/workspace
Cleaning up /home/tfennelly/projects/acceptance-test-harness/target/jenkins8920358853420174796home/jobs/convenient_advertising/workspace/.
Deleting /home/tfennelly/projects/acceptance-test-harness/target/jenkins8920358853420174796home/jobs/convenient_advertising/workspace/unversioned.txt
Updating http://127.0.0.1:32883/svn at revision '2016-04-01T20:13:53.243 +0100'
At revision 2

No changes for http://127.0.0.1:32883/svn since the previous build
[workspace] $ /bin/sh -xe /tmp/hudson3162125481586565868.sh
+ echo test
[workspace] $ /bin/sh -xe /tmp/hudson8389200259849604126.sh
+ test -f unversioned.txt
Build step 'Execute shell' marked build as failure
Finished: FAILURE
```

The `test` command is failing. Where's the bang gone when executing?