### PR TITLE
[JENKINS-48236] WorkflowMultiBranchJob is not reading ElasticTime.factor property

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/WorkflowMultiBranchJob.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WorkflowMultiBranchJob.java
@@ -45,7 +45,7 @@ public class WorkflowMultiBranchJob extends Folder {
 
     public WorkflowMultiBranchJob waitForBranchIndexingFinished(final int timeout) {
         waitFor()
-            .withTimeout(timeout, TimeUnit.SECONDS)
+            .withTimeout(super.time.seconds(timeout), TimeUnit.MILLISECONDS)
             .until(new Callable<Boolean>() {
                 @Override
                 public Boolean call() {


### PR DESCRIPTION
See [JENKINS-48236](https://issues.jenkins-ci.org/browse/JENKINS-48236)

`WorkflowMultiBranchJob.waitForBranchIndexingFinished` is not reading the ElasticTime.factor property when method `waitFor().withTimeout()` is called.

@reviewbybees 
@olivergondza 