### PR TITLE
[JENKINS-49841] Explicitely wait for the configure form to be loaded instead of waiting 1s

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Callable;
 import com.google.inject.Injector;
 
 import groovy.lang.Closure;
+import org.openqa.selenium.By;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.jenkinsci.test.acceptance.Matchers.*;
@@ -103,7 +104,7 @@ public abstract class ConfigurablePageObject extends PageObject {
             return;
         }
         visit(getConfigUrl());
-        elasticSleep(1000); // configure page requires some time to load
+        waitFor(By.xpath("//form[contains(@name, 'config')]"), 10);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
@@ -105,6 +105,7 @@ public abstract class ConfigurablePageObject extends PageObject {
         }
         visit(getConfigUrl());
         waitFor(By.xpath("//form[contains(@name, 'config')]"), 10);
+        waitFor(By.xpath("//span[contains(@class, 'submit-button')]//button[contains(text(), 'Save')]"), 5);
     }
 
     /**


### PR DESCRIPTION
Replace implicit wait of 1s by an explicit wait for the configure form to be present on the page to assert that the configure page is properly loaded.

Jira issue: https://issues.jenkins-ci.org/browse/JENKINS-49841

@reviewbybees 