### PR TITLE
MockUpdateCenter

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/post_build_script/PostBuildScript.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/post_build_script/PostBuildScript.java
@@ -25,7 +25,7 @@ package org.jenkinsci.test.acceptance.plugins.post_build_script;
 
 import org.jenkinsci.test.acceptance.po.*;
 
-@Describable({"Execute a set of scripts", "[PostBuildScript] - Execute a set of scripts"})
+@Describable({"Execute Scripts", "Execute a set of scripts", "[PostBuildScript] - Execute a set of scripts"})
 public class PostBuildScript extends AbstractStep implements PostBuildStep {
     private final Control whenSucceeded = control("scriptOnlyIfSuccess");
     private final Control whenFailed = control("scriptOnlyIfFailure");

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -35,6 +35,7 @@ import static org.apache.http.entity.ContentType.APPLICATION_OCTET_STREAM;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.jenkinsci.test.acceptance.update_center.MockUpdateCenter;
 
 
 /**
@@ -69,6 +70,9 @@ public class PluginManager extends ContainerPageObject {
     @Named("forceRestartAfterPluginInstallation")
     public boolean forceRestart;
 
+    @Inject
+    public MockUpdateCenter mockUpdateCenter;
+
     public PluginManager(Jenkins jenkins) {
         super(jenkins.injector, jenkins.url("pluginManager/"));
         this.jenkins = jenkins;
@@ -76,13 +80,14 @@ public class PluginManager extends ContainerPageObject {
         // injection happens in the base class, so for us to differentiate default state vs false state,
         // we need to use Boolean
         if (uploadPlugins==null)
-            uploadPlugins = true;
+            uploadPlugins = false;
     }
 
     /**
      * Force update the plugin update center metadata.
      */
     public void checkForUpdates() {
+        mockUpdateCenter.ensureRunning();
         visit("advanced");
         final String current = getCurrentUrl();
         // The check now button is a form submit (POST) with a redirect to the same page only if the check is successful.

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -61,10 +61,12 @@ public class PluginManager extends ContainerPageObject {
      * Optional configuration value that selects whether to resolve plugins locally and upload to Jenkins
      * (better performing when Jenkins is closer to the test execution), or install plugins from within Jenkins
      * (more accurate testing.)
+     * @deprecated Blocks use of {@link MockUpdateCenter}.
      */
     @Inject(optional = true)
     @Named("uploadPlugins")
-    public Boolean uploadPlugins;
+    @Deprecated
+    public boolean uploadPlugins;
 
     @Inject(optional = true)
     @Named("forceRestartAfterPluginInstallation")
@@ -76,11 +78,6 @@ public class PluginManager extends ContainerPageObject {
     public PluginManager(Jenkins jenkins) {
         super(jenkins.injector, jenkins.url("pluginManager/"));
         this.jenkins = jenkins;
-
-        // injection happens in the base class, so for us to differentiate default state vs false state,
-        // we need to use Boolean
-        if (uploadPlugins==null)
-            uploadPlugins = false;
     }
 
     /**
@@ -188,8 +185,8 @@ public class PluginManager extends ContainerPageObject {
             checkForUpdates();
         }
 
-        LOGGER.info("Installing plugins by direct upload: " + uploadPlugins);
         if (uploadPlugins) {
+            LOGGER.warning("Installing plugins by direct upload. Better to use the default MockUpdateCenter.");
             // First check to see whether we need to do anything.
             // If not, do not consider transitive dependencies of the requested plugins,
             // which might force updates (and thus restarts) even though we already have
@@ -290,7 +287,9 @@ public class PluginManager extends ContainerPageObject {
 
     /**
      * Installs a plugin by uploading the *.jpi image.
+     * @deprecated Not used when running {@link MockUpdateCenter}.
      */
+    @Deprecated
     public void installPlugin(File localFile) throws IOException {
         HttpClient httpclient = new DefaultHttpClient();
 
@@ -306,13 +305,6 @@ public class PluginManager extends ContainerPageObject {
                     IOUtils.toString(response.getEntity().getContent()));
         } else {
             System.out.format("Plugin %s installed\n", localFile);
-            if (System.getenv("LOCAL_JARS") != null) {
-                try {
-                    Thread.sleep(3000); // TODO find a better way to ensure that core has actually applied the update
-                } catch (InterruptedException x) {
-                    x.printStackTrace();
-                }
-            }
         }
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -87,6 +87,7 @@ public class MockUpdateCenter implements AutoCleaned {
         Jenkins jenkins = injector.getInstance(Jenkins.class);
         List<String> sites = new UpdateCenter(jenkins).getJson("tree=sites[url]").findValuesAsText("url");
         if (sites.size() != 1) {
+            // TODO ideally it would rather delegate to all of them, but that implies deprecating CachedUpdateCenterMetadataLoader.url and using whatever site(s) Jenkins itself specifies
             LOGGER.log(Level.WARNING, "found an unexpected number of update sites: {0}", sites);
             return;
         }

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -104,7 +104,7 @@ public class MockUpdateCenter implements AutoCleaned {
             all = new JSONObject(ucm.originalJSON);
             all.remove("signature");
             JSONObject plugins = all.getJSONObject("plugins");
-            LOGGER.log(Level.INFO, "editing JSON with {0} plugins to reflect {1} possible overrides", new Object[] {plugins.length(), ucm.plugins.size()});
+            LOGGER.info(() -> "editing JSON with " + plugins.length() + " plugins to reflect " + ucm.plugins.size() + " possible overrides");
             for (PluginMetadata meta : ucm.plugins.values()) {
                 String name = meta.getName();
                 String version = meta.getVersion();

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -157,6 +157,7 @@ public class MockUpdateCenter implements AutoCleaned {
 
         });
         server = ServerBootstrap.bootstrap().
+            // could setLocalAddress if using a JenkinsController that requires it
             setHttpProcessor(proc).
             setHandlerMapper(handlerMapper).
             setExceptionLogger((Exception x) -> LOGGER.log(x instanceof ConnectionClosedException ? Level.FINE : Level.WARNING, null, x)).
@@ -178,6 +179,7 @@ public class MockUpdateCenter implements AutoCleaned {
     @Override
     public void close() throws IOException {
         if (original != null) {
+            LOGGER.log(Level.INFO, "stopping MockUpdateCenter on http://{0}:{1}/update-center.json", new Object[] {server.getInetAddress().getHostAddress(), server.getLocalPort()});
             server.shutdown(5, TimeUnit.SECONDS);
             server = null;
             /* TODO only if RemoteController etc.:

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -1,0 +1,189 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.test.acceptance.update_center;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.ConnectionClosedException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.bootstrap.HttpServer;
+import org.apache.http.impl.bootstrap.ServerBootstrap;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpProcessor;
+import org.apache.http.protocol.HttpProcessorBuilder;
+import org.apache.http.protocol.RequestConnControl;
+import org.apache.http.protocol.ResponseContent;
+import org.apache.http.protocol.ResponseServer;
+import org.apache.http.protocol.UriHttpRequestHandlerMapper;
+import org.jenkinsci.test.acceptance.guice.AutoCleaned;
+import org.jenkinsci.test.acceptance.po.Jenkins;
+import org.jenkinsci.test.acceptance.po.UpdateCenter;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Serves a fake update center locally.
+ */
+@Singleton
+public class MockUpdateCenter implements AutoCleaned {
+
+    private static final Logger LOGGER = Logger.getLogger(MockUpdateCenter.class.getName());
+
+    @Inject
+    public Injector injector;
+
+    @Inject
+    private UpdateCenterMetadataProvider ucmd;
+
+    /** Original default site ID; note that this may not match {@link CachedUpdateCenterMetadataLoader#url}. */
+    private String original;
+
+    private HttpServer server;
+
+    public void ensureRunning() {
+        if (original != null) {
+            return;
+        }
+        Jenkins jenkins = injector.getInstance(Jenkins.class);
+        List<String> sites = new UpdateCenter(jenkins).getJson("tree=sites[url]").findValuesAsText("url");
+        if (sites.size() != 1) {
+            LOGGER.log(Level.WARNING, "found an unexpected number of update sites: {0}", sites);
+            return;
+        }
+        UpdateCenterMetadata ucm;
+        try {
+            ucm = ucmd.get(jenkins);
+        } catch (IOException x) {
+            LOGGER.log(Level.WARNING, "cannot load data for mock update center", x);
+            return;
+        }
+        JSONObject all;
+        try {
+            all = new JSONObject(ucm.originalJSON);
+            all.remove("signature");
+            JSONObject plugins = all.getJSONObject("plugins");
+            for (PluginMetadata meta : ucm.plugins.values()) {
+                String name = meta.getName();
+                String version = meta.getVersion();
+                JSONObject plugin = plugins.getJSONObject(name);
+                if (plugin == null) {
+                    plugin = new JSONObject().accumulate("name", name);
+                    plugins.put(name, plugin);
+                }
+                plugin.put("url", name + ".hpi");
+                plugin.put("version", version);
+                // TODO update dependencies, requiredCore
+            }
+        } catch (JSONException x) {
+            LOGGER.log(Level.WARNING, "cannot prepare mock update center", x);
+            return;
+        }
+        HttpProcessor proc = HttpProcessorBuilder.create().
+            add(new ResponseServer("MockUpdateCenter")).
+            add(new ResponseContent()).
+            add(new RequestConnControl()).
+            build();
+        UriHttpRequestHandlerMapper handlerMapper = new UriHttpRequestHandlerMapper();
+        String json = "updateCenter.post(\n" + all + "\n);";
+        handlerMapper.register("/update-center.json", (HttpRequest request, HttpResponse response, HttpContext context) -> {
+            response.setStatusCode(HttpStatus.SC_OK);
+            response.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+        });
+        handlerMapper.register("*.hpi", (HttpRequest request, HttpResponse response, HttpContext context) -> {
+            String plugin = request.getRequestLine().getUri().replaceFirst("^/(.+)[.]hpi$", "$1");
+            PluginMetadata meta = ucm.plugins.get(plugin);
+            if (meta == null) {
+                LOGGER.log(Level.WARNING, "no such plugin {0}", plugin);
+                response.setStatusCode(HttpStatus.SC_NOT_FOUND);
+                return;
+            }
+            File local = meta.resolve(injector, meta.getVersion());
+            LOGGER.log(Level.INFO, "serving {0}", local);
+            response.setStatusCode(HttpStatus.SC_OK);
+            response.setEntity(new FileEntity(local));
+        });
+        handlerMapper.register("*", (HttpRequest request, HttpResponse response, HttpContext context) -> {
+            String location = original.replace("/update-center.json", request.getRequestLine().getUri());
+            LOGGER.log(Level.INFO, "redirect to {0}", location);
+            /* TODO for some reason DownloadService.loadJSONHTML does not seem to process the redirect, despite calling setInstanceFollowRedirects(true):
+            response.setStatusCode(HttpStatus.SC_MOVED_TEMPORARILY);
+            response.setHeader("Location", location);
+             */
+            HttpURLConnection uc = (HttpURLConnection) new URL(location).openConnection();
+            uc.setInstanceFollowRedirects(true);
+            byte[] data = IOUtils.toByteArray(uc);
+            String contentType = uc.getContentType();
+            response.setStatusCode(HttpStatus.SC_OK);
+            response.setEntity(new ByteArrayEntity(data, ContentType.create(contentType)));
+
+        });
+        server = ServerBootstrap.bootstrap().
+            setHttpProcessor(proc).
+            setHandlerMapper(handlerMapper).
+            setExceptionLogger((Exception x) -> LOGGER.log(x instanceof ConnectionClosedException ? Level.FINE : Level.WARNING, null, x)).
+            create();
+        try {
+            server.start();
+        } catch (IOException x) {
+            LOGGER.log(Level.WARNING, "cannot start mock update center", x);
+            return;
+
+        }
+        original = sites.get(0);
+        // TODO figure out how to deal with Docker-based controllers which would need to have an IP address for the host
+        String override = "http://" + server.getInetAddress().getHostAddress() + ":" + server.getLocalPort() + "/update-center.json";
+        LOGGER.log(Level.INFO, "replacing update site {0} with {1}", new Object[] {original, override});
+        jenkins.runScript("DownloadService.signatureCheck = false; Jenkins.instance.updateCenter.sites.replaceBy([new UpdateSite(UpdateCenter.ID_DEFAULT, '%s')])", override);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (original != null) {
+            server.shutdown(5, TimeUnit.SECONDS);
+            server = null;
+            /* TODO only if RemoteController etc.:
+            injector.getInstance(Jenkins.class).runScript("DownloadService.signatureCheck = true; Jenkins.instance.updateCenter.sites.replaceBy([new UpdateSite(UpdateCenter.ID_DEFAULT, '%s')])", original);
+            */
+            original = null;
+        }
+    }
+
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -199,7 +199,7 @@ public class MockUpdateCenter implements AutoCleaned {
     @Override
     public void close() throws IOException {
         if (original != null) {
-            LOGGER.log(Level.INFO, "stopping MockUpdateCenter on http://{0}:{1}/update-center.json", new Object[] {server.getInetAddress().getHostAddress(), server.getLocalPort()});
+            LOGGER.log(Level.INFO, () -> "stopping MockUpdateCenter on http://" + server.getInetAddress().getHostAddress() + ":" + server.getLocalPort() + "/update-center.json");
             server.shutdown(5, TimeUnit.SECONDS);
             server = null;
             /* TODO only if RemoteController etc.:

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -26,7 +26,6 @@ package org.jenkinsci.test.acceptance.update_center;
 
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.google.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -54,6 +53,7 @@ import org.apache.http.protocol.ResponseContent;
 import org.apache.http.protocol.ResponseServer;
 import org.apache.http.protocol.UriHttpRequestHandlerMapper;
 import org.jenkinsci.test.acceptance.guice.AutoCleaned;
+import org.jenkinsci.test.acceptance.guice.TestScope;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.po.UpdateCenter;
 import org.json.JSONException;
@@ -62,7 +62,7 @@ import org.json.JSONObject;
 /**
  * Serves a fake update center locally.
  */
-@Singleton
+@TestScope
 public class MockUpdateCenter implements AutoCleaned {
 
     private static final Logger LOGGER = Logger.getLogger(MockUpdateCenter.class.getName());
@@ -110,6 +110,7 @@ public class MockUpdateCenter implements AutoCleaned {
                 }
                 plugin.put("url", name + ".hpi");
                 plugin.put("version", version);
+                plugin.remove("sha1");
                 // TODO update dependencies, requiredCore
             }
         } catch (JSONException x) {

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -164,6 +164,7 @@ public class MockUpdateCenter implements AutoCleaned {
              */
             HttpURLConnection uc = (HttpURLConnection) new URL(location).openConnection();
             uc.setInstanceFollowRedirects(true);
+            // TODO consider caching these downloads locally like CachedUpdateCenterMetadataLoader does for the main update-center.json
             byte[] data = IOUtils.toByteArray(uc);
             String contentType = uc.getContentType();
             response.setStatusCode(HttpStatus.SC_OK);

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -84,6 +84,7 @@ public class MockUpdateCenter implements AutoCleaned {
         if (original != null) {
             return;
         }
+        // TODO this will likely not work on arbitrary controllers, so perhaps limit to the default WinstoneController
         Jenkins jenkins = injector.getInstance(Jenkins.class);
         List<String> sites = new UpdateCenter(jenkins).getJson("tree=sites[url]").findValuesAsText("url");
         if (sites.size() != 1) {

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginMetadata.java
@@ -58,7 +58,9 @@ public class PluginMetadata {
 
     /**
      * Calls {@link PluginManager#installPlugin(File)}.
+     * @deprecated Not used when running {@link MockUpdateCenter}.
      */
+    @Deprecated
     public void uploadTo(Jenkins jenkins, Injector i, String version) throws ArtifactResolutionException, IOException {
         File f = resolve(i, version);
         jenkins.getPluginManager().installPlugin(f);

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginMetadata.java
@@ -31,7 +31,7 @@ import com.google.inject.Injector;
 public class PluginMetadata {
     private final String name;
     private final String version;
-    private final String gav;
+    final String gav;
     private final String requiredCore;
     private final List<Dependency> dependencies;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
@@ -75,7 +75,9 @@ public class UpdateCenterMetadata {
      * Transitive dependencies will not be included if there is an already valid version of the plugin installed.
      *
      * @throws UnableToResolveDependencies When there requested plugin version can not be installed.
+     * @deprecated Not used when running {@link MockUpdateCenter}.
      */
+    @Deprecated
     public List<PluginMetadata> transitiveDependenciesOf(Jenkins jenkins, Collection<PluginSpec> plugins) throws UnableToResolveDependencies {
         List<PluginMetadata> set = new ArrayList<>();
         for (PluginSpec n : plugins) {
@@ -98,6 +100,7 @@ public class UpdateCenterMetadata {
         return set;
     }
 
+    @Deprecated
     private void transitiveDependenciesOf(Jenkins jenkins, PluginMetadata p, String v, List<PluginMetadata> result) {
         for (Dependency d : p.getDependencies()) {
             if (d.optional || !shouldBeIncluded(jenkins, d)) continue;
@@ -127,6 +130,7 @@ public class UpdateCenterMetadata {
      * @param d the dependency
      * @return true if the dependency should be installed/upgraded. Otherwise, false.
      */
+    @Deprecated
     private boolean shouldBeIncluded(Jenkins jenkins, Dependency d) {
         try {
             VersionNumber installedVersion = jenkins.getPlugin(d.name).getVersion();
@@ -138,6 +142,10 @@ public class UpdateCenterMetadata {
         }
     }
 
+    /**
+     * @deprecated Not used when running {@link MockUpdateCenter}.
+     */
+    @Deprecated
     public static class UnableToResolveDependencies extends RuntimeException {
 
         public UnableToResolveDependencies(String format) {

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
@@ -31,6 +31,8 @@ public class UpdateCenterMetadata {
 
     public String id;
 
+    String originalJSON;
+
     /**
      * Create metadata parsing Jenkins update center file.
      *
@@ -46,6 +48,7 @@ public class UpdateCenterMetadata {
         ObjectMapper om = new ObjectMapper();
         om.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         UpdateCenterMetadata v = om.readValue(json, UpdateCenterMetadata.class);
+        v.originalJSON = json;
         v.init();
         return v;
     }

--- a/src/test/java/plugins/ScriptlerPluginTest.java
+++ b/src/test/java/plugins/ScriptlerPluginTest.java
@@ -33,6 +33,7 @@ import org.jenkinsci.test.acceptance.plugins.scriptler.Scriptler;
 import org.jenkinsci.test.acceptance.po.Slave;
 import org.jenkinsci.test.acceptance.slave.SlaveController;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -40,6 +41,7 @@ import java.util.HashMap;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@Ignore("TODO not currently on the update center, so not testable")
 @WithPlugins("scriptler")
 public class ScriptlerPluginTest extends AbstractJUnitTest {
 


### PR DESCRIPTION
Implements the notion I had in #207, and supersedes that PR. This seems to run a _lot_ faster: there is a single update center click which processes all changes, all dependencies (incl. implicit ones like `bouncycastle-api-2.16.2.hpi`) get served from the local Maven repository rather than the network, and there is no bogus restart.

- [X] serve a mock update center, with `uploadPlugins=false`
- [X] redirect other resources like tool metadata
- [x] allow plugin metadata other than `version` to be overridden
- [X] smoke test: `WorkflowPluginTest.linearFlow`
- [x] test with `LOCAL_JARS` (or similar metadata decorators)
- [x] test with an OEM version of ATH
- [x] consider cleaning up obsolete code, including handling of `uploadPlugins`, and hacks such as #355
- [x] check impact on unusual `JenkinsController`s
- [x] consider caching tool installer metadata locally

Probably supersedes or clashes with #188 & #227.

@reviewbybees @jenkinsci/code-reviewers