### PR TITLE
[JENKINS-40499] Fix PublishOverSSHGlobalConfig#addAdvancedConfig

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/publish_over/PublishOverSSHGlobalConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/publish_over/PublishOverSSHGlobalConfig.java
@@ -6,6 +6,7 @@ import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 import org.jenkinsci.test.acceptance.po.PageObject;
 
 import javax.inject.Inject;
+import static org.jenkinsci.test.acceptance.po.CapybaraPortingLayer.by;
 
 /**
  * @author jenky-hm
@@ -63,12 +64,9 @@ public class PublishOverSSHGlobalConfig extends PageAreaImpl {
         public final Control addAdvancedConfig = control("advanced-button");
 
         public AdvancedConfig addAdvancedConfig() {
-            String path = createPageArea("instance", new Runnable() {
-                @Override public void run() {
-                    addAdvancedConfig.click();
-                }
-            });
-            return new AdvancedConfig(getPage(), path);
+            addAdvancedConfig.click();
+            String p = last(by.xpath(".//div[@name='instance'][starts-with(@path,'/jenkins-plugins-publish_over_ssh-BapSshPublisherPlugin/')]")).getAttribute("path");
+            return new AdvancedConfig(getPage(), p);
         }
 
         public final Control validate = control("validate-button");


### PR DESCRIPTION
Fix for [JENKINS-40499](https://issues.jenkins-ci.org/browse/JENKINS-40499).

The `addAdvancedConfig` isn't actually creating a page area, just extending an existing one with more fields, so the `createPageArea` method call doesn't fit here.

@reviewbybees 