### PR TITLE
[JENKINS-40996] Fix DiskUsagePluginTest#show_graph_on_project_page test

### DIFF
--- a/src/test/java/plugins/DiskUsagePluginTest.java
+++ b/src/test/java/plugins/DiskUsagePluginTest.java
@@ -61,9 +61,9 @@ public class DiskUsagePluginTest extends AbstractJUnitTest {
         job.startBuild().waitUntilFinished();
 
         showGraphOnProjectPage();
-
         du.reload();
 
+        job.open();
         assertThat(driver, hasElement(by.xpath(JOB_GRAPH)));
     }
 


### PR DESCRIPTION
[JENKINS-40996](https://issues.jenkins-ci.org/browse/JENKINS-40996)

The job page needs to be opened after accessing disk-usage plugin configuration.

@reviewbybees 
