### PR TITLE
make pageLoadTimeout configurable

### DIFF
--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -42,6 +42,8 @@ For example,
 
 See [WIRING.md](WIRING.md) for details of where to put this.
 
+One slow hardware it's possible, that all tests fail because the pageLoadTimeout of the WebDriver is exceeded. You can use the `PAGE_LOAD_TIMEOUT` environment variable to configure the timeout. If the value is greater than 0, it is used as the timeout in seconds. Values of 0 or below mean that there is no timeout. The default value is 30 seconds.
+
 ## Avoid focus steal with Xvnc on Linux
 If you select a real GUI browser, such as Firefox, browser window will pop up left and right during tests, making it practically unusable for you to use your computer. There is a script to run vnc server and propage the display number to the test suite using dedicated variable `BROWSER_DISPLAY`.
 

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -188,8 +188,17 @@ public class FallbackConfig extends AbstractModule {
         d.register(new SanityChecker());
         d.register(new Scroller());
 
+        // Check if pageLoadTimeout is set
+        int seconds = 30;
         try {
-            d.manage().timeouts().pageLoadTimeout(time.seconds(30), TimeUnit.MILLISECONDS);
+            String timeout = System.getenv("PAGE_LOAD_TIMEOUT");
+            if (timeout != null) seconds = Integer.parseInt(timeout);
+        } catch (NumberFormatException e) {
+            System.out.println("PAGE_LOAD_TIMEOUT is not an integer, fallback to default of 30 seconds.");
+        }
+
+        try {
+            if (seconds > 0) d.manage().timeouts().pageLoadTimeout(time.seconds(seconds), TimeUnit.MILLISECONDS);
             d.manage().timeouts().implicitlyWait(time.seconds(1), TimeUnit.MILLISECONDS);
         } catch (UnsupportedCommandException e) {
             // sauce labs RemoteWebDriver doesn't support this


### PR DESCRIPTION
On slow hardware it isn't possible to run any test because the
pageLoadTimeout is exceeded.