### PR TITLE
[JENKINS-35134] Ensure no focus lib is used for Firefox.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -90,6 +90,8 @@ public class FallbackConfig extends AbstractModule {
         switch (browser) {
         case "firefox":
             FirefoxProfile profile = new FirefoxProfile();
+            profile.setAlwaysLoadNoFocusLib(true);
+
             profile.setPreference(LANGUAGE_SELECTOR, "en");
 
             return new FirefoxDriver(profile);


### PR DESCRIPTION
Fixes a ton of job creation failures on Linux - doesn't make a
difference on OS X, and there are still a number of failures mentioned
in the JIRA that are credentials-related, but this is real progress.

cc @reviewbybees @recena @uhafner @olivergondza 