### PR TITLE
[JENKINS-31060] make AntPluginTest use ANT_HOME if present

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ant/AntInstallation.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ant/AntInstallation.java
@@ -24,7 +24,6 @@
 package org.jenkinsci.test.acceptance.plugins.ant;
 
 import org.jenkinsci.test.acceptance.po.Jenkins;
-import org.jenkinsci.test.acceptance.po.JenkinsConfig;
 import org.jenkinsci.test.acceptance.po.ToolInstallation;
 import org.jenkinsci.test.acceptance.po.ToolInstallationPageObject;
 
@@ -40,7 +39,10 @@ public class AntInstallation extends ToolInstallation {
     }
 
     public String useNative() {
-        String antHome = fakeHome("ant", "ANT_HOME");
+        String antHome = System.getenv("ANT_HOME");
+        if (antHome.trim().isEmpty()) {
+            antHome =  fakeHome("ant", "ANT_HOME");
+        }
         installedIn(antHome);
         return antHome;
     }


### PR DESCRIPTION
Follow up to [PR-156](https://github.com/jenkinsci/acceptance-test-harness/pull/156).
Related to issue [JENKINS-31060](https://issues.jenkins-ci.org/browse/JENKINS-31060).

The fix introduced in the previous PR solves the issue reported, but still I found some setups where some ant bug (see http://stackoverflow.com/questions/2336299/what-is-wrong-with-my-ant-configuration) raises if the ANT_HOME variable is not present and the ant script itself tries to guess it, and we are blanking it in [ToolInstallation.java](https://github.com/jenkinsci/acceptance-test-harness/blob/c1512e4da9dc3b4dd701988dae103eaec405ec25/src/main/java/org/jenkinsci/test/acceptance/po/ToolInstallation.java#L123) when we create a fake home.

So the test will be more resilient if we use ANT_HOME when present, and only create a fake home if needed.

@reviewbybees 