### PR TITLE
[JENKINS-34614] Fix for ftpd container connectivity problems

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
@@ -51,7 +51,9 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
             File runlog = diag.touch("docker-" + fixture.getSimpleName() + ".run.log");
             try {
                 Starter<T> containerStarter = docker.build(fixture, buildlog).start(fixture);
-                if (portOffset != null) containerStarter.withPortOffset(portOffset);
+                if (portOffset != null) {
+                    containerStarter.withPortOffset(portOffset);
+                }
                 container = containerStarter.withLog(runlog).start();
             } catch (InterruptedException | IOException e) {
                 throw new Error("Failed to start container - " + fixture.getName(), e);

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainerHolder.java
@@ -11,6 +11,8 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import java.io.File;
 import java.io.IOException;
+import org.jenkinsci.test.acceptance.docker.DockerImage.Starter;
+import org.jenkinsci.test.acceptance.docker.fixtures.FtpdContainer;
 
 /**
  * Inject this object to automate the cleanup of a running container at the end of the test case.
@@ -36,7 +38,7 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
      */
     @Inject(optional = true)
     @Named("dockerPortOffset")
-    private int portOffset = 0;
+    private Integer portOffset;
 
     /**
      * Lazily starts a container and returns the instance.
@@ -48,7 +50,9 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
             File buildlog = diag.touch("docker-" + fixture.getSimpleName() + ".build.log");
             File runlog = diag.touch("docker-" + fixture.getSimpleName() + ".run.log");
             try {
-                container = docker.build(fixture, buildlog).start(fixture).withPortOffset(portOffset).withLog(runlog).start();
+                Starter<T> containerStarter = docker.build(fixture, buildlog).start(fixture);
+                if (portOffset != null) containerStarter.withPortOffset(portOffset);
+                container = containerStarter.withLog(runlog).start();
             } catch (InterruptedException | IOException e) {
                 throw new Error("Failed to start container - " + fixture.getName(), e);
             }
@@ -61,7 +65,7 @@ public class DockerContainerHolder<T extends DockerContainer> implements Provide
      */
     @Override
     public void close() throws IOException {
-        if (container!=null) {
+        if (container != null) {
             container.close();
             container = null;
         }

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerFixture.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerFixture.java
@@ -37,6 +37,15 @@ public @interface DockerFixture {
      * be retried at runtime via {@link DockerContainer#port(int)}.
      */
     int[] ports() default {};
+    
+    /**
+     * Map container ports to host ports exactly.
+     * 
+     * <p>
+     * If true, no random ephemeral ports will be used, but an exact matching of
+     * container and host ports.
+     */
+    boolean matchHostPorts() default false;
 
     /**
      * Ip address to bind to

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -167,7 +167,7 @@ public class DockerImage {
         private CommandBuilder options;
         private CommandBuilder args;
         private String ipAddress = getDockerHost();
-        private int portOffset = 0;
+        private Integer portOffset;
         private int[] ports;
         private File log;
 
@@ -177,6 +177,9 @@ public class DockerImage {
 
             DockerFixture fixtureAnnotation = type.getAnnotation(DockerFixture.class);
             ports = fixtureAnnotation.ports();
+            if (fixtureAnnotation.matchHostPorts()) {
+                portOffset = 0;
+            }
         }
 
         public @Nonnull Starter<T> withPorts(int... ports) {
@@ -184,7 +187,7 @@ public class DockerImage {
             return this;
         }
 
-        public @Nonnull Starter<T> withPortOffset(int portOffset) {
+        public @Nonnull Starter<T> withPortOffset(Integer portOffset) {
             this.portOffset = portOffset;
             return this;
         }
@@ -216,7 +219,7 @@ public class DockerImage {
         }
 
         private String getPortMapping(int port) {
-            return portOffset == 0
+            return portOffset == null
                     ? ipAddress + "::" + port
                     : ipAddress + ":" + (portOffset + port) + ":" + port
             ;

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer.java
@@ -17,7 +17,7 @@ import java.io.IOException;
  *
  * @author Tobias Meyer
  */
-@DockerFixture(id = "ftpd", ports = {21, 7050, 7051, 7052, 7053, 7054, 7055}, bindIp = "127.0.0.2")
+@DockerFixture(id = "ftpd", matchHostPorts = true, ports = {21, 7050, 7051, 7052, 7053, 7054, 7055})
 public class FtpdContainer extends DockerContainer implements IPasswordDockerContainer {
     private FTPClient ftpClient;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer.java
@@ -17,7 +17,7 @@ import java.io.IOException;
  *
  * @author Tobias Meyer
  */
-@DockerFixture(id = "ftpd", matchHostPorts = true, ports = {21, 7050, 7051, 7052, 7053, 7054, 7055})
+@DockerFixture(id = "ftpd", matchHostPorts = true, ports = {21, 9050, 9051, 9052, 9053, 9054, 9055})
 public class FtpdContainer extends DockerContainer implements IPasswordDockerContainer {
     private FTPClient ftpClient;
 

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
@@ -2,7 +2,7 @@
 # Runs sshd and allow the 'test' user to login
 #
 
-FROM ubuntu
+FROM ubuntu:trusty
 
 # install FTP
 RUN apt-get update && apt-get install -y vsftpd
@@ -19,10 +19,11 @@ RUN echo "rsa_cert_file=/etc/ssl/private/vsftpd.pem" >> /etc/myftp.conf
 RUN echo "pasv_enable=YES" >> /etc/myftp.conf
 RUN echo "pasv_min_port=7050" >> /etc/myftp.conf
 RUN echo "pasv_max_port=7055" >> /etc/myftp.conf
-# To enable passv mode through NAT (for remote docker) we need to set the 
+# To enable passv mode through NAT (for remote docker) we need to set the
 # passv_address to the address that docker will use to port forward
-# RUN echo "pasv_address=@@DOCKER_HOST@@" >> /etc/myftpd.conf
+RUN echo "pasv_address=localhost" >> /etc/myftpd.conf
 # however DockerCOntainer has no way to specify the port offset so this will just not work..
+# unless the container and host ports match exactly
 RUN mkdir -p /var/run/vsftpd/empty
 
 # create a test user
@@ -33,4 +34,3 @@ RUN useradd test -d /home/test -s /bin/bash && \
 
 # run VSFTPD
 CMD /usr/sbin/vsftpd /etc/myftp.conf
-

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
@@ -17,8 +17,8 @@ RUN echo "secure_chroot_dir=/var/run/vsftpd/empty" >> /etc/myftp.conf
 RUN echo "pam_service_name=vsftpd" >> /etc/myftp.conf
 RUN echo "rsa_cert_file=/etc/ssl/private/vsftpd.pem" >> /etc/myftp.conf
 RUN echo "pasv_enable=YES" >> /etc/myftp.conf
-RUN echo "pasv_min_port=7050" >> /etc/myftp.conf
-RUN echo "pasv_max_port=7055" >> /etc/myftp.conf
+RUN echo "pasv_min_port=9050" >> /etc/myftp.conf
+RUN echo "pasv_max_port=9055" >> /etc/myftp.conf
 # To enable passv mode through NAT (for remote docker) we need to set the
 # passv_address to the address that docker will use to port forward
 RUN echo "pasv_address=localhost" >> /etc/myftpd.conf

--- a/src/test/java/plugins/FtpPublishPluginTest.java
+++ b/src/test/java/plugins/FtpPublishPluginTest.java
@@ -11,6 +11,7 @@ import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.publish_over.*;
 import org.jenkinsci.test.acceptance.plugins.publish_over.FtpGlobalConfig.FtpSite;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 /**

--- a/src/test/java/plugins/FtpPublishPluginTest.java
+++ b/src/test/java/plugins/FtpPublishPluginTest.java
@@ -11,7 +11,6 @@ import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.publish_over.*;
 import org.jenkinsci.test.acceptance.plugins.publish_over.FtpGlobalConfig.FtpSite;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 /**


### PR DESCRIPTION
Fix for [JENKINS-34614](https://issues.jenkins-ci.org/browse/JENKINS-34614).

Several factors were preventing the connection to the ftp server:

1. Due to how FTP protocol works ([details here](http://www.slacksite.com/other/ftp.html)) we need an exact match of container and host ports. If anyone knows another solution please comment.
2. We needed to force the 'passive' ip/host in the ftp server.

My proposed solution to address (1) is to add a new boolean property `matchHostPorts` in the `DockerFixture` annotation, which when true will force an exact port mapping between docker container and host.

Also modified the `FtpdContainer`'s `Dockerfile` to fix the ubuntu version, and to address (2).

@reviewbybees esp @abayer, @olivergondza 