### PR TITLE
[JENKINS-44130] LdapPluginTest failing with ldap 1.15

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ldap/SearchForGroupsLdapGroupMembershipStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ldap/SearchForGroupsLdapGroupMembershipStrategy.java
@@ -5,7 +5,7 @@ import org.jenkinsci.test.acceptance.po.*;
 /**
  * @author Michael Prankl
  */
-@Describable("Search for LDAP groups containing user")
+@Describable({"Search for groups containing user", "Search for LDAP groups containing user"})
 public class SearchForGroupsLdapGroupMembershipStrategy extends LdapGroupMembershipStrategy {
 
     private Control groupMembershipFilter = control("filter");

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ldap/SearchForGroupsLdapGroupMembershipStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ldap/SearchForGroupsLdapGroupMembershipStrategy.java
@@ -5,7 +5,7 @@ import org.jenkinsci.test.acceptance.po.*;
 /**
  * @author Michael Prankl
  */
-@Describable("Search for groups containing user")
+@Describable("Search for LDAP groups containing user")
 public class SearchForGroupsLdapGroupMembershipStrategy extends LdapGroupMembershipStrategy {
 
     private Control groupMembershipFilter = control("filter");


### PR DESCRIPTION
[JENKINS-44130](https://issues.jenkins-ci.org/browse/JENKINS-44130)

Updated the `Describable` value to properly reflect the new caption of the field added in [this commit](https://github.com/jenkinsci/ldap-plugin/commit/0633afcd053254b38ee0d172c4e81c76d486640c#diff-8214e35f22e690a47c1358a68bc4dc1bR2)

I know there is an existing [PR](https://github.com/jenkinsci/acceptance-test-harness/pull/305/files) to increase test coverage for `1.15` but that PR is much broader in scope and AFAIK does not solve this issue, so I believe is compatible with this. This as a quick fix for the existing tests and the other as an enhancement for the ATH

@reviewbybees  