### PR TITLE
[FIXED JENKINS-36125] Expand all Advanced when testing custom workspace

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -339,7 +339,14 @@ public class Job extends TopLevelItem {
 
     public void useCustomWorkspace(String ws) {
         ensureConfigPage();
-        clickButton("Advanced...");
+
+        // There may be multiple "Advanced..." buttons visible on the job config page, and there's no easy way to identify
+        // which one is the Advanced Project Options one, so let's just hit all of them.
+        for (WebElement advancedButton : all(by.button("Advanced..."))) {
+            if (advancedButton.isDisplayed()) {
+                advancedButton.click();
+            }
+        }
 
         // Note that ordering is important here as the old name for the checkbox == new name for the text field.
         control("/customWorkspace", "/hasCustomWorkspace").check();


### PR DESCRIPTION
If we only click the first one, we're vulnerable if there's more than
one on the configure page, as could be the case depending on plugins
installed. To be safe, let's click all of the visible Advanced buttons
- we're not going to break anything by doing so, just increase visibility.

I tried to figure out a way to explicitly find the Advanced Project
Options advanced button, but I don't know xpath well enough to ensure
I get the right sibling of the <tr> that contains the Advanced Project
Options string, so...brute force!

cc @reviewbybees