### PR TITLE
Fix MatrixAuthPluginTest.projectMatrixAuth against matrix-auth 2.x

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/ProjectMatrixProperty.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/ProjectMatrixProperty.java
@@ -10,7 +10,7 @@ import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 public class ProjectMatrixProperty extends PageAreaImpl {
     public final Control enable = control("useProjectSecurity");
 
-    public final Control name = control("useProjectSecurity/");
+    public final Control name = control(/* 2.x */"useProjectSecurity/[1]", /* 1.x */"useProjectSecurity/");
 
     public ProjectMatrixProperty(Job job) {
         super(job, "/properties/hudson-security-AuthorizationMatrixProperty");


### PR DESCRIPTION
Fixes [this failure](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/32/testReport/plugins/MatrixAuthPluginTest/projectMatrixAuth/):

```
Element must be user-editable in order to clear it.
…
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.openqa.selenium.remote.ErrorHandler.createThrowable(ErrorHandler.java:206)
	at org.openqa.selenium.remote.ErrorHandler.throwIfResponseFailed(ErrorHandler.java:158)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:678)
	at org.openqa.selenium.remote.RemoteWebElement.execute(RemoteWebElement.java:327)
	at org.openqa.selenium.remote.RemoteWebElement.clear(RemoteWebElement.java:140)
	at sun.reflect.GeneratedMethodAccessor32.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openqa.selenium.support.events.EventFiringWebDriver$EventFiringWebElement$1.invoke(EventFiringWebDriver.java:335)
	at com.sun.proxy.$Proxy44.clear(Unknown Source)
	at org.openqa.selenium.support.events.EventFiringWebDriver$EventFiringWebElement.clear(EventFiringWebDriver.java:364)
	at org.jenkinsci.test.acceptance.po.Control.set(Control.java:136)
	at org.jenkinsci.test.acceptance.plugins.matrix_auth.ProjectMatrixProperty.addUser(ProjectMatrixProperty.java:23)
	at plugins.MatrixAuthPluginTest.projectMatrixAuth(MatrixAuthPluginTest.java:113)
```

@reviewbybees