### PR TITLE
Wait for the agent to come back online before we even try to resume the build

### DIFF
--- a/src/test/java/plugins/WorkflowPluginTest.java
+++ b/src/test/java/plugins/WorkflowPluginTest.java
@@ -116,10 +116,10 @@ public class WorkflowPluginTest extends AbstractJUnitTest {
         });
         build.shouldContainsConsoleOutput("Building version 1.0-SNAPSHOT");
         jenkins.restart();
+        // Default 120s timeout of Build.waitUntilFinished sometimes expires waiting for RetentionStrategy.Always to tick (after initial failure of CommandLauncher.launch: EOFException: unexpected stream termination):
+        slave.waitUntilOnline(); // TODO rather wait for build output: "Ready to run"
         visit(build.getConsoleUrl());
         clickLink("Proceed");
-        // Default 120s timeout of Build.waitUntilFinished sometimes expires waiting for RetentionStrategy.Always to tick (after initial failure of CommandLauncher.launch: EOFException: unexpected stream termination):
-        slave.waitUntilOnline();
         try {
             build.shouldSucceed();
         } catch (AssertionError x) {


### PR DESCRIPTION
Complements https://github.com/jenkinsci/pipeline-input-step-plugin/pull/2 by being more robust against JENKINS-37154-related behavior. Would benefit from https://github.com/jenkinsci/workflow-cps-plugin/pull/40.

@reviewbybees