### PR TITLE
[JENKINS-46564] Added acceptance test for custom configurations files

### DIFF
--- a/src/test/java/plugins/ConfigFileProviderTest.java
+++ b/src/test/java/plugins/ConfigFileProviderTest.java
@@ -27,6 +27,8 @@ public class ConfigFileProviderTest extends AbstractJUnitTest {
     private static final String CRED_USR = "fakeUser";
     private static final String CRED_PWD = "fakePass";
     private static final String SERVER_ID = "fakeServer";
+    private static final String CUSTOM_CONF_CONTENT = "test_custom";
+
 
     @Before
     public void setup() {
@@ -97,13 +99,13 @@ public class ConfigFileProviderTest extends AbstractJUnitTest {
         final CustomConfig customConfig = this.createCustomConfig();
         final String jobLog = this.createPipelineAndGetConsole(customConfig);
 
-        assertThat(jobLog, containsString("anonymous"));
+        assertThat(jobLog, containsString(CUSTOM_CONF_CONTENT));
     }
 
     private CustomConfig createCustomConfig() {
         final CustomConfig customConfig = new ConfigFileProvider(jenkins).addFile(CustomConfig.class);
 
-        customConfig.content("echo test_custom");
+        customConfig.content(CUSTOM_CONF_CONTENT);
 
         customConfig.save();
         return customConfig;

--- a/src/test/java/plugins/ConfigFileProviderTest.java
+++ b/src/test/java/plugins/ConfigFileProviderTest.java
@@ -27,7 +27,7 @@ public class ConfigFileProviderTest extends AbstractJUnitTest {
     private static final String CRED_USR = "fakeUser";
     private static final String CRED_PWD = "fakePass";
     private static final String SERVER_ID = "fakeServer";
-    private static final String CUSTOM_CONF_CONTENT = "test_custom";
+    private static final String CUSTOM_CONF_CONTENT = "test_custom_content for custom file";
 
 
     @Before
@@ -115,9 +115,9 @@ public class ConfigFileProviderTest extends AbstractJUnitTest {
         final WorkflowJob job = jenkins.jobs.create(WorkflowJob.class);
         job.script.set(String.format("node {\n" +
                 "    configFileProvider(\n" +
-                "        [configFile(fileId: '%s')]) {\n" +
+                "        [configFile(fileId: '%s', variable: 'CUSTOM_SETTINGS')]) {\n" +
                 "            \n" +
-                "        sh 'echo test_custom '\n" +
+                "        sh 'cat $CUSTOM_SETTINGS '\n" +
                 "    }\n" +
                 "}", customConfig.id()));
 


### PR DESCRIPTION
[JENKINS-46564](https://issues.jenkins-ci.org/browse/JENKINS-46564)

It is possible to create custom config files since config-file-provider-2.16.0. Some other plugins like maven-plugin test how they manage their configuration files, but this feature is not tested by any plugin. It would be recommendable to create a test to cover it.

@reviewbybees 