### PR TITLE
Use a Monte Screen Recorder from Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <maven.version>3.1.0</maven.version>
     <groovy.version>2.3.1</groovy.version>
     <shrinkwrap.version>1.2.2</shrinkwrap.version>
-    <monte.version>0.7.7</monte.version>
+    <monte.version>0.7.7.0</monte.version>
     <mockito.version>1.10.19</mockito.version>
     <cucumber.options />
     <trimStackTrace>false</trimStackTrace> <!-- surefire -->
@@ -188,8 +188,8 @@
 
     <!-- recorder -->
     <dependency>
-      <groupId>org.monte</groupId>
-      <artifactId>screen-recorder</artifactId>
+      <groupId>com.github.stephenc.monte</groupId>
+      <artifactId>monte-screen-recorder</artifactId>
       <version>${monte.version}</version>
     </dependency>
     <!-- jclouds -->


### PR DESCRIPTION
- I've been getting this dependency failing to download correctly under different versions of Maven
  Safer to switch to a deployment on Maven

- This is particularly a problem when running the acceptance tests from within a docker container such as with https://github.com/jenkinsci/acceptance-test-harness/pull/238

@reviewbybees 