### PR TITLE
[JENKINS-36469] CapybaraPortingLayerImpl.clickButton() has problems with vertical scroll and sticky buttons

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -22,6 +22,7 @@ import org.openqa.selenium.WebElement;
 
 import com.google.common.base.Joiner;
 import com.google.inject.Injector;
+import org.openqa.selenium.interactions.Actions;
 
 import static java.util.Arrays.*;
 
@@ -82,7 +83,23 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     @Override
     public void clickButton(String text) {
         WebElement e = find(by.button(text));
-        e.click();
+        /*
+         * YUI sticky buttons present some problems when scroll to them, also if you have a sticky button
+         * you should not need to scroll to use them
+         */
+        boolean isStickyButton = false;
+        WebElement stickyContainer = getElement(by.id("bottom-sticker"));
+        if (stickyContainer != null) {
+            JavascriptExecutor je = (JavascriptExecutor)driver;
+            isStickyButton = (boolean)je.executeScript("return arguments[0].contains(arguments[1])", stickyContainer, e);
+        }
+        if (isStickyButton) {
+            Actions builder = new Actions(driver);
+            builder.moveToElement(e).click(e);
+            builder.perform();
+        } else {
+            e.click();
+        }
     }
 
     /**


### PR DESCRIPTION
[JENKINS-36469](https://issues.jenkins-ci.org/browse/JENKINS-36469)

In the case the button is sticky this PR does not scroll before clicking it, in other case the functionality is the existing one

@reviewbybees 
