### PR TITLE
[JENKINS-41310] Fix name of X-Jenkins header.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
@@ -71,7 +71,7 @@ public class Jenkins extends Node implements Container {
         String text;
         try {
             URLConnection urlConnection = url.openConnection();
-            text = urlConnection.getHeaderField("X-Jenkin");
+            text = urlConnection.getHeaderField("X-Jenkins");
             if (text == null) {
 
                 String pageText = IOUtils.toString(urlConnection.getInputStream());


### PR DESCRIPTION
[JENKINS-41310](https://issues.jenkins-ci.org/browse/JENKINS-41310)

Fixing the name of the header so that ATH is able to get Jenkins version correctly. Otherwise, Jenkins instance is not recognised and no test can be run.

@reviewbybees @olivergondza 