### PR TITLE
Automate vnc setup for local testing

### DIFF
--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -10,7 +10,7 @@ by using the `BROWSER` environment variable. The following values are available:
  * `htmlunit`
  * `phantomjs`
  * `saucelabs`
- * `remote-webdriver-firefox` 
+ * `remote-webdriver-firefox`
         _(Needs `REMOTE_WEBDRIVER_URL` to also be set to the url of the remote, for example `http://0.0.0.0:32779/wd/hub`
           when using something like [selenium/standalone-firefox-debug](https://hub.docker.com/r/selenium/standalone-firefox-debug/))_
 
@@ -41,17 +41,11 @@ For example,
 See [WIRING.md](WIRING.md) for details of where to put this.
 
 ## Avoid focus steal with Xvnc on Linux
-If you select a real GUI browser, such as Firefox, browser window will pop up left and right during tests,
-making it practically unusable for you to use your computer.
+If you select a real GUI browser, such as Firefox, browser window will pop up left and right during tests, making it practically unusable for you to use your computer. There is a script to run vnc server and propage the display number to the test suite.
 
-To prevent this, you can use [Xvnc](http://www.hep.phy.cam.ac.uk/vnc_docs/xvnc.html), so that the browser under the test
-will go to a separate display. For example, on Ubuntu you can run `vncserver`, then run tests like the following:
+    $ . vnc.sh
+    $ mvn test
 
-    $ vncserver    
-    ...
-    New 'X' desktop is elf:1
-    $ DISPLAY=elf:1 mvn test 
-    
 ## Example on using remote web driver
 
 Non tested pseudo bash example

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -42,6 +42,7 @@ import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
@@ -95,7 +96,9 @@ public class FallbackConfig extends AbstractModule {
 
             profile.setPreference(LANGUAGE_SELECTOR, "en");
 
-            return new FirefoxDriver(profile);
+            FirefoxBinary binary = new FirefoxBinary();
+            binary.setEnvironmentProperty("DISPLAY", getBrowserDisplay());
+            return new FirefoxDriver(binary, profile);
         case "ie":
         case "iexplore":
         case "iexplorer":
@@ -141,6 +144,19 @@ public class FallbackConfig extends AbstractModule {
         default:
             throw new Error("Unrecognized browser type: "+browser);
         }
+    }
+
+    /**
+     * Get display number to run browser on.
+     *
+     * Custom property <tt></>BROWSER_DISPLAY</tt> has the preference. If not provided <tt>DISPLAY</tt> is used.
+     */
+    private String getBrowserDisplay() {
+        String d = System.getenv("BROWSER_DISPLAY");
+        if (d != null) return d;
+
+        d = System.getenv("DISPLAY");
+        return d;
     }
 
     /**

--- a/vnc.sh
+++ b/vnc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+display=":42"
+if [ ! -z "$1" ]; then
+  display=":$1"
+fi
+
+vncserver $display
+vncviewer $display &
+
+export BROWSER_DISPLAY=$display


### PR DESCRIPTION
ATH now takes the display for browser from `BROWSER_DISPLAY` property. The advantage compared to propagating plain old `DISPLAY` from shell exported envvar (that worked before) is it will not affect any other UI applications launched from the shell.