### PR TITLE
WorkflowPluginTest.sshGitInsideDocker overhaul

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/DockerAgentContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/DockerAgentContainer.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.test.acceptance.docker.fixtures;
+
+import org.jenkinsci.test.acceptance.docker.DockerFixture;
+
+/**
+ * Container that can run a Jenkins agent (SSH) and also run Docker commands.
+ */
+@DockerFixture(id="docker-agent", ports=22)
+public class DockerAgentContainer extends JavaContainer {
+
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer.java
@@ -32,9 +32,17 @@ public class GitContainer extends DockerContainer {
         return "ssh://git@" + host() + ":" + port() + REPO_DIR;
     }
 
-    /** URL visible from other Docker containers. */
+    @Deprecated
     public String getRepoUrlInsideDocker() throws IOException {
         return "ssh://git@" + getIpAddress() + REPO_DIR;
+    }
+
+    /**
+     * URL visible from other Docker containers.
+     * @param alias an alias for this container’s {@link #getCid} passed to {@code --link}
+     */
+    public String getRepoUrlInsideDocker(String alias) throws IOException {
+        return "ssh://git@" + alias + REPO_DIR;
     }
 
 }

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/DockerAgentContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/DockerAgentContainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM jenkins/java:eed7706a10fb
 
 RUN cd /tmp && \
-    wget -nv -O - https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz | tar xvfz - docker/docker && \
+    wget -nv -O - https://get.docker.com/builds/Linux/x86_64/docker-1.13.1.tgz | tar xvfz - docker/docker && \
     chmod a+x docker/docker && \
     mv docker/docker /usr/bin/docker
 VOLUME /home/test/workspace

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/DockerAgentContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/DockerAgentContainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM jenkins/java:eed7706a10fb
+
+RUN cd /tmp && \
+    wget -nv -O - https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz | tar xvfz - docker/docker && \
+    chmod a+x docker/docker && \
+    mv docker/docker /usr/bin/docker
+VOLUME /home/test/workspace
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+ENTRYPOINT ["/bin/sh", "/usr/bin/entrypoint.sh"]

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/DockerAgentContainer/entrypoint.sh
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/DockerAgentContainer/entrypoint.sh
@@ -1,0 +1,4 @@
+groupadd -g $DOCKER_GROUP docker
+usermod -aG docker test
+chown test.test /home/test/workspace
+exec /usr/sbin/sshd -D -e


### PR DESCRIPTION
@mafraba found that this test could fail in a Dockerized test environment and tried to work around this by running the test environment with `-v /tmp`, without success. At root the problem was the unrealistic structure of the test, in which the build was being run on master, using the test environment’s own filesystem; and the consequent attempt to work around JENKINS-36997 by using `/tmp` for the workspace, which will not generally be available in a sibling container. To make it all work I had to switch to running the build in an agent container (linked to the Git container) accessing the host Docker daemon, a supported (indeed recommended) mode for `docker-workflow`, which does not trigger JENKINS-36997 since the workspace path is guaranteed to be short.

@reviewbybees