### PR TITLE
Make InteractiveConsole.execute throw no checked exceptions

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/utils/groovy/InteractiveConsole.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/groovy/InteractiveConsole.java
@@ -22,7 +22,7 @@ public class InteractiveConsole {
      *      [name, value, name, value, ... ] pair array that defines additional variables accessible
      *      from the script. Useful to expose local variables in scope
      */
-    public static void execute(Object caller, Object... args) throws InterruptedException {
+    public static void execute(Object caller, Object... args) {
         Console cons = new Console();
         cons.getConfig().setScriptBaseClass(ClosureScript.class.getName());
         cons.setVariable("delegate",caller);
@@ -49,8 +49,13 @@ public class InteractiveConsole {
             });
 
             // block until the swing app is done
-            while (!done[0])
-                lock.wait();
+            while (!done[0]) {
+                try {
+                    lock.wait();
+                } catch (InterruptedException x) {
+                    throw new AssertionError(x);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
In practice it is an annoyance to have to handle or rethrow `InterruptedException` when you are temporarily adding a break to a method which did not already throw this.

@reviewbybees