### PR TITLE
Skip tests that are not related to a set of 'interesting' plugins

### DIFF
--- a/docs/ONLY_FOR_PLUGINS.md
+++ b/docs/ONLY_FOR_PLUGINS.md
@@ -1,0 +1,11 @@
+# Running only tests related to certain plugins
+
+Sometime you may want to run tests related to certain plugins. For that you can set the `ONLY_FOR_PLUGINS` to
+the comma-separated list of plugins id's you are interested in.
+
+When this variable is set plugins which does not have a `WithPlugins` annotation that includes
+one of the provided plugins or plugins that depend on those will be skipped.
+
+Please be aware that plugins not using the `JenkinsAcceptanceRule` are not affected and will be
+executed unless excluded in some other way.
+


### PR DESCRIPTION
This PR includes a new configuration option (see docs/ONLY_FOR_PLUGINS.md) that let's you skip tests that are not related to a set of specific plugins.

For a test to be considered "related" it must have a `WithPlugins` annotation that include any of the specified plugins or any plugin that depends on them.
