### PR TITLE
Add NetworkID activation parameter

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/openstack/OpenstackSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/openstack/OpenstackSlaveTemplate.java
@@ -91,6 +91,16 @@ public class OpenstackSlaveTemplate extends PageAreaImpl {
         return this;
     }
 
+    public OpenstackSlaveTemplate networkId(String id) {
+        ensureAdvancedOpened();
+        waitFor().withMessage("Network ID select populates").ignoring(NoSuchElementException.class).until(new Callable<Boolean>() {
+            @Override public Boolean call() throws Exception {
+                control("slaveOptions/networkId", "networkId").select(id);
+                return true;
+            }
+        });
+        return this;
+    }
     public OpenstackSlaveTemplate keyPair(String name) {
         ensureAdvancedOpened();
         Control control = control("slaveOptions/keyPairName", "keyPairName");

--- a/src/test/java/plugins/OpenstackCloudPluginTest.java
+++ b/src/test/java/plugins/OpenstackCloudPluginTest.java
@@ -82,6 +82,9 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
     @Inject(optional = true) @Named("OpenstackCloudPluginTest.HARDWARE_ID")
     public String HARDWARE_ID;
 
+    @Inject(optional = true) @Named("OpenstackCloudPluginTest.NETWORK_ID")
+    public String NETWORK_ID;
+
     @Inject(optional = true) @Named("OpenstackCloudPluginTest.IMAGE_ID")
     public String IMAGE_ID;
 
@@ -114,7 +117,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
 
     @Test
     @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {MACHINE_USERNAME, "/openstack_plugin/unsafe"})
-    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
+    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME", "NETWORK_ID"})
     public void provisionSshSlave() {
         configureCloudInit("cloud-init");
         configureProvisioning("SSH", "label");
@@ -128,7 +131,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
 
     @Test
     @WithCredentials(credentialType = WithCredentials.USERNAME_PASSWORD, values = {MACHINE_USERNAME, "ath"})
-    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
+    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME", "NETWORK_ID"})
     public void provisionSshSlaveWithPasswdAuth() {
         configureCloudInit("cloud-init");
         configureProvisioning("SSH", "label");
@@ -142,7 +145,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
 
     @Test
     @WithCredentials(credentialType = WithCredentials.USERNAME_PASSWORD, values = {MACHINE_USERNAME, "ath"})
-    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
+    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME", "NETWORK_ID"})
     public void provisionSshSlaveWithPasswdAuthRetryOnFailedAuth() {
         configureCloudInit("cloud-init-authfix");
         configureProvisioning("SSH", "label");
@@ -158,7 +161,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
     @Test
     // TODO: JENKINS-30784 Do not bother with credentials for jnlp slaves
     @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {MACHINE_USERNAME, "/openstack_plugin/unsafe"})
-    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
+    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME", "NETWORK_ID"})
     public void provisionJnlpSlave() {
         configureCloudInit("cloud-init-jnlp");
         configureProvisioning("JNLP", "label");
@@ -172,7 +175,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
 
     @Test @Issue("JENKINS-29998")
     @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {MACHINE_USERNAME, "/openstack_plugin/unsafe"})
-    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
+    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME", "NETWORK_ID"})
     @WithPlugins("matrix-project")
     public void scheduleMatrixWithoutLabel() {
         configureCloudInit("cloud-init");
@@ -193,7 +196,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
 
     @Test
     @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {MACHINE_USERNAME, "/openstack_plugin/unsafe"})
-    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
+    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME", "NETWORK_ID"})
     public void usePerBuildInstance() {
         configureCloudInit("cloud-init");
         configureProvisioning("SSH", "unused");
@@ -213,7 +216,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
 
     @Test
     @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {MACHINE_USERNAME, "/openstack_plugin/unsafe"})
-    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
+    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME", "NETWORK_ID"})
     public void useSingleUseSlave() {
         configureCloudInit("cloud-init");
         configureProvisioning("SSH", "label");
@@ -230,7 +233,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
 
     @Test
     @WithCredentials(credentialType = WithCredentials.USERNAME_PASSWORD, values = {MACHINE_USERNAME, "ath"})
-    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME"})
+    @TestActivation({"HARDWARE_ID", "IMAGE_ID", "KEY_PAIR_NAME", "NETWORK_ID"})
     public void sshSlaveShouldSurviveRestart() {
         assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         configureCloudInit("cloud-init");
@@ -280,6 +283,7 @@ public class OpenstackCloudPluginTest extends AbstractJUnitTest {
         template.name(CLOUD_DEFAULT_TEMPLATE);
         template.labels(labels);
         template.hardwareId(HARDWARE_ID);
+        template.networkId(NETWORK_ID);
         template.imageId(IMAGE_ID);
         template.credentials(MACHINE_USERNAME);
         template.slaveType(type);


### PR DESCRIPTION
- some tenants have more than 1 network and without a network
  selected will result in an exception resembling "Multiple networks...please select
  a network ID"