### PR TITLE
[JENKINS-44362] Fix MatrixPluginTest#run_configurations_on_with_a_given_label

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/LabelAxis.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/LabelAxis.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.test.acceptance.po;
 
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.lift.Matchers;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -17,6 +18,8 @@ public class LabelAxis extends Axis {
             // unfold the labels and slaves sub-nodes
             find(by.xpath("//div[@class='yahooTree labelAxis-tree']//table[@id='ygtvtableel1']//a")).click();
             find(by.xpath("//div[@class='yahooTree labelAxis-tree']//table[@id='ygtvtableel2']//a")).click();
+
+            waitFor(checkBox, Matchers.displayed(), 3);
         }
         check(checkBox, true);
     }


### PR DESCRIPTION
[JENKINS-44362](https://issues.jenkins-ci.org/browse/JENKINS-44362)

Test is flaky: sometimes when expanding the tree is necessary to look for the element, the click in actually tried before the checkbox is displayed.

@reviewbybees esp. @raul-arabaolaza @olivergondza 

