### PR TITLE
[JENKINS-41196] demonstrate that core component override plugin can work in ATH

### DIFF
--- a/docs/SUT-VERSIONS.md
+++ b/docs/SUT-VERSIONS.md
@@ -21,17 +21,10 @@ When you are testing locally developed Jenkins plugin, you'd like the test harne
 local version as opposed to download the plugin from update center. This can be done by instructing the harness
 accordingly.
 
-One way to do so is to set the environment variable:
-
-    $ env ldap.jpi=/path/to/your/ldap.jpi mvn test
+    $ env LOCAL_JARS=path/to/your/ldap.jpi:path/to/another.jpi
 
 You can also do this from [the groovy wiring script](WIRING.md).
-
-    envs['ldap.jpi'] = '/path/to/your.ldap.jpi'
-
-Since newer shells do not support environment variables with hyphens in the name, rather than `scm-api.jpi` you may use `SCM_API_JPI`.
-
-This same scheme works for a plugin that's not yet released.
+This scheme also works for a plugin that's not yet released.
 
 ### Install plugins from local maven repository
 

--- a/docs/SUT-VERSIONS.md
+++ b/docs/SUT-VERSIONS.md
@@ -31,6 +31,8 @@ You can also do this from [the groovy wiring script](WIRING.md).
 
 Since newer shells do not support environment variables with hyphens in the name, rather than `scm-api.jpi` you may use `SCM_API_JPI`.
 
+This same scheme works for a plugin that's not yet released.
+
 ### Install plugins from local maven repository
 
 As a convenience, you can also run with the variable `LOCAL_SNAPSHOTS=true`.

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/LocalOverrideUpdateCenterMetadataDecoratorImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/LocalOverrideUpdateCenterMetadataDecoratorImpl.java
@@ -1,17 +1,17 @@
 package org.jenkinsci.test.acceptance.update_center;
 
 import com.cloudbees.sdk.extensibility.Extension;
-import java.io.File;
-import java.util.Iterator;
-import java.util.Locale;
-import java.util.Map;
-import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionScheme;
 import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Allow local plugins specified via environment variables to override plugin metadata from update center.
@@ -61,32 +61,28 @@ public class LocalOverrideUpdateCenterMetadataDecoratorImpl implements UpdateCen
         }
         for (Map.Entry<String,String> e : System.getenv().entrySet()) {
             String key = e.getKey();
-            String name;
-            if (key.endsWith(".jpi")) {
-                name = key.replace(".jpi", "");
-            } else if (key.endsWith("_JPI")) { // http://stackoverflow.com/a/36992531/12916
-                name = null;
-                for (String _name : ucm.plugins.keySet()) {
-                    if ((_name.toUpperCase(Locale.ENGLISH).replaceAll("[^A-Z0-9_]", "_") + "_JPI").equals(key)) {
-                        name = _name;
-                        break;
-                    }
-                }
-                if (name == null) {
-                    throw new IllegalArgumentException("Could not identify plugin name from " + key + " given " + ucm.plugins.keySet());
-                }
-            } else {
+            if (!isPluginEnvironmentVariable(key))
                 continue;
-            }
-            PluginMetadata stock = ucm.plugins.get(name);
-            if (stock == null) {
-                throw new IllegalArgumentException("Plugin does not exists in update center: " + name);
-            }
+
             File file = new File(e.getValue());
-            if (!file.exists()) throw new IllegalArgumentException("Plugin file for " + name + " does not exist: " + file.getAbsolutePath());
+            if (!file.exists()) throw new IllegalArgumentException("Plugin file for " + key + " does not exist: " + file.getAbsolutePath());
+
             PluginMetadata m = PluginMetadata.LocalOverride.create(file);
-            System.err.println("Overriding " + name + " " + stock.getVersion() + " with local build of " + m.getVersion());
+            PluginMetadata stock = ucm.plugins.get(m.getName());
+            if (stock == null) {
+                System.err.println("Creating new plugin " + m.getName() + " with local build of " + m.getVersion());
+            } else {
+                System.err.println("Overriding " + m.getName() + " " + stock.getVersion() + " with local build of " + m.getVersion());
+            }
             ucm.plugins.put(m.getName(), m);
         }
