### PR TITLE
[JENKINS-35646] Fix ArtifactoryPluginTest.gradle_integration failure

### DIFF
--- a/src/test/java/plugins/ArtifactoryPluginTest.java
+++ b/src/test/java/plugins/ArtifactoryPluginTest.java
@@ -92,15 +92,15 @@ public class ArtifactoryPluginTest extends AbstractJUnitTest {
         waitForArtifactory(artifactory);
         configureArtifactory(artifactory);
 
-        GradleInstallation.installGradle(jenkins, "gradle 1.12", "1.12");
+        GradleInstallation.installGradle(jenkins, "gradle 2.0", "2.0");
 
         FreeStyleJob job = jenkins.jobs.create();
         job.copyDir(resource("/artifactory_plugin/quickstart"));
         ArtifactoryGradleConfiguratior gradleConfig = new ArtifactoryGradleConfiguratior(job);
         gradleConfig.refresh();
         GradleStep gradle = job.addBuildStep(GradleStep.class);
-        gradle.name.select("gradle 1.12");
-        gradle.tasks.set("build");
+        gradle.name.select("gradle 2.0");
+        gradle.tasks.set("build"); // gradle.tasks.set("build --stacktrace --debug");
         job.save();
 
         Build build = job.startBuild().shouldSucceed();


### PR DESCRIPTION
[JENKINS-35646](https://issues.jenkins-ci.org/browse/JENKINS-35646)

It seems like the test fails due to some groovy versions issue: looks like the ArtifactoryPlugin was built with a groovy version 2.3+, and when we try to launch a job using gradle 1.12 (older groovy) we get the error described here: http://www.groovy-lang.org/mailing-lists.html#nabble-td5720557.

So using gradle 2.0 in the test makes it work, but probably this is a real bug if we want to support past gradle versions (1.X). So should we open an issue for this? If so, where exactly?

EXTRA INFO:

The dependency of gradle with the artifactory plugin seems to stem from an gradle init-script which is autogenerated using a template (see [ArtifactoryGradleConfigurator](https://github.com/jenkinsci/artifactory-plugin/blob/08ea6585e78485305d3f0a3dd7146524b4009116/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java) and [GradleInitScriptWriter](https://github.com/jenkinsci/artifactory-plugin/blob/1e7af0e40f9b47cd7bb0d22212cfb15fa7175197/src/main/java/org/jfrog/hudson/gradle/GradleInitScriptWriter.java)), and there in that template the compatibility fix described in http://www.groovy-lang.org/mailing-lists.html#nabble-td5720557 could probably be applied. But I can't find that template.

Sample init-script used in job:
  
```
import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin
import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask

initscript {
    dependencies {
        classpath fileTree('/home/mfranco/code/acceptance-test-harness/target/jenkins8232563307429622129home/cache/artifactory-plugin/2.5.1')
    }
}

addListener(new BuildInfoPluginListener())
class BuildInfoPluginListener extends BuildAdapter {

    def void projectsLoaded(Gradle gradle) {
        gradle.startParameter.getProjectProperties().put("build.start", Long.toString(System.currentTimeMillis()))
        Project root = gradle.getRootProject()
        root.logger.debug("Artifactory plugin: projectsEvaluated: ${root.name}")
        if (!"buildSrc".equals(root.name)) {
            root.allprojects {
                apply {
                    apply plugin: ArtifactoryPlugin
                }
            }
        }

        // Set the "archives" configuration to all Artifactory tasks.
        for (Project p : root.getAllprojects()) {
            Task t = p.getTasks().findByName(ArtifactoryTask.BUILD_INFO_TASK_NAME)
            if (t != null) {
                ArtifactoryTask task = (ArtifactoryTask)t
                task.setAddArchivesConfigToTask(true)
            }
        }
    }
}%  

```

Anyway this is all quite fuzzy for me right now since I don't have a lot of experience with gradle nor artifactory, so I guess I could use some help here: @recena @abayer would you mind having a look at this and tell me if this makes sense for you?

@reviewbybees 