### PR TITLE
Added IntelliJ IDEA code style settings for imports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ target
 .classpath
 .settings/
 jenkins*home/
-.idea/
+.idea/*
+!.idea/codeStyleSettings.xml
 *.iml
 *.iws
 *.ipr

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectCodeStyleSettingsManager">
+    <option name="PER_PROJECT_SETTINGS">
+      <value>
+        <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100" />
+        <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="0" />
+        <option name="IMPORT_LAYOUT_TABLE">
+          <value>
+            <emptyLine />
+            <package name="javax" withSubpackages="true" static="false" />
+            <package name="java" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="org" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="com" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="" withSubpackages="true" static="false" />
+            <package name="" withSubpackages="true" static="true" />
+          </value>
+        </option>
+      </value>
+    </option>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </component>
+</project>


### PR DESCRIPTION
Another attempt to reduce the hassle when creating pull request: it would be really nice if we could **at least** add the import statement order as an IDEA preference that could be used by contributors. Otherwise providing a PR requires a lot of additional work for a contributor since the diffs need to be adjusted manually. (Actually defining more settings would be even better but I think we can add additional options one after the other.)
Here 2 examples of different styles, it would be helpful if everybody would use the same style:
- https://github.com/jenkinsci/acceptance-test-harness/blob/master/src/test/java/core/FreestyleJobTest.java
- https://github.com/jenkinsci/acceptance-test-harness/blob/master/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java 
