### PR TITLE
[INFRA-1489] Do not overwrite home folder when running container

### DIFF
--- a/ath-container.sh
+++ b/ath-container.sh
@@ -9,6 +9,6 @@ tag="jenkins/ath"
 
 docker build --build-arg=uid="$uid" --build-arg=gid="$gid" src/main/resources/ath-container -t "$tag"
 
-run_opts="--interactive --tty --rm --publish-all --user ath-user --workdir /home/ath-user"
-run_drive_mapping="-v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/home/ath-user -v ${HOME}/.m2/repository:/home/ath-user/.m2/repository"
+run_opts="--interactive --tty --rm --publish-all --user ath-user --workdir /home/ath-user/ath-sources"
+run_drive_mapping="-v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/home/ath-user/ath-sources -v ${HOME}/.m2/repository:/home/ath-user/.m2/repository"
 docker run $run_opts $run_drive_mapping $tag /bin/bash


### PR DESCRIPTION
* The previous code was overwriting the /home/ath-user folder with the contents
of the ATH folder, resulting in .vnc folder, among other things probably,
being deleted and hence the container unable to run the ATH unless an
external browser was used

@reviewbybees 