### PR TITLE
[JENKINS-48314] https://issues.jenkins-ci.org/browse/JENKINS-48314

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/Dockerfile
@@ -5,8 +5,6 @@
 
 FROM ubuntu:xenial
 
-# make sure the package repository is up to date
-RUN echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" > /etc/apt/sources.list
 # install SSHD
 RUN apt-get update && apt-get install -y openssh-server
 


### PR DESCRIPTION
[JENKINS-48314](https://issues.jenkins-ci.org/browse/JENKINS-48314)

Drop legacy line since it is removing the default source list. 
We define ubuntu:xenial so there is no need for that line anymore.

Alternative fix is to add `xenial-security` as well to the souce.list but IMHO the whole line does not make sense anymore. @raul-arabaolaza shares this observation.


@reviewbybees @cloudbees/team-astro

