### PR TITLE
Simpler implementation of check for restart()

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import org.apache.commons.io.IOUtils;
-import org.hamcrest.MatcherAssert;
 import org.jenkinsci.test.acceptance.controller.JenkinsController;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
@@ -17,8 +16,6 @@ import com.google.common.base.Predicate;
 import com.google.inject.Injector;
 
 import hudson.util.VersionNumber;
-import static org.hamcrest.Matchers.*;
-import static org.jenkinsci.test.acceptance.Matchers.*;
 
 /**
  * Top-level object that acts as an entry point to various systems.
@@ -161,8 +158,7 @@ public class Jenkins extends Node implements Container {
                     @Override
                     public boolean apply(WebDriver driver) {
                         visit(driver.getCurrentUrl()); // the page sometimes does not reload (fast enough)
-                        MatcherAssert.assertThat(driver, not(hasContent("Please wait")));
-                        MatcherAssert.assertThat(driver, hasContent("Jenkins ver.")); // Wait until Jenkins actually is up
+                        getJson("tree=nodeName"); // HudsonIsRestarting will serve a 503 to the index page, and will refuse api/json
                         return true;
                     }
                 })


### PR DESCRIPTION
Existing check relied on [this text](https://github.com/jenkinsci/jenkins/blob/dd18af378f014e1aae706c0bb300bcb0f66342a9/core/src/main/resources/lib/layout/layout.jelly#L281), which can be replaced with something else in an OEM distribution. Observed against `WorkflowPluginTest.linearFlow` in CloudBees products. Rather than relying on variable HTML contents, seems simpler and more robust to check the API, which is only offered after startup is complete. (`LocalController.startNow` uses `LogWatcher` but we cannot rely on that from `restart` I think.)

An alternate approach would be to scan for

```html
<span class="jenkins_ver">
```

which is at least less likely to be replaced by branding. Really the proper thing would be for Jenkins core to explicitly offer brandable resource strings, as NetBeans does.

@reviewbybees