### PR TITLE
Add an alternative mechanism for overriding plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <maven.version>3.1.0</maven.version>
     <groovy.version>2.3.1</groovy.version>
     <shrinkwrap.version>1.2.2</shrinkwrap.version>
-    <monte.version>0.7.7</monte.version>
+    <monte.version>0.7.7.0</monte.version>
     <mockito.version>1.10.19</mockito.version>
     <cucumber.options />
     <trimStackTrace>false</trimStackTrace> <!-- surefire -->
@@ -188,8 +188,8 @@
 
     <!-- recorder -->
     <dependency>
-      <groupId>org.monte</groupId>
-      <artifactId>screen-recorder</artifactId>
+      <groupId>com.github.stephenc.monte</groupId>
+      <artifactId>monte-screen-recorder</artifactId>
       <version>${monte.version}</version>
     </dependency>
     <!-- jclouds -->
@@ -657,7 +657,7 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <environmentVariables>
+              <environmentVariables combine.children="append">
                 <CONFIG>single-plugin.groovy</CONFIG>
                 <TEST_ONLY_PLUGINS>${testOnlyPlugins}</TEST_ONLY_PLUGINS>
               </environmentVariables>
@@ -690,7 +690,7 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <environmentVariables>
+              <environmentVariables combine.children="append">
                 <BROWSER>${BROWSER}</BROWSER>
               </environmentVariables>
             </configuration>
@@ -710,7 +710,7 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <environmentVariables>
+              <environmentVariables combine.children="append">
                 <JENKINS_WAR>${JENKINS_WAR}</JENKINS_WAR>
               </environmentVariables>
             </configuration>
@@ -730,7 +730,7 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <environmentVariables>
+              <environmentVariables combine.children="append">
                 <LOCAL_SNAPSHOTS>${LOCAL_SNAPSHOTS}</LOCAL_SNAPSHOTS>
               </environmentVariables>
             </configuration>
@@ -750,7 +750,7 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <environmentVariables>
+              <environmentVariables combine.children="append">
                   <RECORDER>${RECORDER}</RECORDER>
               </environmentVariables>
             </configuration>
@@ -770,7 +770,7 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <environmentVariables>
+              <environmentVariables combine.children="append">
                   <BROWSER_DISPLAY>${BROWSER_DISPLAY}</BROWSER_DISPLAY>
               </environmentVariables>
             </configuration>
@@ -790,8 +790,48 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <environmentVariables>
+              <environmentVariables combine.children="append">
                 <FORM_ELEMENT_PATH_VERSION>${FORM_ELEMENT_PATH_VERSION}</FORM_ELEMENT_PATH_VERSION>
+              </environmentVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>FORCE_PLUGIN_VERSIONS</id>
+      <activation>
+        <property>
+          <name>FORCE_PLUGIN_VERSIONS</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <environmentVariables combine.children="append">
+                <FORCE_PLUGIN_VERSIONS>${FORCE_PLUGIN_VERSIONS}</FORCE_PLUGIN_VERSIONS>
+              </environmentVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>FORCE_PLUGIN_FILES</id>
+      <activation>
+        <property>
+          <name>FORCE_PLUGIN_FILES</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <environmentVariables combine.children="append">
+                <FORCE_PLUGIN_FILES>${FORCE_PLUGIN_FILES}</FORCE_PLUGIN_FILES>
               </environmentVariables>
             </configuration>
           </plugin>

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/DownloadOverrideUpdateCenterMetadataDecorator.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/DownloadOverrideUpdateCenterMetadataDecorator.java
@@ -1,7 +1,15 @@
 package org.jenkinsci.test.acceptance.update_center;
 
 import com.cloudbees.sdk.extensibility.Extension;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Properties;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Download particular plugin version based on environement variable.
@@ -11,6 +19,7 @@ public class DownloadOverrideUpdateCenterMetadataDecorator implements UpdateCent
 
     @Override
     public void decorate(UpdateCenterMetadata ucm) {
+        Map<String,String> overrides = new LinkedHashMap<>();
         for (Map.Entry<String,String> e : System.getenv().entrySet()) {
             String key = e.getKey();
             if (key.endsWith(".version")) {
@@ -21,6 +30,30 @@ public class DownloadOverrideUpdateCenterMetadataDecorator implements UpdateCent
                 if (original == null) throw new IllegalArgumentException("Plugin does not exists in update center: " + name);
                 ucm.plugins.put(name, original.withVersion(version));
             }
+        }
+        String localPlugins = System.getenv("FORCE_PLUGIN_VERSIONS");
+        if (StringUtils.isNotBlank(localPlugins)) {
+            File file = new File(localPlugins);
+            if (!file.isFile()) {
+                throw new AssertionError(
+                        "Environment variable 'FORCE_PLUGIN_VERSIONS' specifies a non-existent file: " + file);
+            }
+            Properties properties = new Properties();
+            try (InputStream is = Files.newInputStream(file.toPath())) {
+                properties.load(is);
+            } catch (IOException e) {
+                throw new AssertionError("Could not read 'FORCE_PLUGIN_VERSIONS' file: " + file, e);
+            }
+            for (Map.Entry<Object, Object> e : properties.entrySet()) {
+                overrides.put((String) e.getKey(), (String) e.getValue());
+            }
+        }
+        for (Map.Entry<String, String> e : overrides.entrySet()) {
+            PluginMetadata original = ucm.plugins.get(e.getKey());
+            if (original == null) {
+                throw new IllegalArgumentException("Plugin does not exists in update center: " + e.getKey());
+            }
+            ucm.plugins.put(e.getKey(), original.withVersion(e.getValue()));
         }
     }
 }


### PR DESCRIPTION
Passing environment variables that contain a . in the name is problematic, much easier to pass the path of a `.properties` file and load the plugin versions or plugin files from that properties file, e.g.

```
echo "ldap=$(pwd)/ldap.hpi" > force.plugins
./run.sh firefox latest -Dtest=LdapPluginTest "-DFORCE_PLUGIN_FILES=$(pwd)/force.plugins"
```

or

```
echo "ldap=1.14" > force.plugins
./run.sh firefox latest -Dtest=LdapPluginTest "-DFORCE_PLUGIN_VERSIONS=$(pwd)/force.plugins"
```

(you can do a combination of both using different files for the versions and the local .hpi files)

@reviewbybees 