### PR TITLE
[JENKINS-44610] GitPluginNoDockerTest is failling in the ATH

### DIFF
--- a/src/test/java/plugins/no_docker/GitPluginNoDockerTest.java
+++ b/src/test/java/plugins/no_docker/GitPluginNoDockerTest.java
@@ -50,12 +50,12 @@ public class GitPluginNoDockerTest extends AbstractJUnitTest {
 
     @Test
     public void checkout_branch_git() {
-        assertExecutesFine(generateJobWithBranch(GIT_IMPL.GIT), "test `git rev-parse origin/svn` = `git rev-parse HEAD`");
+        assertExecutesFine(generateJobWithBranch(GIT_IMPL.GIT), "test `git rev-parse origin/recovery` = `git rev-parse HEAD`");
     }
 
     @Test
     public void checkout_branch_jgit() {
-        assertExecutesFine(generateJobWithBranch(GIT_IMPL.JGIT), "test `git rev-parse origin/svn` = `git rev-parse HEAD`");
+        assertExecutesFine(generateJobWithBranch(GIT_IMPL.JGIT), "test `git rev-parse origin/recovery` = `git rev-parse HEAD`");
     }
 
     @Test
@@ -126,7 +126,7 @@ public class GitPluginNoDockerTest extends AbstractJUnitTest {
 
     private Job generateJobWithBranch(GIT_IMPL type) {
         Job job = generateJob(type);
-        GitScm scm = generateSCM(job).branch("svn");
+        GitScm scm = generateSCM(job).branch("recovery");
         useJGitIfNeccesary(type, scm);
         return job;
     }


### PR DESCRIPTION
[JENKINS-44610](https://issues.jenkins-ci.org/browse/JENKINS-44610)

The problem is that the `svn` branch no longer exists... so the easy fix is to change it to one that exists. I know that this test is fragile but AFAIK this suite is intended to be removed in the future so is not worth the effort

@reviewbybees 

