### PR TITLE
[JENKINS-44232] Fallback when exception is thrown in CapybaraPortingLayerImpl.check

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -288,8 +288,8 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
                 e.click();
             }
         } catch (WebDriverException ex) {
-            // There was an error clicking the element, let's try the fallback
-            LOGGER.log(Level.WARNING, String.format("Element %s could not be clicked. Trying javascript click", e.toString()), e);
+            // There was an error clicking the element, let's try the javascript fallback
+            LOGGER.log(Level.WARNING, String.format("Element %s could not be clicked. Trying javascript click...", e.toString()), ex);
         }
         
         // It seems like Selenium sometimes has issues when trying to click elements that are out of view.


### PR DESCRIPTION
See [JENKINS-44232](https://issues.jenkins-ci.org/browse/JENKINS-44232)

If for some reason, performing a click on a checkbox throws an exception, the Javascript fallback is never tried. We should capture the exception, log it, and try the Javascript fallback. More details in the ticket attached.

@reviewbybees 