### PR TITLE
Avoid diagnostics we never needed. Attachment plugin does not have th…

### DIFF
--- a/src/test/java/plugins/KerberosSsoTest.java
+++ b/src/test/java/plugins/KerberosSsoTest.java
@@ -61,6 +61,8 @@ import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -301,7 +303,7 @@ public class KerberosSsoTest extends AbstractJUnitTest {
      */
     private KerberosContainer startKdc() throws IOException {
         KerberosContainer kdc = kerberos.get();
-        File target = diag.mkdirs("target"); // Keep the data for diagnostics
+        File target = Files.createTempDirectory(getClass().getSimpleName()).toFile();
         kdc.populateTargetDir(target);
         return kdc;
     }


### PR DESCRIPTION
…e permissions to read it.

`java.io.IOException: Failed to copy /mnt/agent-workspace/workspace/eptance-test-harness_master-XGK5QUUU6PPTAXK6V63SIIUPSRNAINZ4FNDUDNGYVGTHACJLEVQQ/target/diagnostics/kerberosTicket(plugins.KerberosSsoTest)/target/keytab/user to /var/jenkins_home/jobs/Core/jobs/acceptance-test-harness/branches/master/builds/47/junit-attachments/plugins.KerberosSsoTest/user`