### PR TITLE
Fix agent not connecting for XvncPluginTest

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/XvncSlaveContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/XvncSlaveContainer.java
@@ -50,9 +50,9 @@ public class XvncSlaveContainer extends DockerContainer {
         SshSlaveLauncher launcher = s.setLauncher(SshSlaveLauncher.class);
         launcher.host.set(ipBound(22));
         launcher.port(port(22));
-        launcher.pwdCredentials("jenkins", "jenkins");
+        launcher.pwdCredentials("test", "test");
         launcher.setSshHostKeyVerificationStrategy(SshSlaveLauncher.NonVerifyingKeyVerificationStrategy.class);
-        s.remoteFS.set("/home/jenkins");
+        s.remoteFS.set("/home/test");
         s.setExecutors(1);
         return s;
     }

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/XvncSlaveContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/XvncSlaveContainer/Dockerfile
@@ -1,14 +1,14 @@
-FROM evarga/jenkins-slave
+FROM jenkins/java:eed7706a10fb
 RUN apt-get update && apt-get install -y vnc4server imagemagick
 
 # So it is owned by root and has the permissions vncserver seems to require:
 RUN mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix/
 
 # TODO seems this can be picked up from the host, which is unwanted:
-ENV XAUTHORITY /home/jenkins/.Xauthority
+ENV XAUTHORITY /home/test/.Xauthority
 
-USER jenkins
-RUN mkdir /home/jenkins/.vnc && (echo jenkins; echo jenkins) | vncpasswd /home/jenkins/.vnc/passwd
+USER test
+RUN mkdir /home/test/.vnc && (echo jenkins; echo jenkins) | vncpasswd /home/test/.vnc/passwd
 # Default content includes x-window-manager, which is not installed, plus other stuff we do not need (vncconfig, x-terminal-emulator, etc.):
-RUN touch /home/jenkins/.vnc/xstartup && chmod a+x /home/jenkins/.vnc/xstartup
+RUN touch /home/test/.vnc/xstartup && chmod a+x /home/test/.vnc/xstartup
 USER root


### PR DESCRIPTION
Switched to using the same base container as many other tests.

I now get a failure in the take screenshot test about it not printing something expected that I'm trying to investigate.

Basically Jenkins couldn't connect to the "old" container, so instead of deeply digging into why that was I unified the container to use the "standard" JavaContainer used by other tests.

@reviewbybees 