### PR TITLE
[JENKINS-44508] git-userContent ATH test is failing

### DIFF
--- a/src/test/java/plugins/GitUserContentTest.java
+++ b/src/test/java/plugins/GitUserContentTest.java
@@ -40,6 +40,8 @@ public class GitUserContentTest extends AbstractJUnitTest {
                 "    git url: '%suserContent.git/'\n" +
                 "    writeFile encoding: 'UTF-8', file: '%s', text: '%s'\n" +
                 "    sh 'git add %s'\n" +
+                "    sh 'git config user.email \"you@example.com\"'\n" +
+                "    sh 'git config user.name \"Your Name\"'\n" +
                 "    sh 'git commit -m \"Including new file\"'\n" +
                 "    sh 'git push --set-upstream origin master'\n" +
                 "}", jenkins.url, NEW_FILE_NAME, NEW_FILE_CONTENT, NEW_FILE_NAME));


### PR DESCRIPTION
[JENKINS-44508](https://issues.jenkins-ci.org/browse/JENKINS-44508)

Set user.name and user.email before trying to commit

@reviewbybees specially @varyvol 