### PR TITLE
Make minimum browser window size configurable.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -166,12 +166,23 @@ public class FallbackConfig extends AbstractModule {
     public WebDriver createWebDriver(TestCleaner cleaner, TestName testName, ElasticTime time) throws IOException {
         WebDriver base = createWebDriver(testName);
 
+        String minHeightStr = System.getenv("MIN_BROWSER_HEIGHT");
+        if (minHeightStr == null)
+            minHeightStr = "960";
+
+        String minWidthStr = System.getenv("MIN_BROWSER_WIDTH");
+        if (minWidthStr == null)
+            minWidthStr = "960";
+
+        int minHeight = Integer.parseInt(minHeightStr);
+        int minWidth = Integer.parseInt(minWidthStr);
+
         // Make sue the window have minimal resolution set, even when out of the visible screen. Try maximizing first so
         // it has a chance to fit the screen nicely if big enough.
         base.manage().window().maximize();
         Dimension oldSize = base.manage().window().getSize();
-        if (oldSize.height < 960 || oldSize.width < 1280) {
-            base.manage().window().setSize(new Dimension(1280, 960));
+        if (oldSize.height < minHeight || oldSize.width < minWidth) {
+            base.manage().window().setSize(new Dimension(minWidth, minHeight));
         }
 
         final EventFiringWebDriver d = new EventFiringWebDriver(base);


### PR DESCRIPTION
Currently via environment variables.

We've had a lot of problems with scrolling to check
matrix/credentials/etc fields, which are...annoying. And fairly
pointless to work on, frankly. I'd strongly advocate for instead
allowing configurability of window geometry - I'd've thought that the
maximize call would do the trick on its own with a larger Xvnc
geometry, but it didn't, so I've made the browser height and width
configurable via environment variables.

cc @reviewbybees @olivergondza