### PR TITLE
[JENKINS-35307] Discriminate Jenkins version for certain UI aspects when creating/copying jobs

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
@@ -78,6 +78,13 @@ public class Jenkins extends Node {
 
         return version = new VersionNumber(text);
     }
+    
+    /**
+     * Tells if Jenkins version under test is 1.X
+     */
+    public boolean isJenkins1X() {
+        return getVersion().isOlderThan(new VersionNumber("2.0"));
+    }
 
     /**
      * Access global configuration page.

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -2,6 +2,7 @@ package org.jenkinsci.test.acceptance.po;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import static org.jenkinsci.test.acceptance.po.CapybaraPortingLayer.by;
 
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
@@ -21,19 +22,7 @@ public class JobsMixIn extends MixIn {
         visit("newJob");
         fillIn("name", name);
 
-        findCaption(type, new Finder<WebElement>() {
-            @Override protected WebElement find(String caption) {
-                try {
-                    // Jenkins 2.0 introduced a new "new item" page, which listed
-                    // the item types differently and did away with the radio buttons.
-                    String normalizedCaption = caption.replace('.', '_');
-                    return outer.find(by.css("li." + normalizedCaption));
-                } catch (NoSuchElementException e) {
-                    // Jenkins 1.x item type selection was by radio button.
-                    return outer.find(by.radioButton(caption));
-                }
-            }
-        }).click();
+        findCaption(type, getFinder()).click();
 
         clickButton("OK");
         // Sometimes job creation is not fast enough, so make sure it's finished before continue
@@ -79,7 +68,30 @@ public class JobsMixIn extends MixIn {
         visit("newJob");
         fillIn("name",to);
         fillIn("from",from);
-        choose("copy");
+        if (getJenkins().isJenkins1X()) { 
+            // no radio buttons on Jenkins 2.X
+            choose("copy");
+        }
         clickButton("OK");
+    }
+    
+    // Jenkins 1.x item type selection was by radio button.
+    final Finder<WebElement> finder1X = new Finder<WebElement>() {
+        @Override protected WebElement find(String caption) {
+            return outer.find(by.radioButton(caption));
+        }
+    };
+    
+    // Jenkins 2.0 introduced a new "new item" page, which listed
+    // the item types differently and did away with the radio buttons.
+    final Finder<WebElement> finder2X = new Finder<WebElement>() {
+        @Override protected WebElement find(String caption) {
+            String normalizedCaption = caption.replace('.', '_');
+            return outer.find(by.css("li." + normalizedCaption));
+        }
+    };
+    
+    private Finder<WebElement> getFinder() {
+        return getJenkins().isJenkins1X() ? finder1X : finder2X;
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -2,9 +2,7 @@ package org.jenkinsci.test.acceptance.po;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import static org.jenkinsci.test.acceptance.po.CapybaraPortingLayer.by;
-
-import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 /**
@@ -71,6 +69,9 @@ public class JobsMixIn extends MixIn {
         if (getJenkins().isJenkins1X()) { 
             // no radio buttons on Jenkins 2.X
             choose("copy");
+        } else {
+            // a bit hacky: send a tab to enable the OK button
+            find(By.name("from")).sendKeys("\t");
         }
         clickButton("OK");
     }


### PR DESCRIPTION
Reopened [JENKINS-35307](https://issues.jenkins-ci.org/browse/JENKINS-35307) to make the test work for Jenkins `2.x` as well.

Follow up to https://github.com/jenkinsci/acceptance-test-harness/pull/112.

@reviewbybees esp @abayer @recena @tfennelly 