### PR TITLE
Adjust timeout for Apply on job.apply()

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
@@ -101,6 +101,6 @@ public abstract class ConfigurablePageObject extends PageObject {
 
     public void apply() {
         clickButton("Apply");
-        waitFor(driver, hasContent("Saved"), 5);
+        waitFor(driver, hasContent("Saved"), 30);
     }
 }


### PR DESCRIPTION
For instances where a large number of plugins are installed,
5 seconds may not be long enough for apply operation to complete.
Adjusting to 30 seconds.