### PR TITLE
[WIP] Upgrade to Selenium 3.3.0

### DIFF
--- a/jut-server.sh
+++ b/jut-server.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-DIR="$( cd "$( dirname "$0" )" && pwd )"
-CMD="$DIR/target/appassembler/bin/jut-server"
+CMD="target/appassembler/bin/jut-server"
 if [ ! -s $CMD ]
 then
-  mvn package -DskipTests -f "$DIR/pom.xml"
+  mvn package -DskipTests
 fi
 sh "$CMD" "$@"

--- a/jut-server.sh
+++ b/jut-server.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-CMD="target/appassembler/bin/jut-server"
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+CMD="$DIR/target/appassembler/bin/jut-server"
 if [ ! -s $CMD ]
 then
-  mvn package -DskipTests
+  mvn package -DskipTests -f "$DIR/pom.xml"
 fi
 sh "$CMD" "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <selenium.version>2.53.0</selenium.version>
+    <selenium.version>3.1.0</selenium.version>
+    <guava.version>21.0</guava.version>
     <aether.version>0.9.0.v20140226</aether.version>
     <maven.version>3.1.0</maven.version>
     <groovy.version>2.3.1</groovy.version>
@@ -114,7 +115,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>15.0</version>
+      <version>${guava.version}</version>
     </dependency>
     <dependency><!-- to align the version of ASM we use -->
       <groupId>org.eclipse.sisu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,11 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-support</artifactId>
