### PR TITLE
Add delay in clicking button for Delete View

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/View.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/View.java
@@ -50,6 +50,7 @@ public abstract class View extends ContainerPageObject {
     public void delete() {
         configure();
         clickLink("Delete View");
+        elasticSleep(1000);
         clickButton("Yes");
     }
 


### PR DESCRIPTION
We have had random failures relating to deleting a view.
Seems like a timing issue, so added an elasticSleep