### PR TITLE
Update ATH to JDK 8 compiler settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,8 +431,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
@olivergondza @uhafner @jenkinsci/code-reviewers 
Rationale:
* Selenium 3.x requires it
* The core is on its way to Java 8
* Java 8 \o/

See also https://groups.google.com/forum/#!msg/jenkinsci-dev/ckHjD6es4KQ/F7DfD7bQAQAJ

@reviewbybees 