### PR TITLE
Put Docker logs in diagnostics dir

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneDockerController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneDockerController.java
@@ -62,7 +62,7 @@ public class WinstoneDockerController extends LocalController {
             else
                 img = docker.build(fixtureType);
 
-            container = img.start(fixtureType, opts, null);
+            container = img.start(fixtureType).withOptions(opts).start();
 
             CommandBuilder cmds = new CommandBuilder();
             cmds.add("java");

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -91,15 +91,22 @@ public class Docker {
             return new DockerImage(full);
         }
 
-        ProcessBuilder buildCmd = cmd("build").add("-t", full, dir).build();
+        CommandBuilder buildCmd = cmd("build").add("-t", full, dir);
+        ProcessBuilder processBuilder = buildCmd.build();
         if (log != null) {
-            buildCmd.redirectError(log).redirectOutput(log);
+            processBuilder.redirectError(log).redirectOutput(log);
         } else {
-            buildCmd.redirectError(ProcessBuilder.Redirect.INHERIT).redirectOutput(ProcessBuilder.Redirect.INHERIT);
+            processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT).redirectOutput(ProcessBuilder.Redirect.INHERIT);
         }
 
-        if (buildCmd.start().waitFor() != 0) {
-            throw new Error("Failed to start image: " + tag);
+        StringBuilder sb = new StringBuilder("Building Docker image `").append(buildCmd.toString()).append("`");
+        if (log != null) {
+            sb.append(": logfile is at ").append(log);
+        }
+        System.out.println(sb.toString());
+
+        if (processBuilder.start().waitFor() != 0) {
+            throw new Error("Failed to build image: " + tag);
         }
         return new DockerImage(full);
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -7,6 +7,7 @@ import org.jenkinsci.test.acceptance.utils.SHA1Sum;
 import org.jenkinsci.utils.process.CommandBuilder;
 import org.jvnet.hudson.annotation_indexer.Index;
 
+import javax.annotation.CheckForNull;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.File;
@@ -41,18 +42,6 @@ public class Docker {
 
     private static List<String> dockerCmd;// = Arrays.asList("docker");
 
-    /**
-     * Injecting a portOffset will force the binding of dockerPorts to local Ports with an offset
-     * (e.g. bind docker 22 to localhost port 40022,
-     */
-    @Inject(optional = true)
-    @Named("dockerPortOffset")
-    private static int portOffset = 0;
-
-    public int getPortOffset() {
-        return portOffset;
-    }
-
     @Inject(optional = true)
     public ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
@@ -82,6 +71,17 @@ public class Docker {
      * @param dir   Directory that contains Dockerfile
      */
     public DockerImage build(String image, File dir) throws IOException, InterruptedException {
+        return build(image, dir, null);
+    }
+
+    /**
+     * Builds a docker image.
+     *
+     * @param image Name of the image to be built.
+     * @param dir   Directory that contains Dockerfile
+     * @param log   Log file to store image building output
+     */
+    public DockerImage build(String image, File dir, @CheckForNull File log) throws IOException, InterruptedException {
         // compute tag from the content of Dockerfile
         String tag = getDockerFileHash(dir);
         String full = image + ":" + tag;
@@ -91,13 +91,24 @@ public class Docker {
             return new DockerImage(full);
         }
 
-        if (cmd("build").add("-t", full, dir).system() != 0) {
-            throw new Error("Failed to build image: " + tag);
+        ProcessBuilder buildCmd = cmd("build").add("-t", full, dir).build();
+        if (log != null) {
+            buildCmd.redirectError(log).redirectOutput(log);
+        } else {
+            buildCmd.redirectError(ProcessBuilder.Redirect.INHERIT).redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        }
+
+        if (buildCmd.start().waitFor() != 0) {
+            throw new Error("Failed to start image: " + tag);
         }
         return new DockerImage(full);
     }
 
     public DockerImage build(Class<? extends DockerContainer> fixture) throws IOException, InterruptedException {
+        return build(fixture, null);
+    }
+
+    public DockerImage build(Class<? extends DockerContainer> fixture, File log) throws IOException, InterruptedException {
         if (fixture.getSuperclass() != DockerContainer.class && fixture.getSuperclass() != DynamicDockerContainer.class) {
             build((Class) fixture.getSuperclass()); // build the base image first
         }
@@ -113,7 +124,7 @@ public class Docker {
             dir.mkdirs();
             try {
                 copyDockerfileDirectory(fixture, f, dir);
-                return build("jenkins/" + f.id(), dir);
+                return build("jenkins/" + f.id(), dir, log);
             } finally {
                 FileUtils.deleteDirectory(dir);
             }
@@ -210,27 +221,6 @@ public class Docker {
         File dockerFile = new File(dockerFileDir, "Dockerfile");
         SHA1Sum dockerFileHash = new SHA1Sum(dockerFile);
         return dockerFileHash.getSha1String().substring(0, 12);
-    }
-
-    /**
-     * Starts a container of the specific fixture type.
-     * This builds an image if need be.
-     *
-     * @see DockerContainerHolder
-     */
-    /*package*/ <T extends DockerContainer> T start(Class<T> fixture, CommandBuilder options, CommandBuilder cmd) {
-        try {
-            return build(fixture).start(fixture, options, cmd, portOffset);
-        } catch (InterruptedException | IOException e) {
-            throw new AssertionError("Failed to start container " + fixture.getName(), e);
-        }
-    }
-
-    /**
-     * @see DockerContainerHolder
-     */
-    /*package*/ <T extends DockerContainer> T start(Class<T> fixture) {
-        return start(fixture, null, null);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
@@ -5,6 +5,7 @@ import com.google.inject.TypeLiteral;
 import org.jenkinsci.test.acceptance.guice.AutoCleaned;
 import org.jenkinsci.test.acceptance.guice.TestCleaner;
 import org.jenkinsci.test.acceptance.guice.TestScope;
+import org.jenkinsci.test.acceptance.junit.FailureDiagnostics;
 
 import javax.inject.Provider;
 import java.io.IOException;
@@ -21,6 +22,9 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
 
     @Inject
     Docker docker;
+
+    @Inject
+    private FailureDiagnostics diag;
 
     T container;
 
@@ -41,6 +45,7 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
     public void close() throws IOException {
         if (container!=null) {
             container.close();
+            diag.archvie("docker-" + container.getClass().getSimpleName() + ".log", container.getLogfile());
             container = null;
         }
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
@@ -45,11 +45,11 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
     public synchronized T get() {
         if (container==null) {
             Class<T> fixture = (Class<T>) type.getRawType();
-            File buildlog = diag.touch("docker-" + fixture.getSimpleName() + ".start.log");
+            File buildlog = diag.touch("docker-" + fixture.getSimpleName() + ".build.log");
             File runlog = diag.touch("docker-" + fixture.getSimpleName() + ".run.log");
             try {
                 System.out.println("Setting up docker container for " + fixture.getSimpleName());
-                container = docker.build(fixture, buildlog).start(fixture).withPortOffset(portOffset).start();
+                container = docker.build(fixture, buildlog).start(fixture).withPortOffset(portOffset).withLog(runlog).start();
             } catch (InterruptedException | IOException e) {
                 throw new AssertionError("Failed to start container " + fixture.getName(), e);
             }
@@ -64,7 +64,6 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
     public void close() throws IOException {
         if (container!=null) {
             container.close();
-            diag.archvie("docker-" + container.getClass().getSimpleName() + ".log", container.getLogfile());
             container = null;
         }
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
@@ -7,7 +7,9 @@ import org.jenkinsci.test.acceptance.guice.TestCleaner;
 import org.jenkinsci.test.acceptance.guice.TestScope;
 import org.jenkinsci.test.acceptance.junit.FailureDiagnostics;
 
+import javax.inject.Named;
 import javax.inject.Provider;
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -29,12 +31,29 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
     T container;
 
     /**
+     * Injecting a portOffset will force the binding of dockerPorts to local Ports with an offset
+     * (e.g. bind docker 22 to localhost port 40022,
+     */
+    @Inject(optional = true)
+    @Named("dockerPortOffset")
+    private int portOffset = 0;
+
+    /**
      * Lazily starts a container and returns the instance.
      */
     @Override
     public synchronized T get() {
-        if (container==null)
-            container = docker.start((Class<T>)type.getRawType());
+        if (container==null) {
+            Class<T> fixture = (Class<T>) type.getRawType();
+            File buildlog = diag.touch("docker-" + fixture.getSimpleName() + ".start.log");
+            File runlog = diag.touch("docker-" + fixture.getSimpleName() + ".run.log");
+            try {
+                System.out.println("Setting up docker container for " + fixture.getSimpleName());
+                container = docker.build(fixture, buildlog).start(fixture).withPortOffset(portOffset).start();
+            } catch (InterruptedException | IOException e) {
+                throw new AssertionError("Failed to start container " + fixture.getName(), e);
+            }
+        }
         return container;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
@@ -48,7 +48,6 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
             File buildlog = diag.touch("docker-" + fixture.getSimpleName() + ".build.log");
             File runlog = diag.touch("docker-" + fixture.getSimpleName() + ".run.log");
             try {
-                System.out.println("Setting up docker container for " + fixture.getSimpleName());
                 container = docker.build(fixture, buildlog).start(fixture).withPortOffset(portOffset).withLog(runlog).start();
             } catch (InterruptedException | IOException e) {
                 throw new AssertionError("Failed to start container " + fixture.getName(), e);

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
@@ -50,7 +50,7 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
             try {
                 container = docker.build(fixture, buildlog).start(fixture).withPortOffset(portOffset).withLog(runlog).start();
             } catch (InterruptedException | IOException e) {
-                throw new AssertionError("Failed to start container " + fixture.getName(), e);
+                throw new Error("Failed to start container " + fixture.getName(), e);
             }
         }
         return container;

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -111,7 +111,7 @@ public class DockerImage {
             t.init(cid, p, logfile);
             return t;
         } catch (ReflectiveOperationException e) {
-            throw new AssertionError(e);
+            throw new Error(e);
         }
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -57,6 +57,7 @@ public class DockerImage {
         CommandBuilder docker = Docker.cmd("run");
         File cidFile = File.createTempFile("docker", "cid");
         cidFile.delete();
+        cidFile.deleteOnExit();
         docker.add("--cidfile="+cidFile);//strange behaviour in some docker version cidfile needs to come before
 
         for (int p : ports)

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/FailureDiagnostics.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/FailureDiagnostics.java
@@ -76,17 +76,6 @@ public class FailureDiagnostics extends TestWatcher {
         }
     }
 
-    /**
-     * Copy existing file to diagnostics directory.
-     */
-    public void archvie(String targetFilename, File source) {
-        try {
-            Files.copy(source, touch(targetFilename));
-        } catch (IOException e) {
-            new Error(e);
-        }
-    }
-
     @Override
     protected void succeeded(Description description) {
         // Delete the directory if no diagnostics information written

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/FailureDiagnostics.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/FailureDiagnostics.java
@@ -3,6 +3,8 @@ package org.jenkinsci.test.acceptance.junit;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+
+import com.google.common.io.Files;
 import org.codehaus.plexus.util.FileUtils;
 import org.jenkinsci.test.acceptance.guice.TestName;
 import org.jenkinsci.test.acceptance.guice.TestScope;
@@ -69,6 +71,17 @@ public class FailureDiagnostics extends TestWatcher {
             } finally {
                 if (writer != null) writer.close();
             }
+        } catch (IOException e) {
+            new Error(e);
+        }
+    }
+
+    /**
+     * Copy existing file to diagnostics directory.
+     */
+    public void archvie(String targetFilename, File source) {
+        try {
+            Files.copy(source, touch(targetFilename));
         } catch (IOException e) {
             new Error(e);
         }

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SMBContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SMBContainer/Dockerfile
@@ -2,7 +2,7 @@
 # Runs smbd and allow the 'test' user to connect
 #
 
-FROM ubuntu
+FROM ubuntu:trusty
 
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
 RUN apt-get update && apt-get -y install samba


### PR DESCRIPTION
- Log `docker run` and `docker build` separately into diagnostics directory.
- Introduce builder for `DockerImage` starting to keep the signatures sane.
- As a bonus, make sure `cid` file gets deleted.

@reviewbybees esp. @jtnord 