### PR TITLE
[JENKINS-35275] Don't force unneccessary dependencies to get upgraded in ATH

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -154,7 +154,7 @@ public class PluginManager extends ContainerPageObject {
             if (!someChangeRequired) {
                 return false;
             }
-            List<PluginMetadata> pluginToBeInstalled = ucmd.get().transitiveDependenciesOf(jenkins.getVersion(), candidates);
+            List<PluginMetadata> pluginToBeInstalled = ucmd.get().transitiveDependenciesOf(jenkins, candidates);
             for (PluginMetadata newPlugin : pluginToBeInstalled) {
                 final String name = newPlugin.getName();
                 String claimedVersion = candidates.get(name);


### PR DESCRIPTION
[JENKINS-35275](https://issues.jenkins-ci.org/browse/JENKINS-35275)

The proposed fix tries to make the ATH upgrade policy the same as the one in real Jenkins. See ticket for better explanation.

@olivergondza your input here would be much appreciated. Thanks.

@reviewbybees 