### PR TITLE
[JENKINS-40092] Ensuring SshSlavesPluginTest can be run

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_slaves/SshSlaveLauncher.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_slaves/SshSlaveLauncher.java
@@ -10,7 +10,7 @@ import org.jenkinsci.test.acceptance.po.ComputerLauncher;
 import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.PageObject;
-import org.openqa.selenium.WebElement;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -94,11 +94,13 @@ public class SshSlaveLauncher extends ComputerLauncher {
      * to check whether it has already been rendered in the dropdown.
      */
     private void waitForCredentialVisible(final String credUsername) {
-        waitFor().withTimeout(5, TimeUnit.SECONDS).until(new Callable<Boolean>() {
+        assertTrue(waitFor().withTimeout(5, TimeUnit.SECONDS).until(new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
                 return credentialsId.resolve().getText().contains(credUsername);
             }
-        });
+        }));
+        // Select the new credentials. Control.selectDropdownMenu seems to be YUI-only.
+        credentialsId.select(credUsername);
     }
 }

--- a/src/test/java/plugins/SshSlavesPluginTest.java
+++ b/src/test/java/plugins/SshSlavesPluginTest.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 import com.google.inject.Inject;
 import org.junit.experimental.categories.Category;
 
-@WithPlugins("ssh-slaves")
+@WithPlugins({"ssh-slaves@1.11", "credentials@2.1.10", "ssh-credentials@1.12"})
 @Category(DockerTest.class)
 @WithDocker
 public class SshSlavesPluginTest extends AbstractJUnitTest {


### PR DESCRIPTION
While trying to reproduce https://github.com/jenkinsci/ssh-slaves-plugin/pull/37,

- [X] `LOCAL_SNAPSHOTS=true` did not in fact test the local snapshot
- [X] and the test failed because the new credentials were not selected in the launcher

@reviewbybees