### PR TITLE
Make minimum browser window size larger.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -166,12 +166,11 @@ public class FallbackConfig extends AbstractModule {
     public WebDriver createWebDriver(TestCleaner cleaner, TestName testName, ElasticTime time) throws IOException {
         WebDriver base = createWebDriver(testName);
 
-        // Make sue the window have minimal resolution set, even when out of the visible screen. Try maximizing first so
-        // it has a chance to fit the screen nicely if big enough.
-        base.manage().window().maximize();
+        // Make sue the window have minimal resolution set, even when out of the visible screen.
+        // Note - not maximizing here any more because that doesn't do anything.
         Dimension oldSize = base.manage().window().getSize();
-        if (oldSize.height < 960 || oldSize.width < 1280) {
-            base.manage().window().setSize(new Dimension(1280, 960));
+        if (oldSize.height < 1050 || oldSize.width < 1680) {
+            base.manage().window().setSize(new Dimension(1680, 1050));
         }
 
         final EventFiringWebDriver d = new EventFiringWebDriver(base);


### PR DESCRIPTION
We've had a lot of problems with scrolling to check
matrix/credentials/etc fields, which are...annoying. And fairly
pointless to work on, frankly. I'd strongly advocate for instead
allowing configurability of window geometry - I'd've thought that the
maximize call would do the trick on its own with a larger Xvnc
geometry, but it didn't - in fact, it seems to do absolutely *nothing*
when run inside Xvnc.

So instead, let's just suck it up and bump the minimum window size to
an admittedly silly-large 1680x1050. Selenium does fine with detecting
visibility of parts of the window that are off the screen, so a
smaller screen than 1680x1050 causes no problems.

I'd be open to a smaller width too, but definitely bigger than
1280x960, the previous minimum.

This replaces #145.

As always, cc @reviewbybee and @olivergondza.