### PR TITLE
Test dependency resolution

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/UpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/UpdateCenter.java
@@ -3,13 +3,9 @@ package org.jenkinsci.test.acceptance.po;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterables;
 
-import groovy.ui.SystemOutputInterceptor;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.test.acceptance.update_center.PluginSpec;
-
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.*;
 import static org.hamcrest.Matchers.not;

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/Dependency.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/Dependency.java
@@ -1,16 +1,42 @@
 package org.jenkinsci.test.acceptance.update_center;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Databinding for dependency of a plugin.
  *
  * @author Kohsuke Kawaguchi
  */
 public class Dependency {
-    public String version;
-    public String name;
-    public boolean optional;
+    private static final String OPTIONAL = ";resolution:=optional";
+
+    public final String version;
+    public final String name;
+    public final boolean optional;
 
     private UpdateCenterMetadata owner;
+
+    public Dependency(String specification) {
+        optional = specification.endsWith(OPTIONAL);
+        if(optional)
+            specification = specification.substring(0, specification.length()-OPTIONAL.length());
+        String[] tokens = specification.split(":");
+        if (tokens.length != 2) throw new IllegalArgumentException(
+                "Unable to parse dependency declaration " + specification
+        );
+        name = tokens[0];
+        version = tokens[1];
+    }
+
+    public Dependency(
+            @JsonProperty("name") String name,
+            @JsonProperty("version") String version,
+            @JsonProperty("optional") boolean optional
+    ) {
+        this.name = name;
+        this.version = version;
+        this.optional = optional;
+    }
 
     void init(UpdateCenterMetadata owner) {
         this.owner = owner;
@@ -18,5 +44,9 @@ public class Dependency {
 
     public PluginMetadata get() {
         return owner.plugins.get(name);
+    }
+
+    @Override public String toString() {
+        return "Dependency[" + name + (version == null ? "" : ("@" + version)) + ";optional=" + optional + "]";
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginMetadata.java
@@ -143,8 +143,6 @@ public class PluginMetadata {
      * @author ogondza
      */
     public static final class LocalOverride extends PluginMetadata {
-        private static final String OPTIONAL = ";resolution:=optional";
-
         private @Nonnull File override;
 
         /**
@@ -152,7 +150,7 @@ public class PluginMetadata {
          */
         public static LocalOverride create(@Nonnull File jpi) {
 
-            List<Dependency> dependencies = new ArrayList<Dependency>();
+            List<Dependency> dependencies = new ArrayList<>();
             try (JarFile j = new JarFile(jpi)) {
                 Attributes main = j.getManifest().getMainAttributes();
                 String name = main.getValue("Short-Name");
@@ -162,18 +160,11 @@ public class PluginMetadata {
                 String dep = main.getValue("Plugin-Dependencies");
                 if (dep!=null) {
                     for (String token : dep.split(",")) {
-                        Dependency d = new Dependency();
-                        d.optional = token.endsWith(OPTIONAL);
-                        if(d.optional)
-                            token = token.substring(0, token.length()-OPTIONAL.length());
-                        String[] tokens = token.split(":");
-                        if (tokens.length != 2) {
-                            System.err.println("Bad token ‘" + token + "’ from ‘" + dep + "’ in " + jpi);
-                            continue;
+                        try {
+                            dependencies.add(new Dependency(token));
+                        } catch (IllegalArgumentException ex) {
+                            System.err.println(ex.getMessage() + " from '" + dep + "' in " + jpi);
                         }
-                        d.name = tokens[0];
-                        d.version = tokens[1];
-                        dependencies.add(d);
                     }
                 }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/pluginreporter/ConsoleExercisedPluginReporter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/pluginreporter/ConsoleExercisedPluginReporter.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.test.acceptance.utils.pluginreporter;
 
 import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
 
 /**
  * Exercised Plugin Reporter that logs to console
@@ -33,10 +34,12 @@ import java.util.logging.Logger;
  */
 public class ConsoleExercisedPluginReporter implements ExercisedPluginsReporter {
     @Override
-    public void log(String testName, String pluginName, String pluginVersion) {
-        LOGGER.info("Plugin " + pluginName + "@" + pluginVersion + " is installed");
+    public void log(String testName, String pluginName, @CheckForNull String pluginVersion) {
+        if (pluginVersion != null) {
+            pluginName += "@" + pluginVersion;
+        }
+        LOGGER.info("Plugin " + pluginName + " is installed");
     }
 
     private static final Logger LOGGER = Logger.getLogger(ConsoleExercisedPluginReporter.class.getName());
-
 }

--- a/src/test/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadataTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadataTest.java
@@ -1,0 +1,90 @@
+package org.jenkinsci.test.acceptance.update_center;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import hudson.util.VersionNumber;
+import org.hamcrest.Matchers;
+import org.jenkinsci.test.acceptance.po.Jenkins;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * @author ogondza.
+ */
+public class UpdateCenterMetadataTest {
+
+    public static final List<Dependency> NO_DEPS = Collections.emptyList();
+
+    private Jenkins jenkins = mock(Jenkins.class);
+    {
+        when(jenkins.getVersion()).thenReturn(new VersionNumber("2"));
+        when(jenkins.getPlugin(any(String.class))).thenThrow(new IllegalArgumentException("Not installed"));
+    }
+
+    private HashMap<String, PluginMetadata> plugins = new HashMap<>();
+    {
+        plugins.put("standalone", new PluginMetadata("standalone", "jenkins:standalone:1", "1", "1", NO_DEPS));
+
+        plugins.put("provider", new PluginMetadata("provider", "jenkins:provider:1", "1", "1", NO_DEPS));
+            plugins.put("consumer", new PluginMetadata("consumer", "jenkins:consumer:1", "1", "1", Collections.singletonList(new Dependency("provider:1"))));
+
+        plugins.put("complex", new PluginMetadata("complex", "jenkins:complex:1", "1", "1", Arrays.asList(new Dependency("branchb:1"), new Dependency("brancha:1"))));
+            plugins.put("brancha", new PluginMetadata("brancha", "jenkins:brancha:1", "1", "1", Arrays.asList(new Dependency("depa:1"))));
+                plugins.put("depa", new PluginMetadata("depa", "jenkins:depa:1", "1", "1", NO_DEPS));
+            plugins.put("branchb", new PluginMetadata("branchb", "jenkins:branchb:1", "1", "1", Arrays.asList(new Dependency("depb0:1"), new Dependency("depb1:1"))));
+                plugins.put("depb0", new PluginMetadata("depb0", "jenkins:depb0:1", "1", "1", NO_DEPS));
+                plugins.put("depb1", new PluginMetadata("depb1", "jenkins:depb1:1", "1", "1", NO_DEPS));
+    }
+
+    private UpdateCenterMetadata ucm = UpdateCenterMetadata.get("id", plugins);
+
+    @Test
+    public void transitiveDependenciesOfSimple() throws Exception {
+
+        assertThat(ucm.transitiveDependenciesOf(jenkins, specs()), Matchers.<PluginMetadata>emptyIterable());
+        assertThat(ucm.transitiveDependenciesOf(jenkins, specs("standalone")), Matchers.contains(plugins.get("standalone")));
+
+        assertThat(ucm.transitiveDependenciesOf(jenkins, specs("provider")), Matchers.contains(plugins.get("provider")));
+        assertThat(ucm.transitiveDependenciesOf(jenkins, specs("consumer")), Matchers.contains(plugins.get("provider"), plugins.get("consumer")));
+
+        List<PluginMetadata> complexDeps = ucm.transitiveDependenciesOf(jenkins, specs("complex"));
+
+        int complexIndex = complexDeps.indexOf(plugins.get("complex"));
+        int branchAIndex = complexDeps.indexOf(plugins.get("brancha"));
+        int branchBIndex = complexDeps.indexOf(plugins.get("branchb"));
+        int depAIndex = complexDeps.indexOf(plugins.get("depa"));
+        int depB0Index = complexDeps.indexOf(plugins.get("depb0"));
+        int depB1Index = complexDeps.indexOf(plugins.get("depb1"));
+        assertThat(complexIndex, Matchers.greaterThanOrEqualTo(branchAIndex));
+        assertThat(complexIndex, Matchers.greaterThanOrEqualTo(branchBIndex));
+        assertThat(branchAIndex, Matchers.greaterThanOrEqualTo(depAIndex));
+        assertThat(branchBIndex, Matchers.greaterThanOrEqualTo(depB0Index));
+        assertThat(branchBIndex, Matchers.greaterThanOrEqualTo(depB1Index));
+    }
+
+    @Test
+    public void transitiveDependenciesOfExplicitOrder() throws Exception {
+        assertThat(ucm.transitiveDependenciesOf(jenkins, specs("consumer", "provider")), Matchers.contains(plugins.get("provider"), plugins.get("consumer")));
+        assertThat(ucm.transitiveDependenciesOf(jenkins, specs("provider", "consumer")), Matchers.contains(plugins.get("provider"), plugins.get("consumer")));
+
+        assertThat(ucm.transitiveDependenciesOf(jenkins, specs("consumer@1", "provider")), Matchers.contains(plugins.get("provider"), plugins.get("consumer")));
+        assertThat(ucm.transitiveDependenciesOf(jenkins, specs("provider", "consumer@1")), Matchers.contains(plugins.get("provider"), plugins.get("consumer")));
+        assertThat(ucm.transitiveDependenciesOf(jenkins, specs("provider@1", "consumer@1")), Matchers.contains(plugins.get("provider"), plugins.get("consumer")));
+    }
+
+    private List<PluginSpec> specs(String... specs) {
+        ArrayList<PluginSpec> ret = new ArrayList<>(specs.length);
+        for (String spec : specs) {
+            ret.add(new PluginSpec(spec));
+        }
+        return ret;
+    }
+}


### PR DESCRIPTION
Adding test coverage for dependency resolution as a response to #216 and #217, which I am not able to reproduce.

It is expected that the hot-deploy (*Failed to dynamically deploy this plugin*) fail in case the plugin already exists so it needs to be updated or plugin depends on plugin that needs to be updated. Throwing `LinkageError`s is not expected but it occurs due to bug in Jenkins core [JENKINS-40036](https://issues.jenkins-ci.org/browse/JENKINS-40036). The former situation is recognized and Jenkins is restarted to correctly resolve dependencies. The later situation is not detected but is usually accompanied by the former so Jenkins manages to recover. In case ATH does not restart Jenkins in these situations or the exceptions are present after the restart, it is a bug in ATH. But I have not observed that.

[1]
```
WARNING: Failed to instantiate Key[type=org.jenkinsci.plugins.ewm.steps.ExwsAllocateStep$DescriptorImpl, annotation=[none]]; skipping this component
master61632|com.google.inject.ProvisionException: Guice provision errors:
master61632|
master61632|1) Error injecting constructor, java.lang.NoClassDefFoundError: org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper
master61632|  at org.jenkinsci.plugins.ewm.steps.ExwsAllocateStep$DescriptorImpl.<init>(ExwsAllocateStep.java:98)
master61632|
master61632|1 error
master61632|  at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:52)
master61632|  at com.google.inject.Scopes$1$1.get(Scopes.java:65)
master61632|  at hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1.get(ExtensionFinder.java:424)
master61632|  at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
master61632|  at com.google.inject.internal.InjectorImpl$3$1.call(InjectorImpl.java:1005)
master61632|  at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1051)
master61632|  at com.google.inject.internal.InjectorImpl$3.get(InjectorImpl.java:1001)
master61632|  at hudson.ExtensionFinder$GuiceFinder._find(ExtensionFinder.java:386)
master61632|  at hudson.ExtensionFinder$GuiceFinder.access$000(ExtensionFinder.java:232)
master61632|  at hudson.ExtensionFinder$GuiceFinder$3.find(ExtensionFinder.java:341)
master61632|  at jenkins.ExtensionComponentSet$3.find(ExtensionComponentSet.java:98)
master61632|  at jenkins.ExtensionComponentSet$1.find(ExtensionComponentSet.java:70)
master61632|  at hudson.ExtensionList.load(ExtensionList.java:356)
master61632|  at hudson.ExtensionList.refresh(ExtensionList.java:312)
master61632|  at jenkins.model.Jenkins.refreshExtensions(Jenkins.java:2635)
master61632|  at hudson.PluginManager.dynamicLoad(PluginManager.java:866)
master61632|  at hudson.PluginManager.dynamicLoad(PluginManager.java:813)
master61632|  at hudson.model.UpdateCenter$InstallationJob._run(UpdateCenter.java:1889)
master61632|  at hudson.model.UpdateCenter$DownloadJob.run(UpdateCenter.java:1650)
master61632|  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
master61632|  at java.util.concurrent.FutureTask.run(FutureTask.java:266)
master61632|  at hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:110)
master61632|  at java.lang.Thread.run(Thread.java:745)
master61632|Caused by: java.lang.NoClassDefFoundError: org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper
master61632|  at java.lang.Class.getDeclaredMethods0(Native Method)
master61632|  at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
master61632|  at java.lang.Class.privateGetMethodRecursive(Class.java:3048)
master61632|  at java.lang.Class.getMethod0(Class.java:3018)
master61632|  at java.lang.Class.getMethod(Class.java:1784)
master61632|  at hudson.model.Descriptor.<init>(Descriptor.java:287)
master61632|  at org.jenkinsci.plugins.workflow.steps.StepDescriptor.<init>(StepDescriptor.java:55)
master61632|  at org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl.<init>(AbstractStepDescriptorImpl.java:22)
master61632|  at org.jenkinsci.plugins.ewm.steps.ExwsAllocateStep$DescriptorImpl.<init>(ExwsAllocateStep.java:98)
master61632|  at org.jenkinsci.plugins.ewm.steps.ExwsAllocateStep$DescriptorImpl$$FastClassByGuice$$7db9a117.newInstance(<generated>)
master61632|  at com.google.inject.internal.cglib.reflect.$FastConstructor.newInstance(FastConstructor.java:40)
master61632|  at com.google.inject.internal.DefaultConstructionProxyFactory$1.newInstance(DefaultConstructionProxyFactory.java:61)
master61632|  at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:108)
master61632|  at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:88)
master61632|  at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:269)
master61632|  at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
master61632|  at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1058)
master61632|  at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
master61632|  ... 22 more
master61632|Caused by: java.lang.ClassNotFoundException: org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
master61632|  at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1373)
master61632|  at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1326)
master61632|  at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1079)
master61632|  at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
master61632|  ... 40 more
```