### PR TITLE
Stabilisation

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ant/AntInstallation.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ant/AntInstallation.java
@@ -40,7 +40,7 @@ public class AntInstallation extends ToolInstallation {
 
     public String useNative() {
         String antHome = System.getenv("ANT_HOME");
-        if (antHome.trim().isEmpty()) {
+        if (antHome == null || antHome.trim().isEmpty()) {
             antHome =  fakeHome("ant", "ANT_HOME");
         }
         installedIn(antHome);

--- a/src/test/java/plugins/AntPluginTest.java
+++ b/src/test/java/plugins/AntPluginTest.java
@@ -17,6 +17,10 @@ import java.util.regex.Pattern;
 @SuppressWarnings("CdiInjectionPointsInspection")
 @WithPlugins("ant")
 public class AntPluginTest extends AbstractJUnitTest {
+
+    public static final String INSTALL_VERSION_1_8 = "1.8.4";
+    public static final String INSTALL_NAME_1_8 = "ant_" + INSTALL_VERSION_1_8;
+
     FreeStyleJob job;
 
     @Before
@@ -31,10 +35,10 @@ public class AntPluginTest extends AbstractJUnitTest {
 
     @Test
     public void autoInstallAnt() {
-        AntInstallation.install(jenkins, "ant_1.8.4", "1.8.4");
+        AntInstallation.install(jenkins, INSTALL_NAME_1_8, INSTALL_VERSION_1_8);
 
-        buildHelloWorld("ant_1.8.4").shouldContainsConsoleOutput(
-                "Unpacking http://archive.apache.org/dist/ant/binaries/apache-ant-1.8.4-bin.zip"
+        buildHelloWorld(INSTALL_NAME_1_8).shouldContainsConsoleOutput(
+            "Unpacking (http|https)://archive.apache.org/dist/ant/binaries/apache-ant-" + INSTALL_VERSION_1_8 + "-bin.zip"
         );
     }
 

--- a/src/test/java/plugins/SshSlavesPluginTest.java
+++ b/src/test/java/plugins/SshSlavesPluginTest.java
@@ -48,6 +48,9 @@ import org.junit.experimental.categories.Category;
 @Category(DockerTest.class)
 @WithDocker
 public class SshSlavesPluginTest extends AbstractJUnitTest {
+
+    public static final String REMOTE_FS = "/tmp";
+
     @Inject private DockerContainerHolder<JavaContainer> docker;
 
     private SshdContainer sshd;
@@ -58,6 +61,7 @@ public class SshSlavesPluginTest extends AbstractJUnitTest {
 
         slave = jenkins.slaves.create(DumbSlave.class);
         slave.setExecutors(1);
+        slave.remoteFS.set(REMOTE_FS);
     }
 
     @Test public void connectWithPassword() {
@@ -123,7 +127,7 @@ public class SshSlavesPluginTest extends AbstractJUnitTest {
         
         
         verify();
-        verifyLog("sh -c \"cd \"/tmp/" + slave.getName() + "\" && java  -jar slave.jar\"");
+        verifyLog("sh -c \"cd \"" + REMOTE_FS + "\" && java  -jar slave.jar\"");
     }
         
     private void verify() {


### PR DESCRIPTION
Some minor tweaks helping to stabilise the execution of ATH. 

* A valid path is used as value of "Remote FS dir" for docker containers 
* Ant plugin tests should work correctly when ANT_HOME is not set at all 