### PR TITLE
[JENKINS-39504] PmdPluginTest might fail due to plugins installation order

### DIFF
--- a/src/test/java/plugins/AbstractAnalysisTest.java
+++ b/src/test/java/plugins/AbstractAnalysisTest.java
@@ -693,6 +693,16 @@ public abstract class AbstractAnalysisTest<P extends AnalysisAction> extends Abs
     }
 
     /**
+     * Creates a new Dashboard-View ready to be configured
+     *
+     * @return The view to be configured.
+     */
+    protected DashboardView addDashboardViewToConfigure() {
+        DashboardView view = createNewViewForAllJobs(DashboardView.class);
+        return view;
+    }
+
+    /**
      * Creates a new Dashboard-View and adds the given portlet as "bottom portlet".
      *
      * @param portlet The Portlet that shall be added.

--- a/src/test/java/plugins/PmdPluginTest.java
+++ b/src/test/java/plugins/PmdPluginTest.java
@@ -471,10 +471,12 @@ public class PmdPluginTest extends AbstractAnalysisTest<PmdAction> {
      */
     @Test @WithPlugins("dashboard-view")
     public void should_set_warnings_count_in_dashboard_portlet() {
-        MavenModuleSet job = createMavenJob();
+        jenkins.restart();
+
+        final MavenModuleSet job = createMavenJob();
         buildJobAndWait(job).shouldSucceed();
 
-        DashboardView view = addDashboardViewAndBottomPortlet(PmdWarningsPortlet.class);
+        final DashboardView view = addDashboardViewAndBottomPortlet(PmdWarningsPortlet.class);
 
         assertValidLink(job.name);
         view.delete();


### PR DESCRIPTION
[JENKINS-39504](https://issues.jenkins-ci.org/browse/JENKINS-39504)

In some WARs, the plugins are being installed in different order and the functionality is not available without a restart.

@reviewbybees 