### PR TITLE
Fix ATH broken build after PR#83 merged

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/msbuild/MSBuildInstallation.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/msbuild/MSBuildInstallation.java
@@ -1,13 +1,13 @@
 package org.jenkinsci.test.acceptance.msbuild;
 
-import org.jenkinsci.test.acceptance.po.JenkinsConfig;
+import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.po.ToolInstallation;
 import org.jenkinsci.test.acceptance.po.ToolInstallationPageObject;
 
 @ToolInstallationPageObject(installer = "", name = "MSBuild")
 public class MSBuildInstallation extends ToolInstallation  {
 
-    public MSBuildInstallation(JenkinsConfig context, String path) {
+    public MSBuildInstallation(Jenkins context, String path) {
         super(context, path);
     }
 


### PR DESCRIPTION
Follow up on #83,  review completed 12 days ago. Merged today.

#89  merged 11 days ago, included a modification in the constructor of `ToolInstallation` from which `MSBuildInstallation` extends. 

Today #83 has been merged and build failed because the constructor that existed when the PR was under discussion has been modified. This PR fixes the issue.

@reviewbybees 