### PR TITLE
[FIXED JENKINS-35334] Decorators should be cleaned up in reverse order.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/guice/Cleaner.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/guice/Cleaner.java
@@ -3,8 +3,8 @@ package org.jenkinsci.test.acceptance.guice;
 import org.junit.runners.model.Statement;
 
 import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.concurrent.Callable;
 
 /**
@@ -16,10 +16,10 @@ import java.util.concurrent.Callable;
  * @author Kohsuke Kawaguchi
  */
 public class Cleaner {
-    private final List<Statement> tasks = new ArrayList<>();
+    private final Deque<Statement> tasks = new ArrayDeque<>();
 
     public void addTask(Statement stmt) {
-        tasks.add(stmt);
+        tasks.push(stmt);
     }
 
     public void addTask(final Runnable r) {


### PR DESCRIPTION
For instance, you could have some clean up relying on the WebDriver
which is initialized before. It should be cleaned up after.

https://issues.jenkins-ci.org/browse/JENKINS-35334

@reviewbybees 