### PR TITLE
adding more detailed logging in the event that a test rule fails to apply

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
@@ -112,9 +112,8 @@ public class JenkinsAcceptanceTestRule implements MethodRule { // TODO should us
                     for (TestRule rule: rulesGroup) {
                         try {
                             body = rule.apply(body, description);
-                        } catch (Exception e) { //This is to note which rule is failing when a rule does fail as the evaluate method hinds this information
-                            System.out.println("Test Rule " + rule.getClass() + " failed to apply. Failed with: " + e.getCause());
-                            throw e;
+                        } catch (Exception e) {
+                            throw new TestRuleException(e, rule);
                         }
                     }
                 }

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
@@ -110,7 +110,12 @@ public class JenkinsAcceptanceTestRule implements MethodRule { // TODO should us
 
                 for (Set<TestRule> rulesGroup: rules.values()) {
                     for (TestRule rule: rulesGroup) {
-                        body = rule.apply(body, description);
+                        try {
+                            body = rule.apply(body, description);
+                        } catch (Exception e) { //This is to note which rule is failing when a rule does fail as the evaluate method hinds this information
+                            System.err.println("Test Rule " + rule.getClass() + " failed to apply. Failed with: " + e.getCause());
+                            throw e;
+                        }
                     }
                 }
                 return body;

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
@@ -113,7 +113,7 @@ public class JenkinsAcceptanceTestRule implements MethodRule { // TODO should us
                         try {
                             body = rule.apply(body, description);
                         } catch (Exception e) { //This is to note which rule is failing when a rule does fail as the evaluate method hinds this information
-                            System.err.println("Test Rule " + rule.getClass() + " failed to apply. Failed with: " + e.getCause());
+                            System.out.println("Test Rule " + rule.getClass() + " failed to apply. Failed with: " + e.getCause());
                             throw e;
                         }
                     }

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/TestRuleException.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/TestRuleException.java
@@ -2,15 +2,18 @@ package org.jenkinsci.test.acceptance.junit;
 
 import org.junit.rules.TestRule;
 
+/**
+ * This is a service exception that wraps the TestRule failure to all traceability back to failing test rules.
+ */
 public class TestRuleException extends RuntimeException {
-
+    //This is the test rule that failed.
     public final TestRule testRule;
-
+    //We take the exception, as a throwable, and the test rule
     public TestRuleException(Throwable throwable, TestRule failingRule) {
         super(throwable);
         testRule = failingRule;
     }
-
+    //This displays what the test rule that failed.
     @Override
     public String getMessage() {
         return "TestRule " + testRule.getClass() + " failed with stacktrace.\n" + super.getMessage();

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/TestRuleException.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/TestRuleException.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.test.acceptance.junit;
+
+import org.junit.rules.TestRule;
+
+public class TestRuleException extends RuntimeException {
+
+    public final TestRule testRule;
+
+    public TestRuleException(Throwable throwable, TestRule failingRule) {
+        super(throwable);
+        testRule = failingRule;
+    }
+
+    @Override
+    public String getMessage() {
+        return "TestRule " + testRule.getClass() + " failed with stacktrace.\n" + super.getMessage();
+    }
+}


### PR DESCRIPTION
I have some tests running with the withPlugins test rule and a few others. I would really like a way to tell which of my test rules is failing when the tests fail to apply all the test rules. To that end I am submitting this PR to report which test rule failed and the throwable's cause. I didn't see a contributors guide for this, so if I missed it please let me know. @reviewbybees 