### PR TITLE
[JENKINS-36046] Fixing FileCredentials and StringCredentials controls

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/FileCredentials.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/FileCredentials.java
@@ -9,7 +9,7 @@ import org.jenkinsci.test.acceptance.po.PageObject;
 @Describable("Secret file")
 public class FileCredentials extends BaseStandardCredentials {
 
-    public Control file = control("file");
+    public Control file = control(by.name("file"));
     
     public FileCredentials(PageObject context, String path) {
         super(context, path);

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/StringCredentials.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/StringCredentials.java
@@ -9,7 +9,7 @@ import org.jenkinsci.test.acceptance.po.PageObject;
 @Describable("Secret text")
 public class StringCredentials extends BaseStandardCredentials {
 
-    public Control secret = control("secret");
+    public Control secret = control(by.name("_.secret"));
     
     public StringCredentials(PageObject context, String path) {
         super(context, path);


### PR DESCRIPTION
Fixing `FileCredentials` and `StringCredentials` controls to be compatible with credentials 2.x line.

See [JENKINS-36046](https://issues.jenkins-ci.org/browse/JENKINS-36046) 

@reviewbybees 