### PR TITLE
Deprecating getSlaveJarPath

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
@@ -150,8 +150,12 @@ public abstract class LocalController extends JenkinsController implements LogLi
         return tempDir;
     }
 
+    /**
+     * @deprecated Will not work correctly in Jenkins 2.33 and later. Apparently unused anyway.
+     */
+    @Deprecated
     public File getSlaveJarPath() {
-        return new File(getJenkinsHome(),"war/WEB-INF/slave.jar");
+        return new File(getJenkinsHome(),"war/WEB-INF/slave.jar"); // TODO look for war/WEB-INF/lib/remoting-*.jar instead
     }
 
 


### PR DESCRIPTION
Cf. https://github.com/jenkinsci/ssh-slaves-plugin/pull/37. Both unused (according to my GitHub search), and wrong as https://github.com/jenkinsci/jenkins/pull/2633.

@reviewbybees