### PR TITLE
[JENKINS-48034] Enable configuration for HttpURLConnection timeouts

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/utils/IOUtil.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/IOUtil.java
@@ -35,7 +35,7 @@ import javax.annotation.Nonnull;
 
 public class IOUtil {
 
-    private static final int CONNECTION_TIMEOUT = Integer.parseInt(SystemEnvironmentVariables.getPropertyVariableOrEnvironment("CONNECTION_TIMEOUT", "10000"));
+    private static final int CONNECTION_TIMEOUT = Integer.parseInt(SystemEnvironmentVariables.getPropertyVariableOrEnvironment("CONNECTION_TIMEOUT", "1"));
 
     /**
      * Get First existing file or directory.

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/IOUtil.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/IOUtil.java
@@ -23,6 +23,8 @@
  */
 package org.jenkinsci.test.acceptance.utils;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -32,6 +34,8 @@ import java.util.Arrays;
 import javax.annotation.Nonnull;
 
 public class IOUtil {
+
+    private static final int CONNECTION_TIMEOUT = Integer.parseInt(SystemEnvironmentVariables.getPropertyVariableOrEnvironment("CONNECTION_TIMEOUT", "10000"));
 
     /**
      * Get First existing file or directory.
@@ -56,8 +60,8 @@ public class IOUtil {
      */
     public static HttpURLConnection openConnection(@Nonnull URL url) throws IOException {
         HttpURLConnection httpURLConnection = (HttpURLConnection) url.openConnection();
-        httpURLConnection.setConnectTimeout(10000);
-        httpURLConnection.setReadTimeout(10000);
+        httpURLConnection.setConnectTimeout(CONNECTION_TIMEOUT);
+        httpURLConnection.setReadTimeout(CONNECTION_TIMEOUT);
         return httpURLConnection;
     }
 }


### PR DESCRIPTION
See [JENKINS-48034](https://issues.jenkins-ci.org/browse/JENKINS-48034)

**Features:**

Enable the possibility of configure HttpURLConnection timeouts via environment variable. In case of not setting a property or environment variable they remain with the default value.

@reviewbybees 
@olivergondza this is the PR associated to the discussion in the JIRA issue