### PR TITLE
[JENKINS-36046] Correct parent path for credentials. 

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/CredentialsPage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/CredentialsPage.java
@@ -28,7 +28,7 @@ public class CredentialsPage extends ConfigurablePageObject {
 
     public <T extends Credential> T add(Class<T> type) {
         addButton.selectDropdownMenuAlt(type);
-        String path = find(by.name("newCredentials")).getAttribute("path");
+        String path = find(by.name("credentials")).getAttribute("path");
 
         return newInstance(type, this, path);
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
@@ -184,8 +184,7 @@ public class Control extends CapybaraPortingLayerImpl {
      * @param type
      */
     public void selectDropdownMenuAlt(Class type) {
-        click();
-        findCaption(type,findDropDownMenuItemBySelector).click();
+        findCaption(type,findDropDownMenuItemBySelector);
         elasticSleep(1000);
     }
 


### PR DESCRIPTION
Supersedes #133 

- [x] The initial reason to create #133 was that I thought the `path` for  controls in `FileCredentials` and `StringCredentials` were incorrect, but that is not the case. The problem was that after #123 , when adding a new credential the parent `path` with which it was created was empty. This PR fixes this and there is now no need to change the `FileCredentilas` and `StringCredentials` controls. 

- [x] Also, I have noticed that `selectDropdownMenuAlt` method (also introduced in #123) is making tests to be flaky. It performs several redundant clicks in the credentials type select that should not be performed and cause unexpected behaviour.

@olivergondza I have closed #133 since it is no longer relevant.

@reviewbybees esp @amuniz @recena @kwhetstone 