### PR TITLE
[JENKINS-41484] Create test for antisamy-markup-formatter plugin

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
@@ -34,6 +34,8 @@ import org.openqa.selenium.WebElement;
  */
 public class GlobalSecurityConfig extends ContainerPageObject {
 
+    private static final String SAFE_HTML = "Safe HTML";
+
     public GlobalSecurityConfig(Jenkins context) {
         super(context, context.url("configureSecurity/"));
     }
@@ -61,6 +63,14 @@ public class GlobalSecurityConfig extends ContainerPageObject {
         });
 
         return newInstance(type, this, path);
+    }
+
+    public void selectSafeHtmlFormatter() {
+        this.selectMarkupFormatter(SAFE_HTML);
+    }
+
+    private void selectMarkupFormatter(final String formatter) {
+        find(by.option(formatter)).click();
     }
 
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.inject.Injector;
+import org.openqa.selenium.WebElement;
 
 /**
  * Super class for top level items. 
@@ -54,6 +55,27 @@ public abstract class TopLevelItem extends ContainerPageObject {
         catch (MalformedURLException e) {
             throw new AssertionError("Not a valid url: " + newName, e);
         }
+    }
+
+    /**
+     * Renames the job. Opens the configuration section, sets the name and saves the form. Finally the rename is
+     * confirmed.
+     *
+     * @param description the description of the job
+     * @param withCodeMirror if description field uses CodeMirror or not (depending on Markup Formatter)
+     */
+    public void description(final String description, final boolean withCodeMirror) {
+        configure();
+
+        if (withCodeMirror) {
+            new CodeMirror(this, "/description").set(description);
+        } else {
+            WebElement descrElem = find(by.name("description"));
+            descrElem.clear();
+            descrElem.sendKeys(description);
+        }
+
+        save();
     }
 
     /**

--- a/src/test/java/plugins/AntisamyMarkupFormatterTest.java
+++ b/src/test/java/plugins/AntisamyMarkupFormatterTest.java
@@ -1,0 +1,60 @@
+package plugins;
+
+import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.jenkinsci.test.acceptance.junit.WithPlugins;
+import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
+import org.junit.Test;
+import org.openqa.selenium.NoSuchElementException;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.jenkinsci.test.acceptance.Matchers.hasContent;
+
+@WithPlugins ("antisamy-markup-formatter")
+public class AntisamyMarkupFormatterTest extends AbstractJUnitTest {
+
+    private static final String NO_HTML = "safe text with no html";
+    private static final String HREF_MESSAGE = "LINK IN DESCRIPTION";
+    private static final String HREF_VALID = "http://www.google.com";
+    private static final String HREF_INVALID = "javascript:alert(5)";
+    private static final String HREF_ELEM = "<a href='%s'>" + HREF_MESSAGE + "</a>";
+
+    @Test
+    public void safeHtmlTest() {
+        final GlobalSecurityConfig security = new GlobalSecurityConfig(jenkins);
+        security.open();
+        security.selectSafeHtmlFormatter();
+        security.save();
+
+        final FreeStyleJob job = jenkins.jobs.create(FreeStyleJob.class);
+        job.description(NO_HTML, true);
+
+        assertThat(driver, hasContent(NO_HTML));
+
+        job.description(String.format(HREF_ELEM, HREF_VALID), true);
+
+        assertThat(driver, hasContent(HREF_MESSAGE));
+        this.assertHref(HREF_VALID, true);
+
+        job.description(String.format(HREF_ELEM, HREF_INVALID), true);
+
+        assertThat(driver, hasContent(HREF_MESSAGE));
+        this.assertHref(HREF_INVALID, false);
+    }
+
+    private void assertHref(final String href, final boolean expectsHref) {
+        try {
+            find(by.href(href));
+
+            if (!expectsHref) {
+                fail("Link in description is not sanitized");
+            }
+        } catch (final NoSuchElementException ex) {
+            if (expectsHref) {
+                fail("Link in description is not displayed");
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
[JENKINS-41484](https://issues.jenkins-ci.org/browse/JENKINS-41484)

Acceptance test for Antisamy Markup Formatter plugin.

Also includes the possibility of changing the Markup Formatter in Global Security config as well as setting a description for TopLevelItem (Folders and Jobs).

@reviewbybees 