### PR TITLE
[JENKINS-36321] Extra check when trying to install dependencies

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
@@ -84,7 +84,13 @@ public class UpdateCenterMetadata {
     private void transitiveDependenciesOf(Jenkins jenkins, PluginMetadata p, String v, List<PluginMetadata> result) {
         for (Dependency d : p.getDependencies()) {
             if (d.optional || !shouldBeIncluded(jenkins, d)) continue;
-            transitiveDependenciesOf(jenkins, plugins.get(d.name), d.version, result);
+            PluginMetadata depMetaData = plugins.get(d.name);
+            if (depMetaData==null) {
+                throw new UnableToResolveDependencies(
+                    String.format("Unable to install dependency '%s' for '%s': plugin not found", depMetaData, p)
+                );
+            }
+            transitiveDependenciesOf(jenkins, depMetaData, d.version, result);
         }
 
         if (!result.contains(p)) {

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
@@ -85,7 +85,7 @@ public class UpdateCenterMetadata {
         for (Dependency d : p.getDependencies()) {
             if (d.optional || !shouldBeIncluded(jenkins, d)) continue;
             PluginMetadata depMetaData = plugins.get(d.name);
-            if (depMetaData==null) {
+            if (depMetaData == null) {
                 throw new UnableToResolveDependencies(
                     String.format("Unable to install dependency '%s' for '%s': plugin not found", depMetaData, p)
                 );


### PR DESCRIPTION
[JENKINS-36321](https://issues.jenkins-ci.org/browse/JENKINS-36321)

The issue reported is not easily reproduced.

My theory is that the error stems from an inconsistent UpdateCenter metadata: we get a NullPointerException when trying to install a plugin which is present as a dependency of another one, but actually not present in the UC metadata.

One thing we can do is to control this error and throw a proper exception if that happens. We were already validating that a plugin exists before trying to install it, but we were not doing so with the plugins declared as dependencies.

@reviewbybees esp @armfergom