### PR TITLE
apt-get update alone can lead to Docker caching the results.

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/ArtifactoryContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/ArtifactoryContainer/Dockerfile
@@ -2,9 +2,8 @@ FROM codingtony/java
 
 MAINTAINER tony.bussieres@ticksmith.com
 
-RUN apt-get update
+RUN apt-get update && apt-get install -y unzip
 RUN apt-get upgrade -y
-RUN apt-get install unzip -y
 RUN wget --content-disposition http://dl.bintray.com/jfrog/artifactory/artifactory-3.4.0.zip
 RUN cd /opt && unzip ~/artifactory-3.4.0.zip
 RUN mv /opt/artifactory-3.4.0 /opt/artifactory

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
@@ -5,8 +5,7 @@
 FROM ubuntu
 
 # install FTP
-RUN apt-get update
-RUN apt-get install -y vsftpd
+RUN apt-get update && apt-get install -y vsftpd
 RUN echo "local_enable=YES" >> /etc/myftp.conf
 RUN echo "write_enable=YES" >> /etc/myftp.conf
 RUN echo "listen=YES" >> /etc/myftp.conf

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/Dockerfile
@@ -7,10 +7,9 @@ FROM ubuntu
 
 # make sure the package repository is up to date
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
-RUN apt-get update
-
 # install SSHD
-RUN apt-get install -y openssh-server
+RUN apt-get update && apt-get install -y openssh-server
+
 RUN mkdir -p /var/run/sshd
 
 # install git

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JabberContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JabberContainer/Dockerfile
@@ -6,11 +6,9 @@ FROM ubuntu:latest
 
 # Needed for supervisord
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get upgrade -y
-
 # install prosody
-RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y prosody
+RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y prosody
+RUN apt-get upgrade -y
 
 # configure prosody
 RUN sed -i -e 's/admins = { }/admins = { "admin@localhost" }/g' /etc/prosody/prosody.cfg.lua

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
@@ -4,8 +4,7 @@
 
 # TODO have to inline SshdContainer/Dockerfile since 'FROM jenkins/sshd' does not work: jenkins/sshd is not pushed to the Docker registry, so we cannot build against it
 FROM ubuntu
-RUN apt-get update
-RUN apt-get install -y openssh-server
+RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir -p /var/run/sshd
 RUN useradd test -d /home/test && \
     mkdir -p /home/test/.ssh && \

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer/Dockerfile
@@ -6,8 +6,7 @@
 FROM ubuntu
 
 # base package installation
-RUN apt-get update -y
-RUN apt-get install -y apt-transport-https && echo "deb https://sdkrepo.atlassian.com/debian/ stable contrib" >> /etc/apt/sources.list && apt-get update
+RUN apt-get update -y && apt-get install -y apt-transport-https && echo "deb https://sdkrepo.atlassian.com/debian/ stable contrib" >> /etc/apt/sources.list && apt-get update
 RUN apt-get install -y --allow-unauthenticated openjdk-6-jdk atlassian-plugin-sdk netcat
 
 # this will install the whole thing, launches Tomcat,

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer/Dockerfile
@@ -18,10 +18,8 @@ CMD ["/sbin/my_init"]
 
 # Configure apt
 RUN echo 'deb http://us.archive.ubuntu.com/ubuntu/ precise universe' >> /etc/apt/sources.list
-RUN apt-get -y update
-
 # Install slapd
-RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y slapd
+RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get -y update && apt-get install -y slapd
 
 # Default configuration: can be overridden at the docker command line
 ENV LDAP_ROOTPASS jenkins

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SMBContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SMBContainer/Dockerfile
@@ -5,14 +5,12 @@
 FROM ubuntu
 
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
-RUN apt-get update
+RUN apt-get update && apt-get -y install samba
 
 RUN useradd test -d /home/test -s /bin/bash && \
         mkdir -p /home/test && \
         chown test /home/test && \
         echo "test:test" | chpasswd
-
-RUN apt-get install -y samba
 
 RUN echo "workgroup = WORKGROUP" >> /etc/mysmb.conf
 RUN echo "restrict anonymous = no" >> /etc/mysmb.conf

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer/Dockerfile
@@ -5,8 +5,7 @@
 FROM ubuntu
 
 # install SSHD
-RUN apt-get update
-RUN apt-get install -y openssh-server
+RUN apt-get update -y && apt-get install -y openssh-server
 RUN mkdir -p /var/run/sshd
 
 # create a test user

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SvnContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SvnContainer/Dockerfile
@@ -1,9 +1,8 @@
 # Sets up
 FROM ubuntu:precise
-RUN apt-get update
+RUN apt-get update && apt-get install -y wget
 
 # Install Subversion 1.8 and Apache
-RUN apt-get install -y wget
 RUN echo 'deb http://archive.ubuntu.com/ubuntu precise main universe' >> /etc/apt/sources.list
 RUN sh -c 'echo "deb http://opensource.wandisco.com/ubuntu precise svn18" >> /etc/apt/sources.list.d/WANdisco.list'
 RUN wget -q http://opensource.wandisco.com/wandisco-debian.gpg -O- | apt-key add -

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/Tomcat7Container/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/Tomcat7Container/Dockerfile
@@ -8,8 +8,7 @@ FROM ubuntu
 
 # Tomcat7 is from Universe
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise universe" >> /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get install -y tomcat7 tomcat7-admin
+RUN apt-get update && apt-get install -y tomcat7 tomcat7-admin
 
 # configure the admin user
 RUN echo '<tomcat-users><role rolename="tomcat"/><role rolename="manager-gui"/><role rolename="admin-gui"/><role rolename="manager-script"/><user username="admin" password="tomcat" roles="tomcat,admin-gui,manager-gui,manager-script"/></tomcat-users>' > /etc/tomcat7/tomcat-users.xml


### PR DESCRIPTION
Run another command on the same line to make sure that doesn't happen.

We're hitting this on an internal test run where there's a stale apt cache on an image and this is the best workaround I can find.

See https://github.com/docker/docker/issues/3313 

cc @reviewbybees