### PR TITLE
Increasing timeout for waitForInstallationToComplete

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/UpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/UpdateCenter.java
@@ -71,7 +71,7 @@ public class UpdateCenter extends ContainerPageObject {
     public boolean waitForInstallationToComplete(final PluginSpec... specs) throws InstallationFailedException {
         open();
         // Wait for all plugins to get installed
-        waitFor(driver, not(Matchers.hasElement(by.xpath("//*[@id='log']//*[contains(.,'Pending') or contains(.,'Installing')]"))), 60);
+        waitFor(driver, not(Matchers.hasElement(by.xpath("//*[@id='log']//*[contains(.,'Pending') or contains(.,'Installing')]"))), 300);
 
         String uc = getPageContent(driver);
         // "IOException: Failed to dynamically deploy this plugin" can be reported (by at least some Jenkins versions)


### PR DESCRIPTION
As noted in https://github.com/jenkinsci/acceptance-test-harness/pull/207#issuecomment-342691560 the download of transitive dependencies can be quite slow, several minutes, so imposing a 60s timeout just makes tests fail when you run on a slowish network.

@reviewbybees