### PR TITLE
[Jenkins 49263] Romeve flaky and no robust enough tests from SmokeTest Category

### DIFF
--- a/src/test/java/core/JenkinsDatabaseSecurityRealmTest.java
+++ b/src/test/java/core/JenkinsDatabaseSecurityRealmTest.java
@@ -60,7 +60,8 @@ public class JenkinsDatabaseSecurityRealmTest extends AbstractJUnitTest {
     }
 
     @Test
-    @Category(SmokeTest.class)
+    //TODO Re enable category once JENKINS-49524 is done
+    //@Category(SmokeTest.class)
     public void login_and_logout() {
 
         User user = realm.signup().fullname(FULL_NAME).email(EMAIL).password(PWD).signup(NAME);

--- a/src/test/java/core/ScriptTest.java
+++ b/src/test/java/core/ScriptTest.java
@@ -16,7 +16,6 @@ public class ScriptTest extends AbstractJUnitTest {
     SlaveController slave;
 
     @Test
-    @Category(SmokeTest.class)
     public void execute_system_script() throws Exception {
         String output = jenkins.runScript("println Jenkins.instance.displayName;");
         assertThat(output, is("Jenkins"));

--- a/src/test/java/core/SlaveTest.java
+++ b/src/test/java/core/SlaveTest.java
@@ -75,7 +75,6 @@ public class SlaveTest extends AbstractJUnitTest {
     }
 
     @Test
-    @Category(SmokeTest.class)
     public void tie_job_to_specified_label() throws Exception {
         FreeStyleJob j = jenkins.jobs.create();
         slave.configure();


### PR DESCRIPTION
[JENKINS-49263](https://issues.jenkins-ci.org/browse/JENKINS-49263)

IMO `SmokeTest` Category should contain only fully trustable tests, by my tests and check of the Build history of ATH I would like to remove from this category the following tests:

* `JenkinsDatabaseSecurityRealmTest` Because it has shown symptoms of flakiness (See JENKINS-49524)
* `ScriptTest` Because is has shown symptoms of lack of robustness (check [build history]((https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/58/testReport/junit/core/ScriptTest/execute_system_script/history/)
* `SlaveTest` for the same lack of robustness (check [build history](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/58/testReport/junit/core/SlaveTest/tie_job_to_specified_label/history/)

Please note that unlike `JenkinsDatabaseSecurityRealmTest` `ScriptTest` and `SlaveTest` are running perfectly fine (I have not been able to find any flakiness) but they are too dependant on UI changes (labels for example) to be IMO in the SmokeTest category if we want it to be very trustable. 

That is the reason I have not created tickets to fix anything in `ScriptTest`and `SlaveTest` as I believe those tests are ok

@reviewbybees @rtyler @olivergondza 