### PR TITLE
When using $LOCAL_JARS, give installPlugin a moment to catch up

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -301,6 +301,13 @@ public class PluginManager extends ContainerPageObject {
                     IOUtils.toString(response.getEntity().getContent()));
         } else {
             System.out.format("Plugin %s installed\n", localFile);
+            if (System.getenv("LOCAL_JARS") != null) {
+                try {
+                    Thread.sleep(3000); // TODO find a better way to ensure that core has actually applied the update
+                } catch (InterruptedException x) {
+                    x.printStackTrace();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
When checking #354 with a local plugin build from https://github.com/jenkinsci/ssh-credentials-plugin/pull/30, the test did not work: first Jenkins installed `ssh-credentials@1.14-SNAPSHOT` as requested, and then immediately afterwards it clobbered it with `ssh-credentials@1.13` from the UC. After the restart (BTW why do we need to restart when all the plugins are fresh installations?!), 1.13 was installed, thus defeating the purpose of specifying `$LOCAL_JARS`.

I found that by introducing a delay into the process, the asynchronous update center jobs had time to actually register that `ssh-credentials@1.14-SNAPSHOT` was already there and thus did not need to be added as a dependent installation of `ssh-slaves`.

I do not like this but I have not found a better way yet. Not clear if there is a core bug here, or if ATH just needs to poll `updateCenter/api/json?tree=jobs[success]` (?) to wait for `pluginManager/uploadPlugin` to actually take effect. (I think the CLI command `install-plugin` blocks until it is finished, but the REST variant definitely does not.)

@reviewbybees