### PR TITLE
[FIXED JENKINS-36116] Select SVN advanced button based on siblings.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/subversion/SubversionScm.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/subversion/SubversionScm.java
@@ -19,7 +19,7 @@ public class SubversionScm extends Scm {
     public static final String CLEAN_CHECKOUT = "Emulate clean checkout by first deleting";
 
     public final Control url = control("locations/remote");
-    public final Control btAdvanced = control(by.xpath("//tr[@nameref='radio-block-3']//div[@class='advancedLink']//button"));
+    public final Control btAdvanced = control(by.xpath("//td[table/tbody/tr/td[@class='setting-main']/input[@name='_.ignoreDirPropChanges']]/div[@class='advancedLink']//button"));
     public final Control local = control("locations/local");
     public final Control checkoutStrategy = control(by.xpath("//td[@class='setting-name' and text()='%s']/../td[@class='setting-main']/select", "Check-out Strategy"));
     public final Control credentials = control("locations/credentialsId");


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-36116

If multiple SCMs are installed, hardcoding to a specific radio button number doesn't work, so here's a more specific xpath.

cc @reviewbybees @olivergondza 