### PR TITLE
Don't visit Jenkins home page after scheduleBuild

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Build.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Build.java
@@ -68,7 +68,6 @@ public class Build extends ContainerPageObject {
     }
 
     public Build waitUntilStarted(int timeout) {
-        job.getJenkins().visit("");
         waitFor().withMessage("Next build of %s is started", job)
                 .withTimeout(timeout, TimeUnit.SECONDS)
                 .until(new Callable<Boolean>() {


### PR DESCRIPTION
Since we don't visit the build page anymore once the build is started,
it is not useful to go to the Jenkins home page. Especially since the
method getJenkins() is not fully implemented (doesn't work if there are
several Jenkins instance in injector)