### PR TITLE
[JENKINS-39716] adapt docker tests execution when ATH itself runs as docker container

### DIFF
--- a/docs/FIXTURES.md
+++ b/docs/FIXTURES.md
@@ -77,6 +77,14 @@ public class TestContainer extends DockerContainer {
 
 In this case the docker file must be located at classpath and in `org/ame/fixture/test` instead of the default location.
 
+## Running the ATH itself as a docker container
+Depending on the CI infrastructure setup one may need to run the ATH itself in a docker container with access to the host docker service,
+following a strategy similar to the one described in [this article](http://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/).
 
+When this is needed, the docker fixtures should not be accessed through mapped ports on the docker host, but directly
+through their container IP and port since they are "sibling" containers to the ATH.
 
+To enable this, set the environment variable `SHARED_DOCKER_SERVICE=true`, and then the functions ipBound(n) and port(n)
+will just return the container's IP and port where the fixture can be accessed.
 
+TO-DO: Instead of depending on setting this environment variable, in the future we could try to somehow automatically detect the situation.

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
@@ -2,7 +2,6 @@ package org.jenkinsci.test.acceptance.docker;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Joiner;
 import org.jenkinsci.test.acceptance.junit.Resource;
 import org.jenkinsci.utils.process.ProcessUtils;
 
@@ -82,6 +81,9 @@ public class DockerContainer implements Closeable {
     public String ipBound(int n) {
         assertRunning();
         try {
+            if (sharingHostDockerService()) {
+                return getIpAddress();
+            }
             String out = Docker.cmd("port").add(cid, n).popen().verifyOrDieWith("docker port command failed").trim();
             if (out.isEmpty())  // expected to return single line like "0.0.0.0:55326"
                 throw new IllegalStateException(format("Port %d is not mapped for container %s", n, cid));
@@ -97,6 +99,9 @@ public class DockerContainer implements Closeable {
     public int port(int n) {
         assertRunning();
         try {
+            if (sharingHostDockerService()) {
+                return n;
+            }
             String out = Docker.cmd("port").add(cid, n).popen().verifyOrDieWith("docker port command failed").trim();
             if (out.isEmpty())  // expected to return single line like "0.0.0.0:55326"
                 throw new IllegalStateException(format("Port %d is not mapped for container %s", n, cid));
@@ -169,5 +174,14 @@ public class DockerContainer implements Closeable {
     @Override
     public String toString() {
         return "Docker container " + cid;
+    }
+    
+    /**
+     * Support the case when ATHs are running in a docker container and
+     * using the host docker service to spin "sibling" containers, as
+     * described in http://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/
+     */
+    public boolean sharingHostDockerService() {
+        return Boolean.valueOf(System.getenv("SHARED_DOCKER_SERVICE"));
     }
 }


### PR DESCRIPTION
[JENKINS-39716](https://issues.jenkins-ci.org/browse/JENKINS-39716)

Support running ATH as docker container. Connect to docker fixtures through docker IPs instead of using host port-mappings.

For the moment, an environment variable SHARED_DOCKER_SERVICE is used to select this behaviour. Maybe in the future try to detect the situation automatically.

@reviewbybees 