### PR TITLE
[JENKINS-38058] bring back lost constructor for 'Folder'

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Folder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Folder.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package org.jenkinsci.test.acceptance.po;
 
 import java.net.URL;
@@ -33,12 +32,19 @@ import com.google.inject.Injector;
  */
 @Describable("com.cloudbees.hudson.plugins.folder.Folder")
 public class Folder extends TopLevelItem implements Container {
+
     private final JobsMixIn jobs;
     private final ViewsMixIn views;
 
     public Folder(final Injector injector, final URL url, final String name) {
         super(injector, url, name);
 
+        jobs = new JobsMixIn(this);
+        views = new ViewsMixIn(this);
+    }
+
+    public Folder(PageObject context, URL url, String name) {
+        super(context, url, name);
         jobs = new JobsMixIn(this);
         views = new ViewsMixIn(this);
     }


### PR DESCRIPTION
Part of the changes once introduced with [JENKINS-38058](https://issues.jenkins-ci.org/browse/JENKINS-38058) have been removed in a recent commit (02c3799d89681b2447cffaa5380f45f803db9959).

This brings back a constructor, used in projects that depend on this ATH.

@reviewbybees 

@olivergondza please, if this is accepted and merged, I'd kindly ask to release a new version as well so we can pick up the change in depending projects.