### PR TITLE
[JENKINS-31060] - AntPluginTest does not work if ANT_HOME set

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ant/AntInstallation.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ant/AntInstallation.java
@@ -39,7 +39,9 @@ public class AntInstallation extends ToolInstallation {
         super(context, path);
     }
 
-    public void useNative() {
-        installedIn(fakeHome("ant", "ANT_HOME"));
+    public String useNative() {
+        String antHome = fakeHome("ant", "ANT_HOME");
+        installedIn(antHome);
+        return antHome;
     }
 }

--- a/src/test/java/plugins/AntPluginTest.java
+++ b/src/test/java/plugins/AntPluginTest.java
@@ -65,11 +65,9 @@ public class AntPluginTest extends AbstractJUnitTest {
 
     @Test @Native("ant")
     public void locallyInstalledAnt() {
-        String expectedVersion = localAntVersion();
-
         AntInstallation ant = ToolInstallation.addTool(jenkins, AntInstallation.class);
         ant.name.set("native_ant");
-        ant.useNative();
+        String antHome = ant.useNative();
         ant.getPage().save();
 
         job.configure();
@@ -79,6 +77,7 @@ public class AntPluginTest extends AbstractJUnitTest {
         step.targets.set("-version");
         job.save();
 
+        String expectedVersion = localAntVersion(antHome);
         job.startBuild().shouldSucceed().shouldContainsConsoleOutput(Pattern.quote(expectedVersion));
     }
 
@@ -97,7 +96,7 @@ public class AntPluginTest extends AbstractJUnitTest {
         return job.startBuild().shouldSucceed().shouldContainsConsoleOutput("Hello World");
     }
 
-    private String localAntVersion() {
-        return jenkins.runScript("'ant -version'.execute().text");
+    private String localAntVersion(String antHome) {
+        return jenkins.runScript(String.format("'%s/bin/ant -version'.execute().text", antHome));
     }
 }


### PR DESCRIPTION
[JENKINS-31060](https://issues.jenkins-ci.org/browse/JENKINS-31060)

Proposal to bring back the test previously removed, with some modifications to make it work.

The original error was due mainly to:

1. an inconsistent setup of PATH and ANT_HOME env variables,
2. how ant is "too smart" when looking for an "ANT_HOME" variable
3. how we are also being smart enough at setting up a fake home for tool installations (see [ToolInstallation.java](https://github.com/jenkinsci/acceptance-test-harness/blob/c1512e4da9dc3b4dd701988dae103eaec405ec25/src/main/java/org/jenkinsci/test/acceptance/po/ToolInstallation.java#L123)).

In this test "the user" is entering the ANT_HOME (fake home) which jenkins must use for the build. I think that if the test uses this exact same ant script to set the expected version, the test both makes more sense and will be tolerant to the wrong set up which caused the issue.

@reviewbybees , esp @abayer 