### PR TITLE
[JENKINS-40476] WorkflowMultibranchTest#testMultibranchPipeline is failing

### DIFF
--- a/src/test/java/plugins/WorkflowMultibranchTest.java
+++ b/src/test/java/plugins/WorkflowMultibranchTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests a multibranch pipeline flow
  */
-@WithPlugins({"git", "workflow-job", "workflow-cps", "workflow-basic-steps", "workflow-durable-task-step", "workflow-multibranch", "github-branch-source"})
+@WithPlugins({"git", "javadoc@1.4", "workflow-job", "workflow-cps", "workflow-basic-steps", "workflow-durable-task-step", "workflow-multibranch", "github-branch-source"})
 public class WorkflowMultibranchTest extends AbstractJUnitTest {
 
     @Before


### PR DESCRIPTION
[JENKINS-40476](https://issues.jenkins-ci.org/browse/JENKINS-40476)

Request 1.4 version of Javadoc plugin so there is no failure when used within a Pipeline.

@reviewbybees 