### PR TITLE
[JENKINS-49470] Fixing test assertion to take into account the sanitized url

### DIFF
--- a/src/test/java/core/InstallWizardTest.java
+++ b/src/test/java/core/InstallWizardTest.java
@@ -70,7 +70,7 @@ public class InstallWizardTest extends AbstractJUnitTest {
 
         // Check that the new user is logged in
         Login login = new Login(jenkins);
-        Assert.assertThat(login, loggedInAs("adminUser"));
+        Assert.assertThat(login, loggedInAs("adminuser"));
     }
 
     @Since("2.0")
@@ -102,6 +102,6 @@ public class InstallWizardTest extends AbstractJUnitTest {
 
         // Check that the new user is logged in
         Login login = new Login(jenkins);
-        Assert.assertThat(login, loggedInAs("adminUser"));
+        Assert.assertThat(login, loggedInAs("adminuser"));
     }
 }

--- a/src/test/java/core/InstallWizardTest.java
+++ b/src/test/java/core/InstallWizardTest.java
@@ -45,6 +45,11 @@ public class InstallWizardTest extends AbstractJUnitTest {
     @Inject
     public JenkinsController controller;
 
+    private static final String USERNAME = "adminuser";
+    private static final String PASSWORD = "adminPassword";
+    private static final String FULL_NAME = "admin full name";
+    private static final String EMAIL = "admin@email.com";
+
     @Since("2.0")
     @Test
     public void wizardInstallSuggestedTest() throws IOException {
@@ -64,7 +69,7 @@ public class InstallWizardTest extends AbstractJUnitTest {
         // Create user test
         WizardCreateAdminUser createAdmin = new WizardCreateAdminUser(jenkins);
 
-        createAdmin.createAdminUser("adminUser", "adminPassword", "admin full name", "admin@email.com");
+        createAdmin.createAdminUser(USERNAME, PASSWORD, FULL_NAME, EMAIL);
         createAdmin.shouldCreateTheUserSuccessfully();
         createAdmin.wizardShouldFinishSuccessfully();
 
@@ -96,7 +101,7 @@ public class InstallWizardTest extends AbstractJUnitTest {
         // Create user test
         WizardCreateAdminUser createAdmin = new WizardCreateAdminUser(jenkins);
 
-        createAdmin.createAdminUser("adminUser", "adminPassword", "admin full name", "admin@email.com");
+        createAdmin.createAdminUser(USERNAME, PASSWORD, FULL_NAME, EMAIL);
         createAdmin.shouldCreateTheUserSuccessfully();
         createAdmin.wizardShouldFinishSuccessfully();
 


### PR DESCRIPTION
[JENKINS-49470](https://issues.jenkins-ci.org/browse/JENKINS-49470)

Fixing a test that has been consistently failing due to not taking into account that user.url is sanitized

@olivergondza I believe that the best fix would actually be to sanitize the url in the test as well but since the tests depend on a 1.36 jenkins version, I do not have hudson.Util available to use.

@reviewbybees 