### PR TITLE
[JENKINS-41484] Fix wrong comment in Javadoc

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
@@ -58,8 +58,7 @@ public abstract class TopLevelItem extends ContainerPageObject {
     }
 
     /**
-     * Renames the job. Opens the configuration section, sets the name and saves the form. Finally the rename is
-     * confirmed.
+     * Changes the description. Opens the configuration section, sets the description and saves the form.
      *
      * @param description the description of the job
      * @param withCodeMirror if description field uses CodeMirror or not (depending on Markup Formatter)


### PR DESCRIPTION
Fixes a wrong comment introduced by [PR #263](https://github.com/jenkinsci/acceptance-test-harness/pull/263) 

@reviewbybees 