### PR TITLE
[JENKINS-37615] Honor context PageObject when looking for Jenkins instance

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ContainerPageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ContainerPageObject.java
@@ -32,7 +32,10 @@ public abstract class ContainerPageObject extends ConfigurablePageObject {
     }
 
     protected ContainerPageObject(PageObject context, URL url) {
-        this(context.injector, url);
+        super(context, url);
+        if (!url.toExternalForm().endsWith("/")) {
+            throw new IllegalArgumentException("URL should end with '/': " + url);
+        }
     }
 
     public URL getJsonApiUrl() {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
@@ -42,6 +42,11 @@ public class Jenkins extends Node {
         slaves = new SlavesMixIn(this);
     }
 
+    @Override
+    public Jenkins getJenkins() {
+        return this;
+    }
+
     public Jenkins(Injector injector, JenkinsController controller) {
         this(injector, startAndGetUrl(controller));
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PageObject.java
@@ -32,6 +32,12 @@ public abstract class PageObject extends CapybaraPortingLayerImpl {
      * @see ContainerPageObject#url(String) Method that lets you resolve relative paths easily.
      */
     public final URL url;
+    
+    /**
+     * If the object was created with some context, preserve it so that we can
+     * easily get the real Jenkins root
+     */
+    private PageObject context;
 
     private static final RandomNameGenerator RND = new RandomNameGenerator();
 
@@ -42,6 +48,7 @@ public abstract class PageObject extends CapybaraPortingLayerImpl {
 
     protected PageObject(PageObject context, URL url) {
         this(context.injector, url);
+        this.context = context;
     }
 
     public static String createRandomName() {
@@ -49,6 +56,9 @@ public abstract class PageObject extends CapybaraPortingLayerImpl {
     }
 
     public Jenkins getJenkins() {
+        if (context != null) {
+            return context.getJenkins();
+        }
         // TODO try to find the real Jenkins root according to the owner of this object, via breadcrumb
         // Alternately, Job could have a method to get Jenkins by appending ../../ to its own URL, if not in a folder (need a separate method to find folder owner, but that needs its own page object too)
         return injector.getInstance(Jenkins.class);


### PR DESCRIPTION
Proposal for [JENKINS-37615](https://issues.jenkins-ci.org/browse/JENKINS-37615).

Save page object context when received in constructor, and use it later to find the real Jenkins instance associated with the element, if available.

@reviewbybees 