### PR TITLE
[JENKINS-49599] Fix last-page.html and heap-dump.log junit attachement by moving them into a Junit Rule

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/DiagnosticRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/DiagnosticRule.java
@@ -1,0 +1,72 @@
+package org.jenkinsci.test.acceptance.junit;
+
+import java.io.File;
+import java.io.IOException;
+import javax.inject.Inject;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.test.acceptance.controller.JenkinsController;
+import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@GlobalRule
+public class DiagnosticRule extends TestWatcher {
+    private static final Logger logger = LoggerFactory.getLogger(DiagnosticRule.class);
+
+    @Inject
+    FailureDiagnostics diagnostics;
+    @Inject
+    JenkinsController controller;
+    @Inject
+    WebDriver driver;
+
+    @Override
+    protected void failed(Throwable t, Description description) {
+        takeScreenshot();
+
+        if (causedBy(t, NoSuchElementException.class)) {
+            writeHtmlPage();
+        }
+
+        try {
+            controller.diagnose(t);
+        } catch (IOException e) {
+            throw new Error(e);
+        }
+
+    }
+
+    private void takeScreenshot() {
+        try {
+            File file = diagnostics.touch("screenshot.png");
+            File screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+            FileUtils.copyFile(screenshot, file);
+
+        } catch (IOException e) {
+            logger.warn("An error occurred when taking screenshot");
+            throw new Error(e);
+        }
+    }
+
+    private void writeHtmlPage() {
+        diagnostics.write("last-page.html", CapybaraPortingLayerImpl.getPageSource(driver));
+    }
+
+    /**
+     * Detect the outermost exception of given type.
+     */
+    private boolean causedBy(Throwable caught, Class<? extends Throwable> type) {
+        for (Throwable cur = caught; cur != null; cur = cur.getCause()) {
+            if (type.isInstance(cur))
+                return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
@@ -44,8 +44,6 @@ public class JenkinsAcceptanceTestRule implements MethodRule { // TODO should us
         return new Statement() {
             @Inject JenkinsController controller;
             @Inject Injector injector;
-            @Inject FailureDiagnostics diagnostics;
-            @Inject WebDriver driver;
 
             @Override
             public void evaluate() throws Throwable {
@@ -61,15 +59,6 @@ public class JenkinsAcceptanceTestRule implements MethodRule { // TODO should us
                 } catch (AssumptionViolatedException e) {
                     System.out.printf("Skipping %s%n", description.getDisplayName());
                     e.printStackTrace();
-                    throw e;
-                } catch (Exception|AssertionError e) { // Errors and failures
-                    if (causedBy(e, NoSuchElementException.class) != null) {
-                        diagnostics.write(
-                                "last-page.html",
-                                CapybaraPortingLayerImpl.getPageSource(driver)
-                        );
-                    }
-                    controller.diagnose(e);
                     throw e;
                 } finally {
                     world.endTestScope();


### PR DESCRIPTION
Move last-page.html and heap-dump.log generation to DiagnosticRule so they are taken into account by FailureDiagnostics when adding junit attachments
Adding screenshot in case of failure (screen recording is not available in headless mode so having a screenshot is better than nothing)

@reviewbybees 