### PR TITLE
[INFRA-1404] Use junit-attachments & junit-realtime-test-reporter plugins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,16 +12,13 @@ pipeline {
     stages {
         stage('Run ATH') {
             steps {
-                sh '''
-                    eval $(./vnc.sh)
-                    ./run.sh firefox latest -Dmaven.test.failure.ignore=true -DforkCount=1 -B
+                realtimeJUnit(testResults: 'target/surefire-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]) {
+                    sh '''
+                        eval $(./vnc.sh)
+                        ./run.sh firefox latest -Dmaven.test.failure.ignore=true -DforkCount=1 -B
                     '''
+                }
             }
-        }
-    }
-    post {
-        always {
-            junit 'target/surefire-reports/TEST-*.xml'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,9 @@ pipeline {
     stages {
         stage('Run ATH') {
             steps {
+                script { // TODO pending proper solution for JENKINS-43353
+                    for (int i = 0; i < (BUILD_NUMBER as int); i++) {milestone()}
+                }
                 realtimeJUnit(testResults: 'target/surefire-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]) {
                     sh '''
                         eval $(./vnc.sh)


### PR DESCRIPTION
[INFRA-1404](https://issues.jenkins-ci.org/browse/INFRA-1404)

Enabled by https://github.com/jenkins-infra/jenkins-infra/pull/898. Would be improved by having https://github.com/jenkinsci/junit-realtime-test-reporter-plugin/pull/5 merged & released. Would be a merge conflict with #380, but easy to resolve.

@reviewbybees