### PR TITLE
Revert "Update to latest parent jenkins:1.37"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.37</version>
+    <version>1.36</version>
   </parent>
 
   <artifactId>acceptance-test-harness</artifactId>


### PR DESCRIPTION
This failed the build, so reveals an issue. We need to work on understanding the failure this upgrades causes. I will refile a PR with that change and see if we can fix the failures.

Reverts jenkinsci/acceptance-test-harness#286

@reviewbybees 