### PR TITLE
[JENKINS-37276] Path atributes can change values if reordered

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -251,7 +251,7 @@ public class FallbackConfig extends AbstractModule {
     @Named("form-element-path.hpi") @Provides
     public File getFormElementsPathFile(RepositorySystem repositorySystem, RepositorySystemSession repositorySystemSession) {
         ArtifactResolverUtil resolverUtil = new ArtifactResolverUtil(repositorySystem, repositorySystemSession);
-        ArtifactResult resolvedArtifact = resolverUtil.resolve(new DefaultArtifact("org.jenkins-ci.plugins", "form-element-path", "hpi", "1.4"));
+        ArtifactResult resolvedArtifact = resolverUtil.resolve(new DefaultArtifact("org.jenkins-ci.plugins", "form-element-path", "hpi", "1.7-alpha-1"));
         return resolvedArtifact.getArtifact().getFile();
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -137,7 +137,7 @@ public class Job extends TopLevelItem {
         elasticSleep(1000); // it takes some time until the element is visible
         String path = null;
         // if I have got a Describable use it to get the path
-        if (describableValue != null) {
+        if (describableValue != null && type.equals(PostBuildStep.class)) {
             List<WebElement> newSteps = driver.findElements(by.xpath("//div[@name='%s']", section));
             outer:
             for (WebElement element : newSteps) {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -137,7 +137,7 @@ public class Job extends TopLevelItem {
         elasticSleep(1000); // it takes some time until the element is visible
         String path = null;
         // if I have got a Describable use it to get the path
-        if (describableValue != null && type.equals(PostBuildStep.class)) {
+        if (describableValue != null && PostBuildStep.class.isAssignableFrom(type)) {
             List<WebElement> newSteps = driver.findElements(by.xpath("//div[@name='%s']", section));
             outer:
             for (WebElement element : newSteps) {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -128,11 +128,31 @@ public class Job extends TopLevelItem {
     private <T extends Step> T addStep(Class<T> type, String section) {
         ensureConfigPage();
 
+        // get @Describable value to use later to retrieve the path
+        String[] describableValue = null;
+        if (type.isAnnotationPresent(Describable.class)) {
+            describableValue = type.getAnnotation(Describable.class).value();
+        }
         control(by.path("/hetero-list-add[%s]", section)).selectDropdownMenu(type);
         elasticSleep(1000); // it takes some time until the element is visible
-        WebElement last = last(by.xpath("//div[@name='%s']", section));
-        String path = last.getAttribute("path");
-
+        String path = null;
+        // if I have got a Describable use it to get the path
+        if (describableValue != null) {
+            List<WebElement> newSteps = driver.findElements(by.xpath("//div[@name='%s']", section));
+            outer:
+            for (WebElement element : newSteps) {
+                for (String s : describableValue) {
+                    if (element.getText().contains(s)) {
+                        path = element.getAttribute("path");
+                        break outer;
+                    }
+                }
+            }
+        } else {
+            // on the other case just use the last element
+            WebElement last = last(by.xpath("//div[@name='%s']", section));
+            path = last.getAttribute("path");
+        }
         return newInstance(type, this, path);
     }
 

--- a/src/test/java/core/PublisherOrderTest.java
+++ b/src/test/java/core/PublisherOrderTest.java
@@ -1,0 +1,55 @@
+package core;
+
+import org.apache.commons.lang.SystemUtils;
+import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.jenkinsci.test.acceptance.po.AggregateDownstreamTestResults;
+import org.jenkinsci.test.acceptance.po.ArtifactArchiver;
+import org.jenkinsci.test.acceptance.po.BuildTrigger;
+import org.jenkinsci.test.acceptance.po.Fingerprint;
+import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+import org.junit.Test;
+
+public class PublisherOrderTest extends AbstractJUnitTest {
+
+    @Test
+    public void testOrdered() {
+        FreeStyleJob upstream = jenkins.jobs.create(FreeStyleJob.class);
+        upstream.configure();
+        String command = "echo 'hello' > aggregate.txt";
+        if(SystemUtils.IS_OS_UNIX) {
+            upstream.addShellStep(command);
+        } else {
+            upstream.addBatchStep(command);
+        }
+        AggregateDownstreamTestResults aggregate = upstream.addPublisher(AggregateDownstreamTestResults.class);
+        aggregate.specify.check();
+        ArtifactArchiver archiver = upstream.addPublisher(ArtifactArchiver.class);
+        archiver.includes("aggregate.txt");
+        BuildTrigger trigger = upstream.addPublisher(BuildTrigger.class);
+        trigger.childProjects.set("projectName");
+        Fingerprint fingerprint = upstream.addPublisher(Fingerprint.class);
+        fingerprint.targets.set("aggregate.txt");
+        upstream.save();
+    }
+
+    @Test
+    public void testUnordered() {
+        FreeStyleJob upstream = jenkins.jobs.create(FreeStyleJob.class);
+        upstream.configure();
+        String command = "echo 'hello' > aggregate.txt";
+        if(SystemUtils.IS_OS_UNIX) {
+            upstream.addShellStep(command);
+        } else {
+            upstream.addBatchStep(command);
+        }
+        ArtifactArchiver archiver = upstream.addPublisher(ArtifactArchiver.class);
+        archiver.includes("aggregate.txt");
+        BuildTrigger trigger = upstream.addPublisher(BuildTrigger.class);
+        trigger.childProjects.set("projectName");
+        Fingerprint fingerprint = upstream.addPublisher(Fingerprint.class);
+        fingerprint.targets.set("aggregate.txt");
+        AggregateDownstreamTestResults aggregate = upstream.addPublisher(AggregateDownstreamTestResults.class);
+        aggregate.specify.check();
+        upstream.save();
+    }
+}

--- a/src/test/java/core/PublisherOrderTest.java
+++ b/src/test/java/core/PublisherOrderTest.java
@@ -7,6 +7,7 @@ import org.jenkinsci.test.acceptance.po.ArtifactArchiver;
 import org.jenkinsci.test.acceptance.po.BuildTrigger;
 import org.jenkinsci.test.acceptance.po.Fingerprint;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+import org.jenkinsci.test.acceptance.po.JUnitPublisher;
 import org.junit.Test;
 
 public class PublisherOrderTest extends AbstractJUnitTest {
@@ -50,6 +51,11 @@ public class PublisherOrderTest extends AbstractJUnitTest {
         fingerprint.targets.set("aggregate.txt");
         AggregateDownstreamTestResults aggregate = upstream.addPublisher(AggregateDownstreamTestResults.class);
         aggregate.specify.check();
+        fingerprint.targets.set("another.txt");
         upstream.save();
+        upstream.configure();
+        archiver.includes("another.txt");
+        JUnitPublisher junit = upstream.addPublisher(JUnitPublisher.class);
+        fingerprint.targets.set("yetanother");
     }
 }


### PR DESCRIPTION
[JENKINS-37276](https://issues.jenkins-ci.org/browse/JENKINS-37276)

Downstream of [PR-5](https://github.com/jenkinsci/form-element-path-plugin/pull/5)

I am not very sure about the `getText().contains` part, but as long as I see I only have four alternatives:

* The `getText().contains` one
* Modify @Describable value in the same way that the proposed by #162 
* Implement any other suggestion
* Let the things like they are because there is a very easy workaround for the bug

Option 2 seems not to have a lot of supporters given the time the PR has been open without activity
I am open to option 3 as soon as I receive a better alternative approach
I am also open to option 4 if anyone considers that this bug is not important or worth the risk

@reviewbybees specially @jglick 
Also @olivergondza opinion would be great here 
