### PR TITLE
Add a Jenkinsfile for parallelized ATH runs via Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,50 @@
+/*
+ * This Jenkinsfile is intended to run on https://jenkins.ci.cloudbees.com and may fail anywhere else.
+ * It makes assumptions about plugins being installed, labels mapping to nodes that can build what is needed, etc.
+ *
+ * The required label is "hi-speed" */
+
+// Only keep the 50 most recent builds.
+properties([[$class: 'jenkins.model.BuildDiscarderProperty', strategy: [$class: 'LogRotator',
+                                                                        numToKeepStr: '50']]])
+
+loadParameterizedLibs { functions, ath ->
+
+    parallel 'jenkins-war': { functions.stashJenkinsWar(war, athLabel(), true) },
+        'get-ath': { stashAth(functions) },
+        failFast: true
+
+
+}
+
+def loadParameterizedLibs(def body) {
+    String functionsRepo = FUNCTIONS_REPO
+    String functionsBranch = FUNCTIONS_BRANCH
+    String label = FUNCTIONS_LABEL
+    loadLibs(label, functionsRepo, functionsBranch, body)
+}
+
+def loadLibs(String label = null,
+             String functionsRepo = "jenkinsci/jenkins-project-pipeline-lib",
+             String functionsBranch = "master",
+             def body) {
+    if (label == null) {
+        label = athLabel()
+    }
+
+    if (!functionsRepo.endsWith(".git")) {
+        functionsRepo = functionsRepo + ".git"
+    }
+    
+    def functions
+    def ath
+
+    node(label) {
+        git changelog: false, poll: false, url: "git://github.com/" + functionsRepo, branch: functionsBranch
+
+        functions = load 'lib/functions.groovy'
+        ath = load 'lib/ath.groovy'
+    }
+
+    body(functions, ath)
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,33 +4,46 @@
  *
  * The required label is "hi-speed" */
 
-// Only keep the 50 most recent builds.
-properties([[$class: 'jenkins.model.BuildDiscarderProperty', strategy: [$class: 'LogRotator',
-                                                                        numToKeepStr: '50']]])
+// TODO: Figure out how to run just changed/affected-by-changes tests when running from a PR.
+// TODO: Get https://issues.jenkins-ci.org/browse/JENKINS-33274 fixed and configured so that we don't have to run
+//   serially for the first run on a branch.
 
-loadParameterizedLibs { functions, ath ->
+timestamps {
+    // Only keep the 50 most recent builds.
+    properties([[$class: 'jenkins.model.BuildDiscarderProperty', strategy: [$class: 'LogRotator',
+                                                                            numToKeepStr: '50']]])
 
-    parallel 'jenkins-war': { functions.stashJenkinsWar(war, athLabel(), true) },
-        'get-ath': { stashAth(functions) },
-        failFast: true
+    stage "Load libs"
+    loadLibs { functions, ath ->
 
+        stage "Fetch WAR and ATH source"
+        parallel 'jenkins-war': { functions.stashJenkinsWar(war, ath.athLabel(), true) },
+            'get-ath': { ath.stashAth(functions) },
+            failFast: true
 
-}
+        stage "Run tests"
+        def branches = ath.getAthBranches(
+            functions,       // Used for things like getting the Maven environment set up.
+            ath.athLabel(),  // What label to use for execution.
+            false,           // Whether to archive JUnit report files for processing in a later job.
+            3,               // Number of times to retry failed tests
+            4                // Parallel branch count, in addition to the cucumber branch
+        )
 
-def loadParameterizedLibs(def body) {
-    String functionsRepo = FUNCTIONS_REPO
-    String functionsBranch = FUNCTIONS_BRANCH
-    String label = FUNCTIONS_LABEL
-    loadLibs(label, functionsRepo, functionsBranch, body)
-}
-
-def loadLibs(String label = null,
-             String functionsRepo = "jenkinsci/jenkins-project-pipeline-lib",
-             String functionsBranch = "master",
-             def body) {
-    if (label == null) {
-        label = athLabel()
+        parallel branches
     }
+}
+
+/**
+ * Loads the libraries using known parameters for repo/branch/node if they're specified, and then makes the libraries
+ *   available in the execution of the body.
+ *
+ * @param body Closure to execute.
+ */
+def loadLibs(def body) {
+    String functionsRepo = defaultValueIfNotSet("FUNCTIONS_REPO", "jenkinsci/jenkins-project-pipeline-lib")
+    String functionsBranch = defaultValueIfNotSet("FUNCTIONS_BRANCH", "master")
+    String label = defaultValueIfNotSet("FUNCTIONS_LABEL", "hi-speed")
 
     if (!functionsRepo.endsWith(".git")) {
         functionsRepo = functionsRepo + ".git"
@@ -47,4 +60,27 @@ def loadLibs(String label = null,
     }
 
     body(functions, ath)
+}
+
+/**
+ * Given a parameter name and an optional default value, try to get the value of that parameter. If the parameter
+ *   exists, it's not null, and its value isn't the empty string, return that. Otherwise, return the default value.
+ *
+ * @param paramName A String name of a build parameter
+ * @param defaultValue An optional default value if the parameter does not exist, is unset or is the empty string.
+ * @return The value of the parameter if appropriate, the default value otherwise.
+ */
+def defaultValueIfNotSet(String paramName, def defaultValue = null) {
+    def result = defaultValue
+
+    try {
+        def prop = getProperty(paramName)
+        if (prop != null && prop != '') {
+            result = prop
+        }
+    } catch (Exception e) {
+        // This just means the parameter doesn't exist at all, so let's move on.
+    }
+
+    return result
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,28 @@
 /*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
  * This Jenkinsfile is intended to run on https://jenkins.ci.cloudbees.com and may fail anywhere else.
  * It makes assumptions about plugins being installed, labels mapping to nodes that can build what is needed, etc.
  *


### PR DESCRIPTION
Note - this depends on https://github.com/jenkinsci/jenkins-project-pipeline-lib/pull/1.

This is descended from how we've been doing ATH runs internally at CloudBees - loading most of the logic from Pipeline libraries, splitting the ATH into a number of separate parallel blocks using the Parallel Test Executor plugin, and then pulling all the results back together in the end. 

The plan is to start using this for the non-PR-triggered ATH builds on jenkins.ci.cloudbees.com, with the PR builds moved out to a separate, still linear job for now. Until [JENKINS-33274](https://issues.jenkins-ci.org/browse/JENKINS-33274) is resolved, multibranch jobs will have to run all the tests serially for the first build on each branch or PR anyway, but the main reason is that we'll simply exhaust our executor resources on jenkins.ci.cloudbees.com with PR builds. Down the road, once we've got [JENKINS-30412](https://issues.jenkins-ci.org/browse/JENKINS-30412), we should hopefully be able to get some logic in place to figure out what tests have changed/are relevant to a given PR so that we can avoid having to run _all_ the tests for every PR.

cc @jenkinsci/code-reviewers, @reviewbybees, @olivergondza, @jtnord 
