### PR TITLE
LogParser Plugin: Check for unstable and failed builds

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/logparser/LogParserPublisher.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/logparser/LogParserPublisher.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.test.acceptance.plugins.logparser;
 
+import org.jenkinsci.test.acceptance.junit.Resource;
 import org.jenkinsci.test.acceptance.po.*;
 
 /**
@@ -14,10 +15,14 @@ public class LogParserPublisher extends AbstractStep implements PostBuildStep {
     public enum RuleType {
         PROJECT("true"), GLOBAL("false");
         private final String projecttype;
-        RuleType(String projecttype){
+
+        RuleType(String projecttype) {
             this.projecttype = projecttype;
-        };
-        public String getProjecttype(){
+        }
+
+        ;
+
+        public String getProjecttype() {
             return projecttype;
         }
     }
@@ -44,7 +49,7 @@ public class LogParserPublisher extends AbstractStep implements PostBuildStep {
      *
      * @param state The boolean state of the checkbox
      */
-    public void setMarkOnUnstableWarning(boolean state){
+    public void setMarkOnUnstableWarning(boolean state) {
         controlMarkOnUnstableWarning.check(state);
     }
 
@@ -53,7 +58,7 @@ public class LogParserPublisher extends AbstractStep implements PostBuildStep {
      *
      * @param state The boolean state of the checkbox
      */
-    public void setMarkOnBuildFail(boolean state){
+    public void setMarkOnBuildFail(boolean state) {
         controlMarkOnBuildFail.check(state);
     }
 
@@ -62,7 +67,7 @@ public class LogParserPublisher extends AbstractStep implements PostBuildStep {
      *
      * @param state The boolean state of the checkbox
      */
-    public void setShowGraphs(boolean state){
+    public void setShowGraphs(boolean state) {
         controlShowGraphs.check(state);
     }
 
@@ -84,5 +89,14 @@ public class LogParserPublisher extends AbstractStep implements PostBuildStep {
             default:
                 break;
         }
+    }
+
+    /**
+     * Sets a new rule as {@link RuleType#PROJECT}.
+     *
+     * @param resource The {@link Resource} object of a rule file.
+     */
+    public void setRule(Resource resource) {
+        setRule(RuleType.PROJECT, resource.url.getPath());
     }
 }

--- a/src/test/java/plugins/LogParserTest.java
+++ b/src/test/java/plugins/LogParserTest.java
@@ -63,7 +63,7 @@ public class LogParserTest extends AbstractJUnitTest {
 
     /**
      * Test case:
-     * Check for the build to be marked as failed.
+     * Check for the build to be marked as unstable.
      */
     @Test
     public void checkMarkedUnstableOnWarning() {
@@ -73,12 +73,12 @@ public class LogParserTest extends AbstractJUnitTest {
 
         // Create a new freestyle job
         FreeStyleJob job = jenkins.jobs.create(FreeStyleJob.class, "simple-job");
-        job.configure();
-        job.addShellStep("echo marked as warn");
-        LogParserPublisher lpp = job.addPublisher(LogParserPublisher.class);
-        lpp.setMarkOnUnstableWarning(true);
-        lpp.setRule(LogParserPublisher.RuleType.GLOBAL, "" + rule.url.getPath());
-        job.save();
+        job.configure(() -> {
+            job.addShellStep("echo marked as warn");
+            LogParserPublisher lpp = job.addPublisher(LogParserPublisher.class);
+            lpp.setMarkOnUnstableWarning(true);
+            lpp.setRule(LogParserPublisher.RuleType.GLOBAL, "" + rule.url.getPath());
+        });
 
         job.startBuild().waitUntilFinished().open();
 
@@ -99,12 +99,12 @@ public class LogParserTest extends AbstractJUnitTest {
 
         // Create a new freestyle job
         FreeStyleJob job = jenkins.jobs.create(FreeStyleJob.class, "simple-job");
-        job.configure();
-        job.addShellStep("echo marked as error");
-        LogParserPublisher lpp = job.addPublisher(LogParserPublisher.class);
-        lpp.setMarkOnBuildFail(true);
-        lpp.setRule(LogParserPublisher.RuleType.GLOBAL, "" + rule.url.getPath());
-        job.save();
+        job.configure(() -> {
+            job.addShellStep("echo marked as error");
+            LogParserPublisher lpp = job.addPublisher(LogParserPublisher.class);
+            lpp.setMarkOnBuildFail(true);
+            lpp.setRule(LogParserPublisher.RuleType.GLOBAL, "" + rule.url.getPath());
+        });
 
         job.startBuild().waitUntilFinished().open();
 

--- a/src/test/java/plugins/LogParserTest.java
+++ b/src/test/java/plugins/LogParserTest.java
@@ -111,9 +111,9 @@ public class LogParserTest extends AbstractJUnitTest {
      * Adds a new rule to the existing config.
      *
      * @param description The description of the new rule.
-     * @param resource The {@link Resource} object of the rule file. 
+     * @param resource    The {@link Resource} object of the rule file.
      */
-    private void addLogParserRule(final String description, Resource resource){
+    private void addLogParserRule(final String description, Resource resource) {
         addLogParserRule(description, resource.url.getPath());
     }
 

--- a/src/test/java/plugins/LogParserTest.java
+++ b/src/test/java/plugins/LogParserTest.java
@@ -108,6 +108,16 @@ public class LogParserTest extends AbstractJUnitTest {
     }
 
     /**
+     * Adds a new rule to the existing config.
+     *
+     * @param description The description of the new rule.
+     * @param resource The {@link Resource} object of the rule file. 
+     */
+    private void addLogParserRule(final String description, Resource resource){
+        addLogParserRule(description, resource.url.getPath());
+    }
+
+    /**
      * Adds serveral rules to the existing config.
      *
      * @param rules Map of the rules. Key is the description and Value is the path.

--- a/src/test/resources/logparser_plugin/rules/log-parser-rule-markings
+++ b/src/test/resources/logparser_plugin/rules/log-parser-rule-markings
@@ -1,0 +1,2 @@
+warn /.*warn.*/
+error /.*error.*/


### PR DESCRIPTION
Implemented two test cases to check if a build is appropriately marked as failed or unstable. 