### PR TITLE
[JENKINS-36045] Rework acquiring Docker CID.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -3,6 +3,7 @@ package org.jenkinsci.test.acceptance.docker;
 import com.google.inject.Inject;
 import hudson.remoting.Which;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.jenkinsci.test.acceptance.utils.SHA1Sum;
 import org.jenkinsci.utils.process.CommandBuilder;
 import org.jvnet.hudson.annotation_indexer.Index;
@@ -62,6 +63,26 @@ public class Docker {
         } catch (InterruptedException | IOException e) {
             return false;
         }
+    }
+
+    /**
+     * Checks if a given container is currently running.
+     *
+     * @param container Container id
+     * @return false if the container is not running, true otherwise
+     */
+    public boolean isContainerRunning(String container) throws IOException, InterruptedException {
+        ProcessBuilder pBuilder = cmd("ps").add("-q", "--filter", "\"id=" + container + '"').build();
+        Process psProcess = pBuilder.start();
+        psProcess.waitFor();
+        if (psProcess.exitValue() == 0) {
+            String psOutput = IOUtils.toString(psProcess.getInputStream());
+            if (psOutput.contains(container)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
@@ -47,31 +47,10 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
             Class<T> fixture = (Class<T>) type.getRawType();
             File buildlog = diag.touch("docker-" + fixture.getSimpleName() + ".build.log");
             File runlog = diag.touch("docker-" + fixture.getSimpleName() + ".run.log");
-            Exception launchException = null;
-            boolean keepTrying = true;
-            int i = 0;
-            for (; i < 5 && keepTrying; i++) {
-                try {
-                    container = docker.build(fixture, buildlog).start(fixture).withPortOffset(portOffset).withLog(runlog).start();
-                    launchException = null;
-                    break;
-                } catch (InterruptedException | IOException e) {
-                    launchException = e;
-                    // Only keep trying if the error is cidFile related.
-                    if (!e.getMessage().contains("docker didn't leave CID file")) {
-                        keepTrying = false;
-                    }
-                }
-                try {
-                    // If we've got this far, that means there was a failure - sleep for 5 seconds and try again.
-                    Thread.sleep(5000);
-                } catch (InterruptedException e2) {
-                    // Swallow it
-                }
-            }
-
-            if (launchException != null) {
-                throw new Error("Failed to start container after " + i + " tries - " + fixture.getName(), launchException);
+            try {
+                container = docker.build(fixture, buildlog).start(fixture).withPortOffset(portOffset).withLog(runlog).start();
+            } catch (InterruptedException | IOException e) {
+                throw new Error("Failed to start container - " + fixture.getName(), e);
             }
         }
         return container;

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -119,23 +119,16 @@ public class DockerImage {
     }
 
     private String waitForCid(CommandBuilder docker, Process p) throws InterruptedException, IOException {
-        for (int i = 0; i < 10; i++) {
-            Thread.sleep(500);
+        p.waitFor();
 
-            String output = IOUtils.toString(p.getInputStream());
+        String output = IOUtils.toString(p.getInputStream());
 
-            try {
-                if (p.exitValue() != 0) {
-                    throw new IOException("docker died unexpectedly: " + docker + "\n" + output);
-                }
-            } catch (IllegalThreadStateException e) {
-                // Docker is still launching, so we move on.
-            }
+        if (p.exitValue() != 0) {
+            throw new IOException("docker died unexpectedly: " + docker + "\n" + output);
+        }
 
-            if (output != null && output.length() != 0) {
-                return output.trim();
-            }
-
+        if (output != null && output.length() != 0) {
+            return output.trim();
         }
 
         throw new IOException("docker didn't output a container id, yet is still running. Huh?: "+docker+"\n"+IOUtils.toString(p.getInputStream()));

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -82,7 +82,6 @@ public class DockerImage {
         cidFile.delete();
         cidFile.deleteOnExit();
         docker.add("--cidfile="+cidFile);//strange behaviour in some docker version cidfile needs to come before
-
         for (int p : starter.ports) {
             docker.add("-p", starter.getPortMapping(p));
         }
@@ -117,7 +116,7 @@ public class DockerImage {
 
     private String waitForCid(CommandBuilder docker, File cidFile, File logfile, Process p) throws InterruptedException, IOException {
         for (int i = 0; i < 10; i++) {
-            Thread.sleep(1000);
+            Thread.sleep(500);
 
             String cid = FileUtils.readFileToString(cidFile);
             if (cid != null && cid.length() != 0) return cid;

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.test.acceptance.docker;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.utils.process.CommandBuilder;
 
@@ -78,10 +79,7 @@ public class DockerImage {
 
     private <T extends DockerContainer> T start(Starter starter, Class<T> type) throws InterruptedException, IOException {
         CommandBuilder docker = Docker.cmd("run");
-        File cidFile = File.createTempFile("docker", "cid");
-        cidFile.delete();
-        cidFile.deleteOnExit();
-        docker.add("--cidfile="+cidFile);//strange behaviour in some docker version cidfile needs to come before
+        docker.add("-d");
         for (int p : starter.ports) {
             docker.add("-p", starter.getPortMapping(p));
         }
@@ -91,45 +89,56 @@ public class DockerImage {
         docker.add(starter.args);
 
         File logfile = starter.log;
-        if (logfile == null) {
-            logfile = new File(cidFile + ".log");
-        }
 
-        System.out.printf("Launching Docker container `%s`: logfile is at %s\n", docker.toString(), logfile);
+        System.out.printf("Launching Docker container `%s`: logfile will be at %s\n", docker.toString(), logfile);
 
         Process p = docker.build()
+                .redirectInput(new File(SystemUtils.IS_OS_WINDOWS ? "NUL": "/dev/null"))
+                .redirectErrorStream(true)
+                .start();
+
+
+        String cid = waitForCid(docker, p);
+
+        Process logProcess = Docker.cmd("logs")
+                .add("-f")
+                .add(cid)
+                .build()
                 .redirectInput(new File(SystemUtils.IS_OS_WINDOWS ? "NUL": "/dev/null"))
                 .redirectErrorStream(true)
                 .redirectOutput(logfile)
                 .start();
 
-        String cid = waitForCid(docker, cidFile, logfile, p);
-
         try {
             T t = type.newInstance();
-            t.init(cid, p, logfile);
+            t.init(cid, logProcess, logfile);
             return t;
         } catch (ReflectiveOperationException e) {
             throw new Error(e);
         }
     }
 
-    private String waitForCid(CommandBuilder docker, File cidFile, File logfile, Process p) throws InterruptedException, IOException {
+    private String waitForCid(CommandBuilder docker, Process p) throws InterruptedException, IOException {
         for (int i = 0; i < 10; i++) {
             Thread.sleep(500);
 
-            String cid = FileUtils.readFileToString(cidFile);
-            if (cid != null && cid.length() != 0) return cid;
+            String output = IOUtils.toString(p.getInputStream());
 
             try {
-                p.exitValue();
-                throw new IOException("docker died unexpectedly: "+docker+"\n"+ FileUtils.readFileToString(logfile));
+                if (p.exitValue() != 0) {
+                    throw new IOException("docker died unexpectedly: " + docker + "\n" + output);
+                }
             } catch (IllegalThreadStateException e) {
-                //Docker is still running okay.
+                // Docker is still launching, so we move on.
             }
+
+            if (output != null && output.length() != 0) {
+                return output.trim();
+            }
+
         }
 
-        throw new IOException("docker didn't leave CID file yet still running. Huh?: "+docker+"\n"+FileUtils.readFileToString(logfile));
+        throw new IOException("docker didn't leave CID file yet still running. Huh?: "+docker+"\n"+IOUtils.toString(p.getInputStream()));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -138,7 +138,7 @@ public class DockerImage {
 
         }
 
-        throw new IOException("docker didn't leave CID file yet still running. Huh?: "+docker+"\n"+IOUtils.toString(p.getInputStream()));
+        throw new IOException("docker didn't output a container id, yet is still running. Huh?: "+docker+"\n"+IOUtils.toString(p.getInputStream()));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -131,7 +131,7 @@ public class DockerImage {
             return output.trim();
         }
 
-        throw new IOException("docker didn't output a container id, yet is still running. Huh?: "+docker+"\n"+IOUtils.toString(p.getInputStream()));
+        throw new IOException("docker didn't output a container id or have a non-zero exit status. Huh?: "+docker);
     }
 
     /**


### PR DESCRIPTION
Also effectively rolls back 74ec1821ced1d2ef2b2567e92e699117370ff1bf
as unneeded.

NOTE: Don't merge this until I've had a chance to run a few more full runs to be sure it's doing the trick - it certainly appears to be fixing things so far, but I've been bit by false positives on this issue before. =) It's still just a band-aid at the core - I can't for the life of me figure out why it's happening in the first place, but this is the best workaround I've got yet.

EDIT:
I've left the retry in for now, but may end up opting to remove it entirely. The new approach (as described below) reworks how we get the container ID and logs entirely and doesn't seem to run into problems.

```
More testing needed to verify this actually does the trick
consistently, but it does *work* in the non-failure case for
sure. We're now detaching the container, getting the container ID from
the "docker run" output (since that's the output from a detached run)
and running a side process piping "docker logs --follow (cid)" to the
log file. That side process gets automatically killed at the end of
the test when we kill and rm the container as well.
```

cc @reviewbybees @olivergondza 