### PR TITLE
[FIXED JENKINS-35704] Tweaks for CreateSlaveTest.newSlaveWithExisting…

### DIFF
--- a/src/test/java/core/CreateSlaveTest.java
+++ b/src/test/java/core/CreateSlaveTest.java
@@ -71,7 +71,7 @@ public class CreateSlaveTest extends AbstractJUnitTest {
     @Test
     public void newSlaveWithExistingCredential() throws Exception {
         String username = "xyz";
-        String description = "SSH Key setup";
+        String description = "ssh_creds";
         String privateKey = "1212121122121212";
 
         CredentialsPage c = new CredentialsPage(jenkins, "_");
@@ -85,7 +85,6 @@ public class CreateSlaveTest extends AbstractJUnitTest {
         c.create();
 
         //now verify
-        c.open();
         ManagedCredentials mc = new ManagedCredentials(jenkins);
         String href = mc.credentialById("ssh_creds");
         c.setConfigUrl(href);


### PR DESCRIPTION
…Credential

Had to match description and id we look the credential up by, and get
rid of the c.open().

https://issues.jenkins-ci.org/browse/JENKINS-35704

cc @reviewbybees  esp @kwhetstone 