### PR TITLE
[FIXED JENKINS-37232] - starting with 2.7 the ATH began to fail during create item

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayer.java
@@ -87,6 +87,11 @@ public interface CapybaraPortingLayer {
     void check(WebElement e, boolean state);
 
     /**
+     * Sends a blur event to the provided element
+     */
+    void blur(WebElement e);
+
+    /**
      * Finds all the elements that match the selector.
      * <p/>
      * <p/>

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -283,6 +283,17 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
         }
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public void blur(WebElement e) {
+        executeScript(
+            "var obj = arguments[0];"
+            + "var ev = document.createEvent('MouseEvents');"
+            + "ev.initEvent('blur', true, false);"
+            + "obj.dispatchEvent(ev);"
+            + "return true;", e);
+    }
+
     /**
      * Finds all the elements that match the selector.
      * <p/>

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -24,6 +24,7 @@ public class JobsMixIn extends MixIn {
 
         // since 2.7, a bug in Firefox webdriver may prevent the blur event from triggering
         // properly, so we manually execute a blur event here, see: JENKINS-37232
+        // See: https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/7346
         try {
             executeScript(
                 "var obj = document.getElementById('name');"
@@ -31,7 +32,7 @@ public class JobsMixIn extends MixIn {
                 + "ev.initEvent('blur', true, false);"
                 + "obj.dispatchEvent(ev);"
                 + "return true;");
-        } catch(Exception e) {
+        } catch (Exception e) {
             // This should rarely fail on modern browsers,
             // we don't really care if it does since Firefox was 
             // the only one that seemed to exhibit the issue

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -26,12 +26,7 @@ public class JobsMixIn extends MixIn {
         // properly, so we manually execute a blur event here, see: JENKINS-37232
         // See: https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/7346
         try {
-            executeScript(
-                "var obj = document.getElementById('name');"
-                + "var ev = document.createEvent('MouseEvents');"
-                + "ev.initEvent('blur', true, false);"
-                + "obj.dispatchEvent(ev);"
-                + "return true;");
+            blur(find(By.name("name")));
         } catch (Exception e) {
             // This should rarely fail on modern browsers,
             // we don't really care if it does since Firefox was 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -22,6 +22,21 @@ public class JobsMixIn extends MixIn {
 
         findCaption(type, getFinder()).click();
 
+        // since 2.7, a bug in Firefox webdriver may prevent the blur event from triggering
+        // properly, so we manually execute a blur event here, see: JENKINS-37232
+        try {
+            executeScript(
+                "var obj = document.getElementById('name');"
+                + "var ev = document.createEvent('MouseEvents');"
+                + "ev.initEvent('blur', true, false);"
+                + "obj.dispatchEvent(ev);"
+                + "return true;");
+        } catch(Exception e) {
+            // This should rarely fail on modern browsers,
+            // we don't really care if it does since Firefox was 
+            // the only one that seemed to exhibit the issue
+        }
+
         clickButton("OK");
         // Sometimes job creation is not fast enough, so make sure it's finished before continue
         waitFor(by.name("config"), 10);


### PR DESCRIPTION
[JENKINS-37232](http://issues.jenkins-ci.org/browse/JENKINS-37232)

Firefox has an issue sending blur events when running the ATH. This simulates the blur event for a specific field that needs it during item creation.

@reviewbybees