+      <version>${selenium.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
       <version>${selenium.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <selenium.version>3.1.0</selenium.version>
+    <selenium.version>3.3.0</selenium.version>
     <guava.version>21.0</guava.version>
     <aether.version>0.9.0.v20140226</aether.version>
     <maven.version>3.1.0</maven.version>

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -2,15 +2,14 @@ package org.jenkinsci.test.acceptance;
 
 import javax.annotation.CheckForNull;
 import javax.inject.Named;
+
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.aether.RepositorySystem;
@@ -35,9 +34,9 @@ import org.jenkinsci.test.acceptance.utils.SauceLabsConnection;
 import org.jenkinsci.test.acceptance.utils.aether.ArtifactResolverUtil;
 import org.jenkinsci.test.acceptance.utils.mail.MailService;
 import org.jenkinsci.test.acceptance.utils.mail.Mailtrap;
-import org.jenkinsci.test.acceptance.utils.pluginreporter.ConsoleExercisedPluginReporter;
 import org.jenkinsci.test.acceptance.utils.pluginreporter.ExercisedPluginsReporter;
 import org.jenkinsci.test.acceptance.utils.pluginreporter.TextFileExercisedPluginReporter;
+import org.jenkinsci.test.acceptance.utils.pluginreporter.ConsoleExercisedPluginReporter;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.UnsupportedCommandException;
@@ -46,7 +45,6 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
@@ -91,95 +89,72 @@ public class FallbackConfig extends AbstractModule {
     }
 
     private WebDriver createWebDriver(TestName testName) throws IOException {
-        String browser = StringUtils.defaultIfBlank(System.getenv("BROWSER"), "firefox");
+        String browser = System.getenv("BROWSER");
+        if (browser==null) browser = "firefox";
         browser = browser.toLowerCase(Locale.ENGLISH);
 
         switch (browser) {
         case "firefox":
-            return createFirefoxDriver();
+            FirefoxProfile profile = new FirefoxProfile();
+            profile.setAlwaysLoadNoFocusLib(true);
+
+            profile.setPreference(LANGUAGE_SELECTOR, "en");
+
+            // Config screen with many plugins can cause FF to complain JS takes too long to complete - set longer timeout
+            profile.setPreference(DOM_MAX_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
+            profile.setPreference(DOM_MAX_CHROME_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
+
+            FirefoxBinary binary = new FirefoxBinary();
+            String display = getBrowserDisplay();
+            if (display != null) {
+                binary.setEnvironmentProperty("DISPLAY", display);
+            }
+            return new FirefoxDriver(binary, profile);
         case "ie":
         case "iexplore":
         case "iexplorer":
             return new InternetExplorerDriver();
         case "chrome":
-            return createChromeDriver();
+            Map<String, String> prefs = new HashMap<String, String>();
+            prefs.put(LANGUAGE_SELECTOR, "en");
+            ChromeOptions options = new ChromeOptions();
+            options.setExperimentalOption("prefs", prefs);
+
+            return new ChromeDriver(options);
         case "safari":
             return new SafariDriver();
         case "htmlunit":
             return new HtmlUnitDriver(true);
         case "saucelabs":
         case "saucelabs-firefox":
-            return createSauceLabsDriver(testName);
+            DesiredCapabilities caps = DesiredCapabilities.firefox();
+            caps.setCapability("version", "29");
+            caps.setCapability("platform", "Windows 7");
+            caps.setCapability("name", testName.get());
+
+            // if running inside Jenkins, expose build ID
+            String tag = System.getenv("BUILD_TAG");
+            if (tag!=null)
+                caps.setCapability("build", tag);
+
+            return new SauceLabsConnection().createWebDriver(caps);
         case "phantomjs":
-            return createPhantomJSDriver();
+            DesiredCapabilities capabilities = DesiredCapabilities.phantomjs();
+            capabilities.setCapability(LANGUAGE_SELECTOR, "en");
+            capabilities.setCapability(LANGUAGE_SELECTOR_PHANTOMJS, "en");
+            return new PhantomJSDriver(capabilities);
         case "remote-webdriver-firefox":
-            return createRemoteFirefoxDriver();
+            String u = System.getenv("REMOTE_WEBDRIVER_URL");
+            if (StringUtils.isBlank(u)) {
+                throw new Error("remote-webdriver-firefox requires REMOTE_WEBDRIVER_URL to be set");
+            }
+            return new RemoteWebDriver(
+                    new URL(u), //http://192.168.99.100:4444/wd/hub
+                    DesiredCapabilities.firefox());
 
         default:
             throw new Error("Unrecognized browser type: "+browser);
         }
-    }
-
-    private WebDriver createRemoteFirefoxDriver() throws MalformedURLException {
-        String u = System.getenv("REMOTE_WEBDRIVER_URL");
-        if (StringUtils.isBlank(u)) {
-            throw new Error("remote-webdriver-firefox requires REMOTE_WEBDRIVER_URL to be set");
-        }
-        return new RemoteWebDriver(
-                new URL(u), //http://192.168.99.100:4444/wd/hub
-                DesiredCapabilities.firefox());
-    }
-
-    private WebDriver createPhantomJSDriver() {
-        DesiredCapabilities capabilities = DesiredCapabilities.phantomjs();
-        capabilities.setCapability(LANGUAGE_SELECTOR, "en");
-        capabilities.setCapability(LANGUAGE_SELECTOR_PHANTOMJS, "en");
-        return new PhantomJSDriver(capabilities);
-    }
-
-    private WebDriver createSauceLabsDriver(final TestName testName) throws IOException {
-        DesiredCapabilities caps = DesiredCapabilities.firefox();
-        caps.setCapability("version", "29");
-        caps.setCapability("platform", "Windows 7");
-        caps.setCapability("name", testName.get());
-
-        // if running inside Jenkins, expose build ID
-        String tag = System.getenv("BUILD_TAG");
-        if (tag!=null)
-            caps.setCapability("build", tag);
-
-        return new SauceLabsConnection().createWebDriver(caps);
-    }
-
-    private WebDriver createChromeDriver() {
-        Map<String, String> prefs = new HashMap<String, String>();
-        prefs.put(LANGUAGE_SELECTOR, "en");
-        ChromeOptions options = new ChromeOptions();
-        options.setExperimentalOption("prefs", prefs);
-
-        return new ChromeDriver(options);
-    }
-
-    private WebDriver createFirefoxDriver() {
-        FirefoxProfile profile = new FirefoxProfile();
-        profile.setAlwaysLoadNoFocusLib(true);
-        profile.setPreference(LANGUAGE_SELECTOR, "en");
-
-        // Config screen with many plugins can cause FF to complain JS takes too long to complete - set longer timeout
-        profile.setPreference(DOM_MAX_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
-        profile.setPreference(DOM_MAX_CHROME_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
-        profile.setPreference("logFile", "/dev/null");
-
-        FirefoxBinary binary = new FirefoxBinary();
-        String display = getBrowserDisplay();
-        if (display != null) {
-            binary.setEnvironmentProperty("DISPLAY", display);
-        }
-
-        DesiredCapabilities capabilities = new FirefoxOptions().setLogLevel(Level.OFF).addPreference("logFile", "/dev/null").addTo(DesiredCapabilities.firefox());
-        capabilities.setCapability("marionette", true);
-        capabilities.setCapability("logFile", "/dev/null");
-        return new FirefoxDriver(binary, profile, capabilities);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -2,14 +2,15 @@ package org.jenkinsci.test.acceptance;
 
 import javax.annotation.CheckForNull;
 import javax.inject.Named;
-
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.aether.RepositorySystem;
@@ -34,9 +35,9 @@ import org.jenkinsci.test.acceptance.utils.SauceLabsConnection;
 import org.jenkinsci.test.acceptance.utils.aether.ArtifactResolverUtil;
 import org.jenkinsci.test.acceptance.utils.mail.MailService;
 import org.jenkinsci.test.acceptance.utils.mail.Mailtrap;
+import org.jenkinsci.test.acceptance.utils.pluginreporter.ConsoleExercisedPluginReporter;
 import org.jenkinsci.test.acceptance.utils.pluginreporter.ExercisedPluginsReporter;
 import org.jenkinsci.test.acceptance.utils.pluginreporter.TextFileExercisedPluginReporter;
-import org.jenkinsci.test.acceptance.utils.pluginreporter.ConsoleExercisedPluginReporter;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.UnsupportedCommandException;
@@ -45,6 +46,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
@@ -89,72 +91,95 @@ public class FallbackConfig extends AbstractModule {
     }
 
     private WebDriver createWebDriver(TestName testName) throws IOException {
-        String browser = System.getenv("BROWSER");
-        if (browser==null) browser = "firefox";
+        String browser = StringUtils.defaultIfBlank(System.getenv("BROWSER"), "firefox");
         browser = browser.toLowerCase(Locale.ENGLISH);
 
         switch (browser) {
         case "firefox":
-            FirefoxProfile profile = new FirefoxProfile();
-            profile.setAlwaysLoadNoFocusLib(true);
-
-            profile.setPreference(LANGUAGE_SELECTOR, "en");
-
-            // Config screen with many plugins can cause FF to complain JS takes too long to complete - set longer timeout
-            profile.setPreference(DOM_MAX_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
-            profile.setPreference(DOM_MAX_CHROME_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
-
-            FirefoxBinary binary = new FirefoxBinary();
-            String display = getBrowserDisplay();
-            if (display != null) {
-                binary.setEnvironmentProperty("DISPLAY", display);
-            }
-            return new FirefoxDriver(binary, profile);
+            return createFirefoxDriver();
         case "ie":
         case "iexplore":
         case "iexplorer":
             return new InternetExplorerDriver();
         case "chrome":
-            Map<String, String> prefs = new HashMap<String, String>();
-            prefs.put(LANGUAGE_SELECTOR, "en");
-            ChromeOptions options = new ChromeOptions();
-            options.setExperimentalOption("prefs", prefs);
-
-            return new ChromeDriver(options);
+            return createChromeDriver();
         case "safari":
             return new SafariDriver();
         case "htmlunit":
             return new HtmlUnitDriver(true);
         case "saucelabs":
         case "saucelabs-firefox":
-            DesiredCapabilities caps = DesiredCapabilities.firefox();
-            caps.setCapability("version", "29");
-            caps.setCapability("platform", "Windows 7");
-            caps.setCapability("name", testName.get());
-
-            // if running inside Jenkins, expose build ID
-            String tag = System.getenv("BUILD_TAG");
-            if (tag!=null)
-                caps.setCapability("build", tag);
-
-            return new SauceLabsConnection().createWebDriver(caps);
+            return createSauceLabsDriver(testName);
         case "phantomjs":
-            DesiredCapabilities capabilities = DesiredCapabilities.phantomjs();
-            capabilities.setCapability(LANGUAGE_SELECTOR, "en");
-            capabilities.setCapability(LANGUAGE_SELECTOR_PHANTOMJS, "en");
-            return new PhantomJSDriver(capabilities);
+            return createPhantomJSDriver();
         case "remote-webdriver-firefox":
-            String u = System.getenv("REMOTE_WEBDRIVER_URL");
-            if (StringUtils.isBlank(u)) {
-                throw new Error("remote-webdriver-firefox requires REMOTE_WEBDRIVER_URL to be set");
-            }
-            return new RemoteWebDriver(
-                    new URL(u), //http://192.168.99.100:4444/wd/hub
-                    DesiredCapabilities.firefox());
+            return createRemoteFirefoxDriver();
 
         default:
             throw new Error("Unrecognized browser type: "+browser);
         }
+    }
+
+    private WebDriver createRemoteFirefoxDriver() throws MalformedURLException {
+        String u = System.getenv("REMOTE_WEBDRIVER_URL");
+        if (StringUtils.isBlank(u)) {
+            throw new Error("remote-webdriver-firefox requires REMOTE_WEBDRIVER_URL to be set");
+        }
+        return new RemoteWebDriver(
+                new URL(u), //http://192.168.99.100:4444/wd/hub
+                DesiredCapabilities.firefox());
+    }
+
+    private WebDriver createPhantomJSDriver() {
+        DesiredCapabilities capabilities = DesiredCapabilities.phantomjs();
+        capabilities.setCapability(LANGUAGE_SELECTOR, "en");
+        capabilities.setCapability(LANGUAGE_SELECTOR_PHANTOMJS, "en");
+        return new PhantomJSDriver(capabilities);
+    }
+
+    private WebDriver createSauceLabsDriver(final TestName testName) throws IOException {
+        DesiredCapabilities caps = DesiredCapabilities.firefox();
+        caps.setCapability("version", "29");
+        caps.setCapability("platform", "Windows 7");
+        caps.setCapability("name", testName.get());
+
+        // if running inside Jenkins, expose build ID
+        String tag = System.getenv("BUILD_TAG");
+        if (tag!=null)
+            caps.setCapability("build", tag);
+
+        return new SauceLabsConnection().createWebDriver(caps);
+    }
+
+    private WebDriver createChromeDriver() {
+        Map<String, String> prefs = new HashMap<String, String>();
+        prefs.put(LANGUAGE_SELECTOR, "en");
+        ChromeOptions options = new ChromeOptions();
+        options.setExperimentalOption("prefs", prefs);
+
+        return new ChromeDriver(options);
+    }
+
+    private WebDriver createFirefoxDriver() {
+        FirefoxProfile profile = new FirefoxProfile();
+        profile.setAlwaysLoadNoFocusLib(true);
+        profile.setPreference(LANGUAGE_SELECTOR, "en");
+
+        // Config screen with many plugins can cause FF to complain JS takes too long to complete - set longer timeout
+        profile.setPreference(DOM_MAX_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
+        profile.setPreference(DOM_MAX_CHROME_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
+        profile.setPreference("logFile", "/dev/null");
+
+        FirefoxBinary binary = new FirefoxBinary();
+        String display = getBrowserDisplay();
+        if (display != null) {
+            binary.setEnvironmentProperty("DISPLAY", display);
+        }
+
+        DesiredCapabilities capabilities = new FirefoxOptions().setLogLevel(Level.OFF).addPreference("logFile", "/dev/null").addTo(DesiredCapabilities.firefox());
+        capabilities.setCapability("marionette", true);
+        capabilities.setCapability("logFile", "/dev/null");
+        return new FirefoxDriver(binary, profile, capabilities);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -2,7 +2,6 @@ package org.jenkinsci.test.acceptance;
 
 import javax.annotation.CheckForNull;
 import javax.inject.Named;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -34,18 +33,20 @@ import org.jenkinsci.test.acceptance.utils.SauceLabsConnection;
 import org.jenkinsci.test.acceptance.utils.aether.ArtifactResolverUtil;
 import org.jenkinsci.test.acceptance.utils.mail.MailService;
 import org.jenkinsci.test.acceptance.utils.mail.Mailtrap;
+import org.jenkinsci.test.acceptance.utils.pluginreporter.ConsoleExercisedPluginReporter;
 import org.jenkinsci.test.acceptance.utils.pluginreporter.ExercisedPluginsReporter;
 import org.jenkinsci.test.acceptance.utils.pluginreporter.TextFileExercisedPluginReporter;
-import org.jenkinsci.test.acceptance.utils.pluginreporter.ConsoleExercisedPluginReporter;
+import org.jenkinsci.utils.process.CommandBuilder;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.firefox.GeckoDriverService;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
@@ -103,13 +104,8 @@ public class FallbackConfig extends AbstractModule {
             // Config screen with many plugins can cause FF to complain JS takes too long to complete - set longer timeout
             profile.setPreference(DOM_MAX_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
             profile.setPreference(DOM_MAX_CHROME_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
-
-            FirefoxBinary binary = new FirefoxBinary();
-            String display = getBrowserDisplay();
-            if (display != null) {
-                binary.setEnvironmentProperty("DISPLAY", display);
-            }
-            return new FirefoxDriver(binary, profile);
+            setDriverProperty("geckodriver", GeckoDriverService.GECKO_DRIVER_EXE_PROPERTY);
+            return new FirefoxDriver(profile);
         case "ie":
         case "iexplore":
         case "iexplorer":
@@ -120,6 +116,7 @@ public class FallbackConfig extends AbstractModule {
             ChromeOptions options = new ChromeOptions();
             options.setExperimentalOption("prefs", prefs);
 
+            setDriverProperty("chromedriver", ChromeDriverService.CHROME_DRIVER_EXE_PROPERTY);
             return new ChromeDriver(options);
         case "safari":
             return new SafariDriver();
@@ -157,6 +154,26 @@ public class FallbackConfig extends AbstractModule {
         }
     }
 
+    private void setDriverProperty(final String driverCommand, final String property) {
+        String executable = locateDriver(driverCommand);
+        if (StringUtils.isNotBlank(executable)) {
+            System.setProperty(property, executable);
+        }
+        else {
+            System.out.println("Unable to locate " + driverCommand);
+        }
+    }
+
+    // TODO: add Windows support
+    private String locateDriver(final String name) {
+        try {
+            return new CommandBuilder("which", name).popen().asText().trim();
+        }
+        catch (IOException | InterruptedException exception) {
+            return StringUtils.EMPTY;
+        }
+    }
+
     /**
      * Get display number to run browser on.
      *
@@ -177,7 +194,7 @@ public class FallbackConfig extends AbstractModule {
     public WebDriver createWebDriver(TestCleaner cleaner, TestName testName, ElasticTime time) throws IOException {
         WebDriver base = createWebDriver(testName);
 
-        // Make sue the window have minimal resolution set, even when out of the visible screen.
+        // Make sure the window has minimal resolution set, even when out of the visible screen.
         // Note - not maximizing here any more because that doesn't do anything.
         Dimension oldSize = base.manage().window().getSize();
         if (oldSize.height < 1050 || oldSize.width < 1680) {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.test.acceptance.po;
 
 import javax.inject.Inject;
-
 import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.util.List;
@@ -20,12 +19,11 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import com.google.common.base.Joiner;
 import com.google.inject.Injector;
-import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 import static java.util.Arrays.*;
 
@@ -86,23 +84,7 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     @Override
     public void clickButton(String text) {
         WebElement e = find(by.button(text));
-        /*
-         * YUI sticky buttons present some problems when scroll to them, also if you have a sticky button
-         * you should not need to scroll to use them
-         */
-        boolean isStickyButton = false;
-        WebElement stickyContainer = getElement(by.id("bottom-sticker"));
-        if (stickyContainer != null) {
-            JavascriptExecutor je = (JavascriptExecutor)driver;
-            isStickyButton = (boolean)je.executeScript("return arguments[0].contains(arguments[1])", stickyContainer, e);
-        }
-        if (isStickyButton) {
-            Actions builder = new Actions(driver);
-            builder.moveToElement(e).click(e);
-            builder.perform();
-        } else {
-            e.click();
-        }
+        e.click();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
@@ -13,7 +13,7 @@ import org.jenkinsci.test.acceptance.controller.JenkinsController;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 
-import com.google.common.base.Predicate;
+import com.google.common.base.Function;
 import com.google.inject.Injector;
 
 import static org.hamcrest.Matchers.*;
@@ -158,13 +158,10 @@ public class Jenkins extends Node implements Container {
                         AssertionError.class, // Still waiting
                         NoSuchElementException.class // No page served at all
                 )
-                .until(new Predicate<WebDriver>() {
-                    @Override
-                    public boolean apply(WebDriver driver) {
-                        visit(driver.getCurrentUrl()); // the page sometimes does not reload (fast enough)
-                        MatcherAssert.assertThat(driver, not(hasContent("Please wait")));
-                        return true;
-                    }
+                .until((Function<WebDriver, Boolean>) driver -> {
+                    visit(driver.getCurrentUrl()); // the page sometimes does not reload (fast enough)
+                    MatcherAssert.assertThat(driver, not(hasContent("Please wait")));
+                    return true;
                 })
         ;
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -40,7 +40,7 @@ public class JobsMixIn extends MixIn {
 
         clickButton("OK");
         // Sometimes job creation is not fast enough, so make sure it's finished before continue
-        waitFor(by.name("config"), 10);
+        waitFor(by.name("config"), 20);
 
         final T j = get(type, name);
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.test.acceptance.po;
 
-import javax.annotation.Nullable;
 import javax.inject.Named;
 import javax.inject.Provider;
 import java.io.File;
@@ -12,7 +11,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
-import com.google.common.base.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.update_center.PluginMetadata;
@@ -80,25 +78,22 @@ public class PluginManager extends ContainerPageObject {
         // We use the button itself to detect when the page has changed, which happens after the refresh has been done
         // And we check for the presence of the button again
         clickButton("Check now");
-        waitFor(find(by.button("Check now"))).withTimeout(30, TimeUnit.SECONDS).until(new Predicate<WebElement>() {
-            // The wait criteria is: we have left the current page and returned to the same one
-            @Override
-            public boolean apply(@Nullable WebElement webElement) {
+        // The wait criteria is: we have left the current page and returned to the same one
+        waitFor(find(by.button("Check now"))).withTimeout(30, TimeUnit.SECONDS).until(webElement -> {
+            try {
                 try {
-                    try {
-                        // We interact with the element just to detect if it is stale
-                        webElement.findElement(by.id("it does not matter"));
-                    } catch(StaleElementReferenceException e) {
-                        // with this exception we know we've left the original page
-                        // we look for an element in the page to check for success
-                        if (current.equals(getCurrentUrl())) {
-                            return true;
-                        }
+                    // We interact with the element just to detect if it is stale
+                    webElement.findElement(by.id("it does not matter"));
+                } catch(StaleElementReferenceException e) {
+                    // with this exception we know we've left the original page
+                    // we look for an element in the page to check for success
+                    if (current.equals(getCurrentUrl())) {
+                        return true;
                     }
-                } catch(Exception e) {
                 }
-                return true;
+            } catch(Exception e) {
             }
+            return true;
         });
         updated = true;
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/selenium/Scroller.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/selenium/Scroller.java
@@ -1,12 +1,12 @@
 package org.jenkinsci.test.acceptance.selenium;
 
+import java.io.IOException;
+
 import org.apache.commons.io.IOUtils;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.events.AbstractWebDriverEventListener;
-
-import java.io.IOException;
 
 /**
  * Automatically scrolls the element into view.
@@ -73,7 +73,7 @@ public class Scroller extends AbstractWebDriverEventListener {
     }
 
     @Override
-    public void beforeChangeValueOf(WebElement element, WebDriver driver) {
+    public void beforeChangeValueOf(WebElement element, WebDriver driver, CharSequence[] keysToSend) {
         scrollIntoView(element, driver);
     }
 


### PR DESCRIPTION
First attempt to get ATH working with Selenium 3.x. See [JENKINS-38575](https://issues.jenkins-ci.org/browse/JENKINS-38575) for the motivation behind this change.

I get the WarningsPluginTests locally running for both for Firefox and Chrome now. 

In order to get the PR validated on https://jenkins.ci.cloudbees.com/job/core/job/acceptance-test-harness/ we need to add the following properties:
```
-Dwebdriver.gecko.driver=/path/to/geckodriver
-Dwebdriver.chrome.driver=/path/to/chromedriver
```