### PR TITLE
[FIXED JENKINS-36045] Bump sleep for waiting for cidfile

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -117,7 +117,7 @@ public class DockerImage {
 
     private String waitForCid(CommandBuilder docker, File cidFile, File logfile, Process p) throws InterruptedException, IOException {
         for (int i = 0; i < 10; i++) {
-            Thread.sleep(500);
+            Thread.sleep(1000);
 
             String cid = FileUtils.readFileToString(cidFile);
             if (cid != null && cid.length() != 0) return cid;


### PR DESCRIPTION
The half-second sleep seems to hit race conditions periodically,
especially if the host is under load. Moving it to a second got rid of
the issues in my testing - from seeing it error out due to an empty
cidfile roughly half the time in 10 tests to zero times in 10 tests.

cc @reviewbybees 