### PR TITLE
[JENKINS-41796] Create acceptance test for git-userContent

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
@@ -36,6 +36,8 @@ public class GlobalSecurityConfig extends ContainerPageObject {
 
     private static final String SAFE_HTML = "Safe HTML";
 
+    public final Control csrf = control(by.name("_.csrf"));
+
     public GlobalSecurityConfig(Jenkins context) {
         super(context, context.url("configureSecurity/"));
     }
@@ -72,7 +74,6 @@ public class GlobalSecurityConfig extends ContainerPageObject {
     private void selectMarkupFormatter(final String formatter) {
         find(by.option(formatter)).click();
     }
-
 
     private <T> T selectFromRadioGroup(Class<T> type) {
         WebElement radio = findCaption(type, new Finder<WebElement>() {

--- a/src/test/java/plugins/GitUserContentTest.java
+++ b/src/test/java/plugins/GitUserContentTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 
 /**
  * Verifies the Git repository setup by git-userContent plugin is working fine for some basic operations.
@@ -17,8 +18,11 @@ import static org.hamcrest.Matchers.containsString;
 @WithPlugins({"git-userContent", "git", "workflow-job", "workflow-cps", "workflow-basic-steps", "workflow-durable-task-step"})
 public class GitUserContentTest extends AbstractJUnitTest {
 
-    private static final String FILE_NAME = "text.txt";
-    private static final String FILE_CONTENT = "anytextwhatever";
+    private static final String NEW_FILE_NAME = "text.txt";
+    private static final String NEW_FILE_CONTENT = "anytextwhatever";
+
+    private static final String GIT_FOLDER = ".git";
+    private static final String README_FILE = "readme.txt";
 
     @Before
     public void setUp() throws Exception {
@@ -30,21 +34,27 @@ public class GitUserContentTest extends AbstractJUnitTest {
 
     @Test
     public void userContentGitTest() throws Exception {
+        this.checkUserContent(README_FILE);
+
         this.createAndBuildWorkflowJob(String.format("node {\n" +
                 "    git url: '%suserContent.git/'\n" +
                 "    writeFile encoding: 'UTF-8', file: '%s', text: '%s'\n" +
                 "    sh 'git add %s'\n" +
                 "    sh 'git commit -m \"Including new file\"'\n" +
                 "    sh 'git push --set-upstream origin master'\n" +
-                "}", jenkins.url, FILE_NAME, FILE_CONTENT, FILE_NAME));
+                "}", jenkins.url, NEW_FILE_NAME, NEW_FILE_CONTENT, NEW_FILE_NAME));
+
+        this.checkUserContent(README_FILE, GIT_FOLDER, NEW_FILE_NAME);
 
         final String pullConsole = this.createAndBuildWorkflowJob(String.format("node {\n" +
                 "    git url: '%suserContent.git/'\n" +
                 "    sh 'cat %s'\n" +
-                "}", jenkins.url, FILE_NAME)).getConsole();
+                "}", jenkins.url, NEW_FILE_NAME)).getConsole();
 
         assertThat(pullConsole, containsString("Cloning the remote Git repository"));
-        assertThat(pullConsole, containsString(FILE_CONTENT));
+        assertThat(pullConsole, containsString(NEW_FILE_CONTENT));
+
+        this.checkUserContent(README_FILE, GIT_FOLDER, NEW_FILE_NAME);
     }
 
     private Build createAndBuildWorkflowJob(final String script) {
@@ -52,6 +62,14 @@ public class GitUserContentTest extends AbstractJUnitTest {
         job.script.set(script);
         job.save();
         return job.startBuild().shouldSucceed();
+    }
+
+    private void checkUserContent(String... expectedFiles) {
+        jenkins.visit("userContent");
+
+        for (final String file : expectedFiles) {
+            assertThat(driver, hasContent(file));
+        }
     }
 
 }

--- a/src/test/java/plugins/GitUserContentTest.java
+++ b/src/test/java/plugins/GitUserContentTest.java
@@ -1,0 +1,57 @@
+package plugins;
+
+import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.jenkinsci.test.acceptance.junit.WithPlugins;
+import org.jenkinsci.test.acceptance.po.Build;
+import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
+import org.jenkinsci.test.acceptance.po.WorkflowJob;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Verifies the Git repository setup by git-userContent plugin is working fine for some basic operations.
+ */
+@WithPlugins({"git-userContent", "git", "workflow-job", "workflow-cps", "workflow-basic-steps", "workflow-durable-task-step"})
+public class GitUserContentTest extends AbstractJUnitTest {
+
+    private static final String FILE_NAME = "text.txt";
+    private static final String FILE_CONTENT = "anytextwhatever";
+
+    @Before
+    public void setUp() throws Exception {
+        final GlobalSecurityConfig security = new GlobalSecurityConfig(jenkins);
+        security.open();
+        security.csrf.uncheck();
+        security.save();
+    }
+
+    @Test
+    public void userContentGitTest() throws Exception {
+        this.createAndBuildWorkflowJob(String.format("node {\n" +
+                "    git url: '%suserContent.git/'\n" +
+                "    writeFile encoding: 'UTF-8', file: '%s', text: '%s'\n" +
+                "    sh 'git add %s'\n" +
+                "    sh 'git commit -m \"Including new file\"'\n" +
+                "    sh 'git push --set-upstream origin master'\n" +
+                "}", jenkins.url, FILE_NAME, FILE_CONTENT, FILE_NAME));
+
+        final String pullConsole = this.createAndBuildWorkflowJob(String.format("node {\n" +
+                "    git url: '%suserContent.git/'\n" +
+                "    sh 'cat %s'\n" +
+                "}", jenkins.url, FILE_NAME)).getConsole();
+
+        assertThat(pullConsole, containsString("Cloning the remote Git repository"));
+        assertThat(pullConsole, containsString(FILE_CONTENT));
+    }
+
+    private Build createAndBuildWorkflowJob(final String script) {
+        final WorkflowJob job = jenkins.jobs.create(WorkflowJob.class);
+        job.script.set(script);
+        job.save();
+        return job.startBuild().shouldSucceed();
+    }
+
+}


### PR DESCRIPTION
[JENKINS-41796](https://issues.jenkins-ci.org/browse/JENKINS-41796)

Acceptance test for git-userContent plugin (and indirectly for git-server plugin). 

One job clones the repo and pushes some changes. Other job (therefore other workspace) clones again the repo and verifies the changes done by the first one are there.

@reviewbybees 