### PR TITLE
WIP: Switch to using phantomjs for less overhead (in theory) when running in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     stages {
         stage('Run ATH') {
             steps {
-                sh './run.sh phantomjs latest -Dmaven.test.failure.ignore=true -DforkCount=1 -B'
+                sh 'eval $(./vnc.sh) ; ./run.sh phantomjs latest -Dmaven.test.failure.ignore=true -DforkCount=1 -B'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,10 +12,7 @@ pipeline {
     stages {
         stage('Run ATH') {
             steps {
-                sh '''
-                    eval $(./vnc.sh)
-                    ./run.sh firefox latest -Dmaven.test.failure.ignore=true -DforkCount=1 -B
-                    '''
+                sh './run.sh phantomjs latest -Dmaven.test.failure.ignore=true -DforkCount=1 -B'
             }
         }
     }

--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get clean && \
         firefox-esr \
         maven \
         openjdk-8-jdk \
+        phantomjs \
         unzip \
         vnc4server
 


### PR DESCRIPTION
ci.jenkins.io has more capacity than my laptop, so I'm curious to see how executing this works out :smile: 