### PR TITLE
Fix testConnection test in OpenstackCloudPluginTest

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/openstack/OpenstackCloud.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/openstack/OpenstackCloud.java
@@ -24,6 +24,7 @@
 package org.jenkinsci.test.acceptance.plugins.openstack;
 
 import org.jenkinsci.test.acceptance.po.Cloud;
+import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.PageObject;
 import org.openqa.selenium.NoSuchElementException;
@@ -94,7 +95,9 @@ public class OpenstackCloud extends Cloud {
     }
 
     public OpenstackCloud testConnection() {
-        clickButton("Test Connection");
+        Control button = control(by.xpath("//div[@descriptorid='jenkins.plugins.openstack.compute.JCloudsCloud']"
+                + "//button[contains(.,'Test Connection')]"));
+        button.click();
         return this;
     }
 


### PR DESCRIPTION
- need to better locate Test Connection button
  when running test with many plugins.