### PR TITLE
Make name of jut-server socket file configurable for the test runner.

### DIFF
--- a/docs/PRELAUNCH.md
+++ b/docs/PRELAUNCH.md
@@ -22,8 +22,10 @@ To launch a JUT server, run the following command:
     JENKINS_WAR=/path/to/jenkins.war ./jut-server.sh
 
 The server will keep running until you kill the Maven process. The server listens to
-Unix domain socket at `~/jenkins.sock`. You can change the name of the socket using the command
-line parameter `-socket /path/to/jenkins.sock`.
+Unix domain socket at `~/jenkins.sock`. You can change the name of the socket using 
+the environment variable `JUT_SOCKET`:
+
+    JENKINS_WAR=/path/to/jenkins.war JUT_SOCKET=/path/to/jenkins.sock ./jut-server.sh
 
 JUT server internally uses to other real `JenkinsController` implementations to launch JUT,
 and you configure it the same way you configure normal test executions. That is, the above example
@@ -39,7 +41,7 @@ e.g. in order to start 2 instances, run:
 
 If no controller is explicitly specified, the harness checks the presence of `~/jenkins.sock` and
 it automatically selects `PooledJenkinsController`. If you did change the name of the socket (see section
-[Launching JUT server](#launching-jut-server))
-then you need to specify the filename using the `JUT_SOCKET` environment variable.
+[Launching JUT server](#launching-jut-server)) then you also need to specify the name using the 
+`JUT_SOCKET` environment variable when running the tests.
 
 To select this controller explicitly, use `TYPE=pool` environment variable.

--- a/docs/PRELAUNCH.md
+++ b/docs/PRELAUNCH.md
@@ -40,6 +40,6 @@ e.g. in order to start 2 instances, run:
 If no controller is explicitly specified, the harness checks the presence of `~/jenkins.sock` and
 it automatically selects `PooledJenkinsController`. If you did change the name of the socket (see section
 [Launching JUT server](#launching-jut-server))
-then you need to specify the filename using the `SOCKET` environment variable.
+then you need to specify the filename using the `JUT_SOCKET` environment variable.
 
 To select this controller explicitly, use `TYPE=pool` environment variable.

--- a/docs/PRELAUNCH.md
+++ b/docs/PRELAUNCH.md
@@ -22,7 +22,8 @@ To launch a JUT server, run the following command:
     JENKINS_WAR=/path/to/jenkins.war ./jut-server.sh
 
 The server will keep running until you kill the Maven process. The server listens to
-Unix domain socket at `~/jenkins.sock`
+Unix domain socket at `~/jenkins.sock`. You can change the name of the socket using the command
+line parameter `-socket /path/to/jenkins.sock`.
 
 JUT server internally uses to other real `JenkinsController` implementations to launch JUT,
 and you configure it the same way you configure normal test executions. That is, the above example
@@ -37,6 +38,8 @@ e.g. in order to start 2 instances, run:
 ## Selecting PooledJenkinsController
 
 If no controller is explicitly specified, the harness checks the presence of `~/jenkins.sock` and
-it automatically selects `PooledJenkinsController`.
+it automatically selects `PooledJenkinsController`. If you did change the name of the socket (see section
+[Launching JUT server](#launching-jut-server))
+then you need to specify the filename using the `SOCKET` environment variable.
 
 To select this controller explicitly, use `TYPE=pool` environment variable.

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -301,7 +301,7 @@ public class FallbackConfig extends AbstractModule {
      */
     @Provides @Named("socket")
     public File getSocket() {
-        String socket = System.getenv("SOCKET");
+        String socket = System.getenv("JUT_SOCKET");
         if (StringUtils.isNotBlank(socket)) {
             return new File(socket);
         }

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -227,10 +227,10 @@ public class FallbackConfig extends AbstractModule {
         if (type==null)
             type = System.getenv("TYPE");
         if (type==null) {
-            File socket = JenkinsControllerPoolProcess.SOCKET;
+            File socket = getSocket();
             if (socket.exists() && !JenkinsControllerPoolProcess.MAIN) {
                 System.out.println("Found pooled jenkins controller listening on socket " + socket.getAbsolutePath());
-                return new PooledJenkinsController(injector);
+                return new PooledJenkinsController(injector, socket);
             }
             else {
                 System.out.println("No pooled jenkins controller listening on socket " + socket.getAbsolutePath());
@@ -290,6 +290,22 @@ public class FallbackConfig extends AbstractModule {
         String ws = System.getenv("WORKSPACE");
         if (ws != null) return ws;
         return new File(System.getProperty("user.dir"), "target").getPath();
+    }
+
+    /**
+     * Name of the socket file used to communicate between jut-server and JUnit.
+     *
+     * @return the name of the socket
+     * @see JenkinsControllerPoolProcess
+     * @see docs/PRELAUNCH.md
+     */
+    @Provides @Named("socket")
+    public File getSocket() {
+        String socket = System.getenv("SOCKET");
+        if (StringUtils.isNotBlank(socket)) {
+            return new File(socket);
+        }
+        return new File(System.getProperty("user.home"),"jenkins.sock");
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
@@ -434,7 +434,7 @@ public abstract class LocalController extends JenkinsController implements LogLi
 
     /**
      * Set the flag to run the install wizard.
-     * 
+     *
      * @param runInstallWizard - <code>true</code> to run the install wizard
      */
     public void setRunInstallWizard(boolean runInstallWizard) {

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
@@ -434,7 +434,7 @@ public abstract class LocalController extends JenkinsController implements LogLi
 
     /**
      * Set the flag to run the install wizard.
-     *
+     * 
      * @param runInstallWizard - <code>true</code> to run the install wizard
      */
     public void setRunInstallWizard(boolean runInstallWizard) {

--- a/src/main/java/org/jenkinsci/test/acceptance/server/JenkinsControllerPoolProcess.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/server/JenkinsControllerPoolProcess.java
@@ -58,7 +58,7 @@ public class JenkinsControllerPoolProcess {
     @Option(name="-n",usage="Number of instances to pool. >=1.")
     public int n = Integer.getInteger("count",1);
 
-    @Option(name="-socket",usage="Unix domain socket file to communicate with client") @Inject @Named("socket")
+    @Inject @Named("socket")
     public File socket;
 
     private final ExecutorService executors = Executors.newCachedThreadPool();

--- a/src/main/java/org/jenkinsci/test/acceptance/server/JenkinsControllerPoolProcess.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/server/JenkinsControllerPoolProcess.java
@@ -20,6 +20,7 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -57,8 +58,8 @@ public class JenkinsControllerPoolProcess {
     @Option(name="-n",usage="Number of instances to pool. >=1.")
     public int n = Integer.getInteger("count",1);
 
-    @Option(name="-socket",usage="Unix domain socket file to communicate with client")
-    public File socket = SOCKET;
+    @Option(name="-socket",usage="Unix domain socket file to communicate with client") @Inject @Named("socket")
+    public File socket;
 
     private final ExecutorService executors = Executors.newCachedThreadPool();
 
@@ -179,7 +180,6 @@ public class JenkinsControllerPoolProcess {
         }
     }
 
-    public static final File SOCKET = new File(System.getProperty("user.home"),"jenkins.sock");
     /**
      * Are we running the JUT server?
      */

--- a/src/main/java/org/jenkinsci/test/acceptance/server/PooledJenkinsController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/server/PooledJenkinsController.java
@@ -41,11 +41,6 @@ public class PooledJenkinsController extends JenkinsController implements LogLis
     private IJenkinsController controller;
     private final List<byte[]> toUnpack = new LinkedList<>();
 
-    @Inject
-    public PooledJenkinsController(Injector i) {
-        this(i, JenkinsControllerPoolProcess.SOCKET);
-    }
-
     public PooledJenkinsController(Injector i, File socket) {
         super(i);
         this.socket = socket;


### PR DESCRIPTION
jut-server already has the option to change the file name using the command line option -socket. However, the client (i.e. the unit test) does not have this option yet. This PR adds a new environment variable SOCKET that makes the socket configurable on both sides.