### PR TITLE
[JENKINS-36928] Job PO does not accurately reflects the real job underlying state

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/nodelabelparameter/LabelParameter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/nodelabelparameter/LabelParameter.java
@@ -7,7 +7,7 @@ import org.jenkinsci.test.acceptance.po.Parameter;
 /**
  * @author Kohsuke Kawaguchi
  */
-@Describable("Label")
+@Describable({"Label", "org.jvnet.jenkins.plugins.nodelabelparameter.LabelParameterDefinition"})
 public class LabelParameter extends Parameter {
     public LabelParameter(Job job, String path) {
         super(job, path);

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/nodelabelparameter/NodeParameter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/nodelabelparameter/NodeParameter.java
@@ -12,7 +12,7 @@ import org.openqa.selenium.WebElement;
 /**
  * @author Kohsuke Kawaguchi
  */
-@Describable("Node")
+@Describable({"Node", "org.jvnet.jenkins.plugins.nodelabelparameter.NodeParameterDefinition"})
 public class NodeParameter extends Parameter {
     public final Control runIfSuccess = control("triggerIfResult[success]");
     public final Control runIfUnstable = control("triggerIfResult[unstable]");

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -298,6 +298,7 @@ public class Job extends TopLevelItem {
     public Build scheduleBuild(Map<String, ?> params) {
         open();
         int nb = getJson().get("nextBuildNumber").intValue();
+        List<Parameter> parameters = getParameters();
         if (parameters.isEmpty()) {
             clickLink("Build Now");
         } else {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -499,9 +499,7 @@ public class Job extends TopLevelItem {
                     for (String value : captions) {
                         if (elementText.contains(value)) {
                             Parameter param = newInstance(paramClass, Job.this, paramElement.getAttribute("path"));
-                            param.setName(param.control("name").resolve().getAttribute("value"));
-                            param.setDefault(param.control("defaultValue").text());
-                            param.setDescription(param.control("description").text());
+                            param.setNameProperty(param.control("name").resolve().getAttribute("value"));
                             parameters.add(param);
                         }
                     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -490,7 +490,7 @@ public class Job extends TopLevelItem {
             fillJobParams(Arrays.asList(paramClasses));
         }
 
-        private void fillJobParams(List<Class<? extends Parameter>> paramClasses) {
+        protected void fillJobParams(List<Class<? extends Parameter>> paramClasses) {
             List<WebElement> paramElements = driver.findElements(by.xpath("//div[starts-with(@path,'/properties/hudson-model-ParametersDefinitionProperty/parameter')]"));
             for (WebElement paramElement : paramElements) {
                 String elementText = paramElement.getText();

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -439,5 +439,4 @@ public class Job extends TopLevelItem {
         clickLink("Delete Project");
         confirmAlert(2);
     }
-    
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -8,8 +8,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -27,9 +29,9 @@ import org.jenkinsci.test.acceptance.controller.LocalController;
 import org.jenkinsci.test.acceptance.junit.Resource;
 import org.junit.internal.AssumptionViolatedException;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.zeroturnaround.zip.ZipUtil;
 
+import com.google.common.reflect.ClassPath;
 import com.google.inject.Injector;
 
 import cucumber.api.DataTable;
@@ -44,6 +46,7 @@ import static org.jenkinsci.test.acceptance.Matchers.*;
  * @author Kohsuke Kawaguchi
  */
 public class Job extends TopLevelItem {
+    private JobParameterHelper jobParamHelper = new JobParameterHelper();
     public List<Parameter> getParameters() {
         return parameters;
     }
@@ -417,5 +420,94 @@ public class Job extends TopLevelItem {
         this.open();
         clickLink("Delete Project");
         confirmAlert(2);
+    }
+
+    /**
+     * Loads all existing build parameters of the specified type into this Job object. Useful is this Job has been copied/moved or promoted
+     * @param paramClasses The {@link org.jenkinsci.test.acceptance.po.Parameter} subtypes to load
+     */
+    public void loadExistingBuildParameters(Class<? extends Parameter>... paramClasses) {
+        ensureConfigPage();
+        jobParamHelper.loadJobParams(paramClasses);
+    }
+
+    /**
+     * Loads all existing build parameters of any type inside the scanningPaths into this Job object. Useful is this Job
+     * has been copied/moved or promoted
+     * @param scanningPaths The packages to scan for {@link org.jenkinsci.test.acceptance.po.Parameter} subtypes to load
+     */
+    public void loadExistingBuildParameters(String... scanningPaths) {
+        ensureConfigPage();
+        jobParamHelper.loadJobParams(scanningPaths);
+    }
+
+
+    /**
+     * Helper class to fill the Job`s PO build parameters from the existing ones in the config UI, usefull when a Job
+     * has been copied, moved or promoted.
+     *
+     * Since the number and type of params is variable this class needs to known in advance the types of the parameters
+     * to load (for example {@link org.jenkinsci.test.acceptance.po.StringParameter}) or perform a classpath scan for
+     * {@link org.jenkinsci.test.acceptance.po.Parameter} subtypes before loading them.
+     */
+    protected class JobParameterHelper {
+
+        /**
+         * Scans the given packages for {@link org.jenkinsci.test.acceptance.po.Parameter} subtypes. It only scans for
+         * top level classes, that is no nested classes are included in the scan results.
+         * This implementation does not perform any type of catching of the results, is responsability of the caller
+         * to do that if neccesary.
+         *
+         * @param paths The package names to scan for {@link org.jenkinsci.test.acceptance.po.Parameter} subtypes
+         * @return A list of all the {@link org.jenkinsci.test.acceptance.po.Parameter} subtypes found in the given
+         * packages
+         */
+        public List<Class<? extends Parameter>> scan(String... paths) {
+            List<Class<? extends Parameter>> parametersClasses = new LinkedList<>();
+            try {
+                for (String path : paths) {
+                    List<ClassPath.ClassInfo> paramClasses = ClassPath.from(Parameter.class.getClassLoader()).getTopLevelClasses(path).asList();
+                    for (ClassPath.ClassInfo info : paramClasses) {
+                        Class<?> clazz = info.load();
+                        if (!clazz.equals(Parameter.class) && Parameter.class.isAssignableFrom(clazz)) {
+                            parametersClasses.add((Class<? extends Parameter>)clazz);
+                        }
+                    }
+                }
+                return parametersClasses;
+            } catch (IOException e) {
+                throw new Error(e);
+            }
+
+        }
+
+        public void loadJobParams(String... pathsToScan) {
+            List<Class<? extends Parameter>> paramClasses = scan(pathsToScan);
+            fillJobParams(paramClasses);
+        }
+
+        public void loadJobParams(Class<? extends Parameter>... paramClasses) {
+            fillJobParams(Arrays.asList(paramClasses));
+        }
+
+        private void fillJobParams(List<Class<? extends Parameter>> paramClasses) {
+            List<WebElement> paramElements = driver.findElements(by.xpath("//div[starts-with(@path,'/properties/hudson-model-ParametersDefinitionProperty/parameter')]"));
+            for (WebElement paramElement : paramElements) {
+                String elementText = paramElement.getText();
+                for (Class<? extends Parameter> paramClass : paramClasses) {
+                    String[] captions = paramClass.getAnnotation(Describable.class).value();
+                    for (String value : captions) {
+                        if (elementText.contains(value)) {
+                            Parameter param = newInstance(paramClass, Job.this, paramElement.getAttribute("path"));
+                            param.setName(param.control("name").resolve().getAttribute("value"));
+                            param.setDefault(param.control("defaultValue").text());
+                            param.setDescription(param.control("description").text());
+                            parameters.add(param);
+                        }
+                    }
+                }
+
+            }
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Parameter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Parameter.java
@@ -2,20 +2,30 @@ package org.jenkinsci.test.acceptance.po;
 
 import org.openqa.selenium.By;
 
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  * Parameter for builds.
  * <p/>
- * Use {@link Describable} annotation to register an implementation.
+ * Use {@link Describable} annotation to register an implementation. The value of {@link Describable} must be the
+ * corresponding caption of the add parameter menu item AND the corresponding {@link hudson.model.ParameterDefinition}
+ * class. For example {"String Parameter", "hudson.model.StringParameterDefinition"}
  *
  * @author Kohsuke Kawaguchi
  */
 public abstract class Parameter extends PageAreaImpl {
+    private static List<Class<? extends Parameter>> subtypes = new LinkedList<>();
+
     public final Job job;
     private String name;
 
     public Parameter(Job job, String path) {
         super(job, path);
         this.job = job;
+        if (!Parameter.subtypes.contains(this.getClass())) {
+            Parameter.subtypes.add(this.getClass());
+        }
     }
 
     public String getName() {
@@ -63,5 +73,9 @@ public abstract class Parameter extends PageAreaImpl {
         String np = driver.findElement(by.xpath("//input[@name='name' and @value='%s']", name)).getAttribute("path");
         String path = np.replaceAll("/name$", "") + "/" + rel;
         return by.path(path);
+    }
+
+    public static List<Class<? extends Parameter>> all() {
+        return Parameter.subtypes;
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Parameter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Parameter.java
@@ -28,6 +28,13 @@ public abstract class Parameter extends PageAreaImpl {
         return this;
     }
 
+    /**
+     * Sets this objects name property without modifying the UI
+     */
+    void setNameProperty(String name) {
+        this.name = name;
+    }
+
     public Parameter setDescription(String v) {
         control("description").set(v);
         return this;

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Parameter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Parameter.java
@@ -14,6 +14,7 @@ import java.util.List;
  *
  * @author Kohsuke Kawaguchi
  */
+//TODO remove the caption value from @Describable once the addParameter method can ignore it
 public abstract class Parameter extends PageAreaImpl {
     private static List<Class<? extends Parameter>> subtypes = new LinkedList<>();
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/StringParameter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/StringParameter.java
@@ -3,7 +3,7 @@ package org.jenkinsci.test.acceptance.po;
 /**
  * @author Kohsuke Kawaguchi
  */
-@Describable("String Parameter")
+@Describable({"String Parameter", "hudson.model.StringParameterDefinition"})
 public class StringParameter extends Parameter {
     public StringParameter(Job job, String path) {
         super(job, path);

--- a/src/test/java/core/CopyJobTest.java
+++ b/src/test/java/core/CopyJobTest.java
@@ -2,11 +2,13 @@ package core;
 
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+import org.jenkinsci.test.acceptance.po.StringParameter;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasContent;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Feature: Copy a job
@@ -35,5 +37,27 @@ public class CopyJobTest extends AbstractJUnitTest {
         String kxml = driver.getPageSource();
 
         assertThat(jxml, is(kxml));
+    }
+
+    @Test
+    public void copy_a_simple_job_loads_build_params() {
+        FreeStyleJob j = jenkins.jobs.create(FreeStyleJob.class, "simple-job");
+        j.configure();
+        j.addParameter(StringParameter.class).setName("Param1").setDefault("");
+        j.addParameter(StringParameter.class).setName("Param2").setDefault("");
+        j.save();
+        jenkins.jobs.copy(j, "simple-job-copy");
+        assertThat(driver, hasContent("simple-job-copy"));
+
+        FreeStyleJob k = jenkins.jobs.get(FreeStyleJob.class, "simple-job-copy");
+        k.loadExistingBuildParameters(StringParameter.class);
+        j.visit("config.xml");
+        String jxml = driver.getPageSource();
+
+        k.visit("config.xml");
+        String kxml = driver.getPageSource();
+
+        assertThat(jxml, is(kxml));
+        assertTrue(k.getParameters().size() == j.getParameters().size());
     }
 }

--- a/src/test/java/core/CopyJobTest.java
+++ b/src/test/java/core/CopyJobTest.java
@@ -2,6 +2,7 @@ package core;
 
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+import org.jenkinsci.test.acceptance.po.Parameter;
 import org.jenkinsci.test.acceptance.po.StringParameter;
 import org.junit.Test;
 
@@ -45,12 +46,12 @@ public class CopyJobTest extends AbstractJUnitTest {
         j.configure();
         j.addParameter(StringParameter.class).setName("Param1").setDefault("");
         j.addParameter(StringParameter.class).setName("Param2").setDefault("");
+        assertTrue(Parameter.all().size() > 0);
         j.save();
         jenkins.jobs.copy(j, "simple-job-copy");
         assertThat(driver, hasContent("simple-job-copy"));
 
         FreeStyleJob k = jenkins.jobs.get(FreeStyleJob.class, "simple-job-copy");
-        k.loadExistingBuildParameters(StringParameter.class);
         j.visit("config.xml");
         String jxml = driver.getPageSource();
 

--- a/src/test/java/core/CopyJobTest.java
+++ b/src/test/java/core/CopyJobTest.java
@@ -58,6 +58,8 @@ public class CopyJobTest extends AbstractJUnitTest {
         String kxml = driver.getPageSource();
 
         assertThat(jxml, is(kxml));
+        assertTrue(k.getParameters().size() > 0);
         assertTrue(k.getParameters().size() == j.getParameters().size());
+        assertTrue(k.getParameters().get(0).getName().equals(j.getParameters().get(0).getName()));
     }
 }


### PR DESCRIPTION
[JENKINS-36928](https://issues.jenkins-ci.org/browse/JENKINS-36928)

Instead of making a Job always aware of the Build Parameters I have decided to add the ability for the job to load them on demand to minimize impact on existing code. This way only tests that need that need to be modified and the general contract of Job is simply extended instead of modified. So with this PR a Job can load it's existing Build Parameters as follow:

``` @Test
    public void copy_a_simple_job_loads_build_params() {
        FreeStyleJob j = jenkins.jobs.create(FreeStyleJob.class, "simple-job");
        j.configure();
        j.addParameter(StringParameter.class).setName("Param1").setDefault("");
        j.addParameter(StringParameter.class).setName("Param2").setDefault("");
        j.save();
        jenkins.jobs.copy(j, "simple-job-copy");
        assertThat(driver, hasContent("simple-job-copy"));

        FreeStyleJob k = jenkins.jobs.get(FreeStyleJob.class, "simple-job-copy");
        k.loadExistingBuildParameters(StringParameter.class);
        j.visit("config.xml");
        String jxml = driver.getPageSource();

        k.visit("config.xml");
        String kxml = driver.getPageSource();

        assertThat(jxml, is(kxml));
        assertTrue(k.getParameters().size() == j.getParameters().size());
    }
```

Any suggestion/complaint about this approach is more than welcome, especially in the case of specializing the parameter load for custom Job types.

@reviewbybees 
