### PR TITLE
Update Oracle JDK URL for cloud-init

### DIFF
--- a/src/test/resources/openstack_plugin/cloud-init
+++ b/src/test/resources/openstack_plugin/cloud-init
@@ -18,7 +18,7 @@ runcmd:
   - [ "chown", "jenkins", "/home/jenkins" ] # Not sure why this is needed - othwrvise owned by root
   - [ "sh", "-c", "echo jenkins:ath | chpasswd" ]
   - [ "mkdir", "/usr/local/java/" ] # Location searched by ssh-slaves plugin, though not controlled by it
-  - [ "curl", "-L", "-o", "/usr/local/java/java.tar.gz", "http://download.oracle.com/otn-pub/java/jdk/8u51-b16/jdk-8u51-linux-x64.tar.gz", "-H", "Cookie: oraclelicense=accept-securebackup-cookie" ]
+  - [ "curl", "-L", "-o", "/usr/local/java/java.tar.gz", "http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz", "-H", "Cookie: oraclelicense=accept-securebackup-cookie" ]
   - [ "tar", "xf", "/usr/local/java/java.tar.gz", "-C",  "/usr/local/java/", "--strip-components=1" ]
 # Fix auth
   - [ "iptables", "-D", "INPUT", "-m", "tcp", "-p", "tcp", "--dport", "22", "-j", "REJECT" ]

--- a/src/test/resources/openstack_plugin/cloud-init-authfix
+++ b/src/test/resources/openstack_plugin/cloud-init-authfix
@@ -19,7 +19,7 @@ runcmd:
 
   - [ "chown", "jenkins", "/home/jenkins" ] # Not sure why this is needed - othwrvise owned by root
   - [ "mkdir", "/usr/local/java/" ] # Location searched by ssh-slaves plugin, though not controlled by it
-  - [ "curl", "-L", "-o", "/usr/local/java/java.tar.gz", "http://download.oracle.com/otn-pub/java/jdk/8u51-b16/jdk-8u51-linux-x64.tar.gz", "-H", "Cookie: oraclelicense=accept-securebackup-cookie" ]
+  - [ "curl", "-L", "-o", "/usr/local/java/java.tar.gz", "http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz", "-H", "Cookie: oraclelicense=accept-securebackup-cookie" ]
   - [ "tar", "xf", "/usr/local/java/java.tar.gz", "-C",  "/usr/local/java/", "--strip-components=1" ]
 # Fix auth at the very end so ssh-slaves will retry until java is installed. Otherwise, plugin will install java itself which is much slower for some reason
   - [ "sh", "-c", "echo jenkins:ath | chpasswd" ]

--- a/src/test/resources/openstack_plugin/cloud-init-jnlp
+++ b/src/test/resources/openstack_plugin/cloud-init-jnlp
@@ -17,7 +17,7 @@ users:
 runcmd:
   - [ "set", "-x" ]
   - [ "mkdir", "/usr/local/java/" ]
-  - [ "curl", "-LSs", "-o", "/usr/local/java/java.tar.gz", "http://download.oracle.com/otn-pub/java/jdk/8u51-b16/jdk-8u51-linux-x64.tar.gz", "-H", "Cookie: oraclelicense=accept-securebackup-cookie" ]
+  - [ "curl", "-LSs", "-o", "/usr/local/java/java.tar.gz", "http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz", "-H", "Cookie: oraclelicense=accept-securebackup-cookie" ]
   - [ "tar", "xf", "/usr/local/java/java.tar.gz", "-C",  "/usr/local/java/", "--strip-components=1" ]
   - [ "curl", "-LSs", "-o", "/tmp/slave.jar", "http://repo.jenkins-ci.org/releases/org/jenkins-ci/main/remoting/3.4.1/remoting-3.4.1.jar" ]
   - [ "sh", "-c", "/usr/local/java/bin/java -jar /tmp/slave.jar -jnlpUrl ${SLAVE_JNLP_URL} &" ]


### PR DESCRIPTION
Previous URL would simply be redirected. The side-effect would be that the jdk would not get downloaded and installed in /usr/local/java and agents would not be able come up and connect to the JUT