### PR TITLE
Add ssh-slave plugins dependency and Change hash of image.

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaGitContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaGitContainer/Dockerfile
@@ -1,6 +1,6 @@
 # Adds Java tooling to the git container so that this docker image can be used as agent as well
 
-FROM jenkins/git:3e22c64d038a
+FROM jenkins/git:a22007fa1ffb
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y software-properties-common
 

--- a/src/test/java/plugins/WarningsPluginTest.java
+++ b/src/test/java/plugins/WarningsPluginTest.java
@@ -125,7 +125,7 @@ public class WarningsPluginTest extends AbstractAnalysisTest<WarningsAction> {
         assertThat(driver.getPageSource(), containsString("<div id=\"packages\">BEEFs</div>"));
     }
 
-    @Test @WithDocker @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {CREDENTIALS_ID, CREDENTIALS_KEY})
+    @Test @WithDocker @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {CREDENTIALS_ID, CREDENTIALS_KEY}) @WithPlugins("ssh-slaves")
     public void should_have_correct_details() throws ExecutionException, InterruptedException {
         WarningsAction action = createAndBuildCompileJobOnAgent(resource("/warnings_plugin/WarningMain.java"),
                 "javac -Xlint:all WarningMain.java");
@@ -143,7 +143,7 @@ public class WarningsPluginTest extends AbstractAnalysisTest<WarningsAction> {
         assertThatDetailsAre(details, "division by zero", "WarningMain.java:14");
     }
 
-    @Test @WithDocker @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {CREDENTIALS_ID, CREDENTIALS_KEY})
+    @Test @WithDocker @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {CREDENTIALS_ID, CREDENTIALS_KEY}) @WithPlugins("ssh-slaves")
     public void detailsTabContentWithOneWarningTest() throws ExecutionException, InterruptedException {
         WarningsAction action = createAndBuildCompileJobOnAgent(resource("/warnings_plugin/WarningMain2.java"),
                 "javac -Xlint:all WarningMain2.java");
@@ -192,7 +192,7 @@ public class WarningsPluginTest extends AbstractAnalysisTest<WarningsAction> {
         assertThat("Assert the proper detail text" , detailText.trim(), is(expectedDetailText));
     }
 
-    @Test @WithDocker @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {CREDENTIALS_ID, CREDENTIALS_KEY})
+    @Test @WithDocker @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {CREDENTIALS_ID, CREDENTIALS_KEY}) @WithPlugins("ssh-slaves")
     public void should_scan_console_log_of_slave_build() throws ExecutionException, InterruptedException {
         DumbSlave dockerSlave = createDockerAgent();
         FreeStyleJob job = prepareDockerSlave(dockerSlave);
@@ -220,7 +220,7 @@ public class WarningsPluginTest extends AbstractAnalysisTest<WarningsAction> {
     }
 
     @Test @WithDocker
-    @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {CREDENTIALS_ID, CREDENTIALS_KEY})
+    @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {CREDENTIALS_ID, CREDENTIALS_KEY}) @WithPlugins("ssh-slaves")
     public void should_scan_files_on_slave(){
         DumbSlave dockerSlave = createDockerAgent();
         FreeStyleJob job = prepareDockerSlave(dockerSlave);
@@ -238,7 +238,7 @@ public class WarningsPluginTest extends AbstractAnalysisTest<WarningsAction> {
         assertThat(driver, hasContent("Java Warnings: " + 2));
     }
 
-    @Test @Issue("JENKINS-17787") @WithPlugins("violations") @WithDocker @Ignore("Reproduces JENKINS-17787")
+    @Test @Issue("JENKINS-17787") @WithPlugins({"violations", "ssh-slaves"}) @WithDocker @Ignore("Reproduces JENKINS-17787")
     @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {CREDENTIALS_ID, CREDENTIALS_KEY})
     public void should_parse_codenarc_on_agent() {
         DumbSlave dockerSlave = createDockerAgent();


### PR DESCRIPTION
Fix the constant failure. There is used method for creating slave from abstract class, but this method create ssh slave - so there is necessary dependency on ssh-slave plugin. Plus this error hides that hash of image was not upgraded. 