+    }
+
+    private boolean isPluginEnvironmentVariable(String name) {
+        if (name.endsWith(".jpi"))
+            return true;
+        if (name.endsWith("_JPI"))   // http://stackoverflow.com/a/36992531/12916
+            return true;
+        return false;
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/LocalOverrideUpdateCenterMetadataDecoratorImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/LocalOverrideUpdateCenterMetadataDecoratorImpl.java
@@ -78,6 +78,9 @@ public class LocalOverrideUpdateCenterMetadataDecoratorImpl implements UpdateCen
         }
     }
 
+    /**
+     * Returns true if the given environment variable name is an override to point to a local JPI file.
+     */
     private boolean isPluginEnvironmentVariable(String name) {
         if (name.endsWith(".jpi"))
             return true;

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadataDecorator.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadataDecorator.java
@@ -3,6 +3,9 @@ package org.jenkinsci.test.acceptance.update_center;
 import com.cloudbees.sdk.extensibility.ExtensionPoint;
 
 /**
+ * A hook to tweak {@link UpdateCenterMetadata} to allow plugins and versions that are not in the update
+ * center to be installed and tested.
+ *
  * @author Kohsuke Kawaguchi
  */
 @ExtensionPoint

--- a/src/test/java/plugins/RemotingPluginTest.java
+++ b/src/test/java/plugins/RemotingPluginTest.java
@@ -1,0 +1,61 @@
+package plugins;
+
+import hudson.util.VersionNumber;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.jenkinsci.test.acceptance.junit.WithPlugins;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+public class RemotingPluginTest extends AbstractJUnitTest {
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    /**
+     * When installing a core component override plugin, we should see that plugin functioning.
+     *
+     * <p>
+     * Run with environment variable: <tt>REMOTING_JPI=path/to/your-locally-build-remoting.hpi
+     * <p>
+     * We check this by:
+     * <ol>
+     *   <li>Testing the version of the plugin as declared installed
+     *   <li>Making sure that the actual jar file in the system is replaced
+     *  </ol>
+     */
+    @Test
+    @WithPlugins({"remoting"})
+    @Ignore // meant to be used to locally demonstrate JENKINS-41196 support
+    public void test() throws IOException, InterruptedException {
+        final String version = "3.12-SNAPSHOT";
+
+        assertThat(trimSnapshot(jenkins.getPlugin("remoting").getVersion()), is(version));
+
+        File jar = tmp.newFile();
+        FileUtils.copyURLToFile(jenkins.url("jnlpJars/slave.jar"),jar);
+        try (JarFile j = new JarFile(jar)) {// this is the copy of remoting jar
+            Attributes main = j.getManifest().getMainAttributes();
+            assertThat(main.getValue("Version"),is(version));
+        }
+    }
+
+    /**
+     * For version number like "1.0-SNAPSHOT (private-921e74fb-kohsuke)" trim off the whitespace and onward
+     */
+    private String trimSnapshot(VersionNumber v) {
+        return v.toString().split(" ")[0];
+    }
+}

--- a/src/test/java/plugins/RemotingPluginTest.java
+++ b/src/test/java/plugins/RemotingPluginTest.java
@@ -4,11 +4,13 @@ import hudson.util.VersionNumber;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
+import org.jenkinsci.test.acceptance.update_center.UpdateCenterMetadataProvider;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.jar.Attributes;
@@ -23,6 +25,9 @@ import static org.junit.Assert.*;
 public class RemotingPluginTest extends AbstractJUnitTest {
     @Rule
     public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Inject
+    UpdateCenterMetadataProvider ucmp;
 
     /**
      * When installing a core component override plugin, we should see that plugin functioning.
@@ -40,7 +45,8 @@ public class RemotingPluginTest extends AbstractJUnitTest {
     @WithPlugins({"remoting"})
     @Ignore // meant to be used to locally demonstrate JENKINS-41196 support
     public void test() throws IOException, InterruptedException {
-        final String version = "3.12-SNAPSHOT";
+        // expected version
+        final String version = ucmp.get(jenkins).plugins.get("remoting").getVersion();
 
         assertThat(trimSnapshot(jenkins.getPlugin("remoting").getVersion()), is(version));
 


### PR DESCRIPTION
Most of this change just adds a capability to test a plugin that's not yet released and available in the update center.

The test itself worked as expected once this was cleared.