### PR TITLE
[FIXED JENKINS-35307] Explicit selection of copy radio button needed.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -77,6 +77,7 @@ public class JobsMixIn extends MixIn {
         visit("newJob");
         fillIn("name",to);
         fillIn("from",from);
+        choose("copy");
         clickButton("OK");
     }
 }


### PR DESCRIPTION
[JENKINS-35307](https://issues.jenkins-ci.org/browse/JENKINS-35307)

Note - still fails on 2.x due to the more general ATH job creation problems, but fixed on 1.651.2.

cc @reviewbybees 