### PR TITLE
Fixing CachedUpdateCenterMetadataLoader to take into account the version number of Jenkins

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/WithPlugins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/WithPlugins.java
@@ -32,6 +32,7 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 
 import hudson.util.VersionNumber;
+import java.io.IOException;
 
 /**
  * Indicates that a test requires the presence of the specified plugins.
@@ -174,7 +175,7 @@ public @interface WithPlugins {
                         try {
                             //noinspection deprecation
                             pm.installPlugins(installList);
-                        } catch (UnableToResolveDependencies ex) {
+                        } catch (UnableToResolveDependencies | IOException ex) {
                             throw new AssumptionViolatedException("Unable to install required plugins", ex);
                         }
                     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -2,7 +2,6 @@ package org.jenkinsci.test.acceptance.po;
 
 import javax.annotation.Nullable;
 import javax.inject.Named;
-import javax.inject.Provider;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -18,8 +17,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.update_center.PluginMetadata;
 import org.jenkinsci.test.acceptance.update_center.PluginSpec;
-import org.jenkinsci.test.acceptance.update_center.UpdateCenterMetadata;
 import org.jenkinsci.test.acceptance.update_center.UpdateCenterMetadata.UnableToResolveDependencies;
+import org.jenkinsci.test.acceptance.update_center.UpdateCenterMetadataProvider;
 import org.junit.internal.AssumptionViolatedException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
@@ -46,7 +45,7 @@ public class PluginManager extends ContainerPageObject {
     public final Jenkins jenkins;
 
     @Inject
-    private Provider<UpdateCenterMetadata> ucmd;
+    private UpdateCenterMetadataProvider ucmd;
 
     /**
      * Optional configuration value that selects whether to resolve plugins locally and upload to Jenkins
@@ -168,7 +167,7 @@ public class PluginManager extends ContainerPageObject {
      * @return Always false.
      */
     @Deprecated
-    public boolean installPlugins(final PluginSpec... specs) throws UnableToResolveDependencies {
+    public boolean installPlugins(final PluginSpec... specs) throws UnableToResolveDependencies, IOException {
         final Map<String, String> candidates = getMapShortNamesVersion(specs);
 
         if (!updated) {
@@ -191,7 +190,7 @@ public class PluginManager extends ContainerPageObject {
             if (!someChangeRequired) {
                 return false;
             }
-            List<PluginMetadata> pluginToBeInstalled = ucmd.get().transitiveDependenciesOf(jenkins, Arrays.asList(specs));
+            List<PluginMetadata> pluginToBeInstalled = ucmd.get(jenkins).transitiveDependenciesOf(jenkins, Arrays.asList(specs));
             for (PluginMetadata newPlugin: pluginToBeInstalled) {
                 final String name = newPlugin.getName();
                 String requiredVersion = candidates.get(name);

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
@@ -2,7 +2,6 @@ package org.jenkinsci.test.acceptance.update_center;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.inject.ProvidedBy;
 
 import hudson.util.VersionNumber;
 
@@ -24,7 +23,6 @@ import org.junit.internal.AssumptionViolatedException;
  *
  * @author Kohsuke Kawaguchi
  */
-@ProvidedBy(CachedUpdateCenterMetadataLoader.class)
 public class UpdateCenterMetadata {
     /**
      * Details of plugins by {@linkplain PluginMetadata#name their name}.

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadataProvider.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadataProvider.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.test.acceptance.update_center;
+
+import com.google.inject.ImplementedBy;
+import java.io.IOException;
+import org.jenkinsci.test.acceptance.po.Jenkins;
+
+/**
+ * Obtains update center metadata for a given Jenkins service.
+ */
+@ImplementedBy(CachedUpdateCenterMetadataLoader.class)
+public interface UpdateCenterMetadataProvider {
+
+    /**
+     * Loads metadata.
+     * @param jenkins the Jenkins service
+     * @return parsed {@code update-center.json}
+     * @throws IOException if there is any problem
+     */
+    UpdateCenterMetadata get(Jenkins jenkins) throws IOException;
+
+}


### PR DESCRIPTION
Solves the problem alluded to in #318, which can be seen for example by

    JENKINS_WAR=…/jenkins-war-2.46.3.war mvn -Dtest=plugins.FolderPluginTest\#folderScopedCredentialsTest test

Previously this would skip the test case, since metadata for an unspecified and presumed trunk version of Jenkins would be downloaded, so ATH would attempt to install `workflow-job` 2.12, then abort when it saw that this requires 2.60+. Now it will download `update-center.json?version=2.46.3` and install `workflow-job` 2.11 as expected.

@reviewbybees