### PR TITLE
[FIXED JENKINS-35443] Look for form action, not title.

### DIFF
--- a/src/main/groovy/org/jenkinsci/test/acceptance/po/users/AddUserPage.groovy
+++ b/src/main/groovy/org/jenkinsci/test/acceptance/po/users/AddUserPage.groovy
@@ -11,7 +11,7 @@ import org.kohsuke.randname.RandomNameGenerator
 class AddUserPage extends Page {
 
     static url = "securityRealm/addUser"
-    static at = { title == "Create User [Jenkins]" }
+    static at = { $("form", action: endsWith("createAccountByAdmin")).size() == 1 }
     static content = {
         username { $("input[path='/username']") }
         password { $("input[path='/password1']") }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-35443

The title for either addUser or signup is always "Sign up" in 1.x,
at least in 1.651, but in 2.x, the title varies depending on whether
you're hitting the addUser endpoint or the signup endpoint. Since we
want the addUser endpoint, looking for a title of "Sign up" breaks on
2.x, while looking for a title of "Create user" (the one we get on the
right endpoint on 2.x) fails on 1.x.

So - instead, verify we're on the right page by looking for
"createAccountByAdmin" as the form action, since that's consistent and accurate.

cc @reviewbybees @olivergondza 