### PR TITLE
PageArea/PageObjects for plain-credentials and credentials-binding

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/FileCredentials.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/FileCredentials.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.test.acceptance.plugins.credentials;
+
+import org.jenkinsci.test.acceptance.plugins.credentials.BaseStandardCredentials;
+import org.jenkinsci.test.acceptance.po.Control;
+import org.jenkinsci.test.acceptance.po.Describable;
+import org.jenkinsci.test.acceptance.po.PageAreaImpl;
+import org.jenkinsci.test.acceptance.po.PageObject;
+
+@Describable("Secret file")
+public class FileCredentials extends BaseStandardCredentials {
+
+    public Control file = control("file");
+    
+    public FileCredentials(PageObject context, String path) {
+        super(context, path);
+    }
+
+    public FileCredentials(PageAreaImpl area, String relativePath) {
+        super(area, relativePath);
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/StringCredentials.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/StringCredentials.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.test.acceptance.plugins.credentials;
+
+import org.jenkinsci.test.acceptance.plugins.credentials.BaseStandardCredentials;
+import org.jenkinsci.test.acceptance.po.Control;
+import org.jenkinsci.test.acceptance.po.Describable;
+import org.jenkinsci.test.acceptance.po.PageAreaImpl;
+import org.jenkinsci.test.acceptance.po.PageObject;
+
+@Describable("Secret text")
+public class StringCredentials extends BaseStandardCredentials {
+
+    public Control secret = control("secret");
+    
+    public StringCredentials(PageObject context, String path) {
+        super(context, path);
+    }
+    
+    public StringCredentials(PageAreaImpl area, String relativePath) {
+        super(area, relativePath);
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/CredentialsBinding.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/CredentialsBinding.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.test.acceptance.plugins.credentialsbinding;
+
+import org.jenkinsci.test.acceptance.po.ContainerPageObject;
+import org.jenkinsci.test.acceptance.po.Control;
+import org.jenkinsci.test.acceptance.po.PageArea;
+import org.jenkinsci.test.acceptance.po.PageAreaImpl;
+
+/**
+ * Represents a credential binding in the job configuration page.
+ */
+public class CredentialsBinding extends PageAreaImpl {
+
+    public Control credentialId = control("credentialId");
+    public Control variable = control("variable");
+    
+    public CredentialsBinding(PageArea area, String path) {
+        super(area, path);
+    }
+    
+    public CredentialsBinding(ContainerPageObject po, String path) {
+        super(po, path);
+    }
+    
+    /**
+     * Checks whether there are credentials in the credentials drop down
+     * 
+     * @return true if there are no credentials, false otherwise
+     */
+    public boolean noCredentials() {
+        return getElement(by.tagName("options")) == null;
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/CredentialsBinding.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/CredentialsBinding.java
@@ -4,6 +4,7 @@ import org.jenkinsci.test.acceptance.po.ContainerPageObject;
 import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.PageArea;
 import org.jenkinsci.test.acceptance.po.PageAreaImpl;
+import org.openqa.selenium.NoSuchElementException;
 
 /**
  * Represents a credential binding in the job configuration page.
@@ -27,6 +28,11 @@ public class CredentialsBinding extends PageAreaImpl {
      * @return true if there are no credentials, false otherwise
      */
     public boolean noCredentials() {
-        return getElement(by.tagName("options")) == null;
+        try {
+            credentialId.resolve().findElement(by.tagName("option"));
+            return false;
+        } catch (NoSuchElementException ex){
+            return true;
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/ManagedCredentialsBinding.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/ManagedCredentialsBinding.java
@@ -1,0 +1,26 @@
+package org.jenkinsci.test.acceptance.plugins.credentialsbinding;
+
+import org.jenkinsci.test.acceptance.po.ContainerPageObject;
+import org.openqa.selenium.WebElement;
+
+public class ManagedCredentialsBinding extends ContainerPageObject {
+
+    public ManagedCredentialsBinding(ContainerPageObject po) {
+        super(po, po.url("configure/"));
+    }
+    
+    /**
+     * Adds a credential binding of the type passed as parameter
+     * 
+     * @param type
+     * @return
+     */
+    public <T extends CredentialsBinding> T addCredentialBinding(Class<T> type) {
+        control(by.path("/org-jenkinsci-plugins-credentialsbinding-impl-SecretBuildWrapper/hetero-list-add[bindings]")).selectDropdownMenu(type);
+        elasticSleep(1000); // it takes some time until the element is visible
+        WebElement last = last(by.xpath("//div[@name='bindings']"));
+        String path = last.getAttribute("path");
+
+        return newInstance(type, this, path);
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/SecretFileCredentialsBinding.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/SecretFileCredentialsBinding.java
@@ -1,0 +1,12 @@
+package org.jenkinsci.test.acceptance.plugins.credentialsbinding;
+
+import org.jenkinsci.test.acceptance.po.ContainerPageObject;
+import org.jenkinsci.test.acceptance.po.Describable;
+
+@Describable("Secret file")
+public class SecretFileCredentialsBinding extends CredentialsBinding {
+
+    public SecretFileCredentialsBinding(ContainerPageObject po, String path) {
+        super(po, path);
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/SecretStringCredentialsBinding.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/SecretStringCredentialsBinding.java
@@ -1,0 +1,12 @@
+package org.jenkinsci.test.acceptance.plugins.credentialsbinding;
+
+import org.jenkinsci.test.acceptance.po.ContainerPageObject;
+import org.jenkinsci.test.acceptance.po.Describable;
+
+@Describable("Secret text")
+public class SecretStringCredentialsBinding extends CredentialsBinding {
+
+    public SecretStringCredentialsBinding(ContainerPageObject po, String path) {
+        super(po, path);
+    }
+}


### PR DESCRIPTION
`PageArea`s and `PageObject`s for `plain-credentials` and `credentials-binding` plugins so that acceptance tests can be written for them.

@reviewbybees 