### PR TITLE
Avoid a complete system upgrade in Docker image

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/ArtifactoryContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/ArtifactoryContainer/Dockerfile
@@ -3,7 +3,6 @@ FROM codingtony/java
 MAINTAINER tony.bussieres@ticksmith.com
 
 RUN apt-get update && apt-get install -y unzip
-RUN apt-get upgrade -y
 RUN wget --content-disposition http://dl.bintray.com/jfrog/artifactory/artifactory-3.4.0.zip
 RUN cd /opt && unzip ~/artifactory-3.4.0.zip
 RUN mv /opt/artifactory-3.4.0 /opt/artifactory


### PR DESCRIPTION
Otherwise it attempts to download 200+ packages, and then fails with

```
…
Setting up oracle-java7-installer (7u80+7u60arm-0~webupd8~1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
Downloading Oracle Java 7...
--2017-11-13 18:48:09--  http://download.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-linux-x64.tar.gz
Resolving download.oracle.com (download.oracle.com)... 96.16.12.121, 96.16.12.114
Connecting to download.oracle.com (download.oracle.com)|96.16.12.121|:80... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: https://edelivery.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-linux-x64.tar.gz [following]
--2017-11-13 18:48:09--  https://edelivery.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-linux-x64.tar.gz
Resolving edelivery.oracle.com (edelivery.oracle.com)... 184.51.128.154, 2600:141e:2:196::2d3e, 2600:141e:2:186::2d3e
Connecting to edelivery.oracle.com (edelivery.oracle.com)|184.51.128.154|:443... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: http://download.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-linux-x64.tar.gz?AuthParam=1510599009_2d8cc7372ef2b2b572db8f1944b55ef6 [following]
--2017-11-13 18:48:10--  http://download.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-linux-x64.tar.gz?AuthParam=1510599009_2d8cc7372ef2b2b572db8f1944b55ef6
Connecting to download.oracle.com (download.oracle.com)|96.16.12.121|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2017-11-13 18:48:11 ERROR 404: Not Found.

download failed
Oracle JDK 7 is NOT installed.
dpkg: error processing package oracle-java7-installer (--configure):
 subprocess installed post-installation script returned error exit status 1
Processing triggers for ureadahead (0.100.0-16) ...
Setting up initramfs-tools (0.103ubuntu4.9) ...
update-initramfs: deferring update (trigger activated)
Setting up plymouth (0.8.8-0ubuntu17.1) ...
update-initramfs: deferring update (trigger activated)
Setting up perl-modules (5.18.2-2ubuntu1.3) ...
Setting up perl (5.18.2-2ubuntu1.3) ...
Setting up init-system-helpers (1.14ubuntu1) ...
Setting up rsyslog (7.4.4-1ubuntu2.7) ...
Installing new version of config file /etc/apparmor.d/usr.sbin.rsyslogd ...
Installing new version of config file /etc/rsyslog.conf ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
The user `syslog' is already a member of `adm'.
invoke-rc.d: policy-rc.d denied execution of restart.
Processing triggers for libc-bin (2.19-0ubuntu6.13) ...
Processing triggers for ca-certificates (20170717~14.04.1) ...
Updating certificates in /etc/ssl/certs... 46 added, 62 removed; done.
Running hooks in /etc/ca-certificates/update.d....done.
Processing triggers for initramfs-tools (0.103ubuntu4.9) ...
Errors were encountered while processing:
 oracle-java7-installer
E: Sub-process /usr/bin/dpkg returned an error code (1)
The command '/bin/sh -c apt-get upgrade -y' returned a non-zero code: 100
```

After this patch, I can confirm that the container starts successfully (and the Artifactory banner is printed etc.), though both nonignored test cases in `ArtifactoryPluginTest` fail for other reasons (some missing buttons for Selenium).

@reviewbybees