### PR TITLE
[JENKINS-35644] Fix JiraPluginTest

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer/Dockerfile
@@ -2,8 +2,14 @@
 # Runs JIRA
 #
 #    The initial password is 'admin:admin'
-# 
+#
 FROM ubuntu:xenial
+
+# Pin JIRA version to make the tests more predictable and less fragile
+# In particular, pinned to 6.X because from 7.X the SOAP API is gone, and it's
+# used in the tests. Upgrading the tests to use the REST API is not trivial
+# since some operations are not yet available in its java client (e.g. project creation)
+ENV JIRA_VERSION 6.3
 
 # base package installation
 RUN apt-get update -y && apt-get install -y apt-transport-https && echo "deb https://sdkrepo.atlassian.com/debian/ stable contrib" >> /etc/apt/sources.list && apt-get update
@@ -12,9 +18,8 @@ RUN apt-get install -y --allow-unauthenticated openjdk-8-jdk atlassian-plugin-sd
 # this will install the whole thing, launches Tomcat,
 # asks the user to do Ctrl+C to quit, then it shuts down presumably because it
 # fails to read from stdin?
-RUN atlas-run-standalone --product jira < /dev/null
+RUN atlas-run-standalone --product jira -v $JIRA_VERSION < /dev/null
 
 # unlike the above command, this launches Tomcat then hangs, because it feeds its own tail
 # and so stdin will block
-CMD atlas-run-standalone --product jira < /dev/stderr
-
+CMD atlas-run-standalone --product jira -v $JIRA_VERSION < /dev/stderr


### PR DESCRIPTION
[JENKINS-35644](https://issues.jenkins-ci.org/browse/JENKINS-35644)

Fix for JiraPluginTest. The problem is that the fixture was using always the latest JIRA version available, but from 7.0 the JIRA SOAP API was gone.

The test set up was trying to interact with the JIRA through this missing API, hence the failure. I've pinned down the docker fixture to 6.3, and the test now succeeds.

@reviewbybees 