### PR TITLE
[JENKINS-38058] pass context when creating 'FolderItem' objects

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/FolderItem.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/FolderItem.java
@@ -39,5 +39,10 @@ public class FolderItem extends TopLevelItem {
         super(injector, url, name);
         jobs = new JobsMixIn(this);
     }
+    
+    public FolderItem(PageObject context, URL url, String name) {
+        super(context, url, name);
+        jobs = new JobsMixIn(this);
+    }
 
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -65,6 +65,10 @@ public class Job extends TopLevelItem {
         super(injector, url, name);
     }
 
+    public Job(PageObject context, URL url, String name) {
+        super(context, url, name);
+    }
+    
     public <T extends Scm> T useScm(Class<T> type) {
         ensureConfigPage();
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -58,7 +58,14 @@ public class JobsMixIn extends MixIn {
     }
 
     public <T extends TopLevelItem> T get(Class<T> type, String name) {
-        return newInstance(type, injector, url("job/%s/", name), name);
+        try {
+            assert getContext() != null;
+            return newInstance(type, getContext(), url("job/%s/", name), name);
+        } catch (AssertionError e) {
+            // will get here either if the contructor with 'context' parameter
+            // was not found or if we have no context
+            return newInstance(type, injector, url("job/%s/", name), name);
+        }
     }
 
     public FreeStyleJob create() {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.test.acceptance.po;
 
+import java.net.URL;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import org.openqa.selenium.By;
@@ -58,14 +59,23 @@ public class JobsMixIn extends MixIn {
     }
 
     public <T extends TopLevelItem> T get(Class<T> type, String name) {
-        try {
-            assert getContext() != null;
+        if (contextAvailable() && typeAcceptsContext(type)) {
             return newInstance(type, getContext(), url("job/%s/", name), name);
-        } catch (AssertionError e) {
-            // will get here either if the contructor with 'context' parameter
-            // was not found or if we have no context
-            return newInstance(type, injector, url("job/%s/", name), name);
         }
+        return newInstance(type, injector, url("job/%s/", name), name);
+    }
+
+    private <T extends TopLevelItem> boolean typeAcceptsContext(Class<T> type) {
+        try {
+            type.getConstructor(PageObject.class, URL.class, String.class);
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    private boolean contextAvailable() {
+        return getContext() != null;
     }
 
     public FreeStyleJob create() {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PageObject.java
@@ -115,4 +115,8 @@ public abstract class PageObject extends CapybaraPortingLayerImpl {
     public String toString() {
         return String.format("%s(%s)", getClass().getSimpleName(), url);
     }
+
+    protected PageObject getContext() {
+        return context;
+    }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
@@ -28,6 +28,11 @@ public abstract class TopLevelItem extends ContainerPageObject {
         this.name = name;
     }
 
+    public TopLevelItem(PageObject context, URL url, String name) {
+        super(context, url);
+        this.name = name;
+    }
+
     /**
      * Renames the job. Opens the configuration section, sets the name and saves the form. Finally the rename is
      * confirmed.


### PR DESCRIPTION
[JENKINS-38058](https://issues.jenkins-ci.org/browse/JENKINS-38058)

Passing context page object to folders so that we can retrieve the real Jenkins instance later on

@reviewbybees 