### PR TITLE
[Jenkins-50023] core.ViewTest#renameJob was failing

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
@@ -43,12 +43,12 @@ public abstract class TopLevelItem extends ContainerPageObject {
      */
     @CheckReturnValue
     public <T extends TopLevelItem> T renameTo(final String newName) {
-        configure();
+        open();
         String oldName = name;
-        control("/name").set(newName);
-        save();
-        waitFor(by.button("Yes")).click();
-
+        control(by.href("/job/" + oldName + "/confirm-rename")).click();
+        WebElement renameButton = waitFor(by.button("Rename"));
+        control(by.name("newName")).set(newName);
+        renameButton.click();
         try {
             return (T) newInstance(getClass(),
                     injector, new URL(url.toExternalForm().replace(oldName, newName)), newName);

--- a/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
@@ -6,6 +6,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import hudson.util.VersionNumber;
+import org.jenkinsci.test.acceptance.junit.Since;
 import org.openqa.selenium.WebElement;
 
 import com.google.inject.Injector;
@@ -43,12 +45,20 @@ public abstract class TopLevelItem extends ContainerPageObject {
      */
     @CheckReturnValue
     public <T extends TopLevelItem> T renameTo(final String newName) {
-        open();
         String oldName = name;
-        control(by.href("/job/" + oldName + "/confirm-rename")).click();
-        WebElement renameButton = waitFor(by.button("Rename"));
-        control(by.name("newName")).set(newName);
-        renameButton.click();
+        // Change in behaviour of the rename is in versions > 2.110 see JENKINS-22936
+        if (getJenkins().getVersion().isOlderThan(new VersionNumber("2.110"))) {
+            configure();
+            control("/name").set(newName);
+            save();
+            waitFor(by.button("Yes")).click();
+        } else {
+            open();
+            control(by.href("/job/" + oldName + "/confirm-rename")).click();
+            WebElement renameButton = waitFor(by.button("Rename"), 5);
+            control(by.name("newName")).set(newName);
+            renameButton.click();
+        }
         try {
             return (T) newInstance(getClass(),
                     injector, new URL(url.toExternalForm().replace(oldName, newName)), newName);


### PR DESCRIPTION
[JENKINS-50023](https://issues.jenkins-ci.org/browse/JENKINS-50023)

[JENKINS-22936](https://issues.jenkins-ci.org/browse/JENKINS-22936) changed the way to rename `TopLevelItem`s so `ViewTest#renameJob` is failing from `2.110` onwards

This small change makes the test to work again. Also, I have checked which tests use this method to compare with the results in [last master build](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/67/testReport/junit/plugins/) to check for possible regressions introduced by this change

* AnalysisCollectorPluginTest 
* CheckstylePluginTest 
* FindbugsPluginTest
* PmdPluginTest
* TaskScannerPluginTest
* WarningsPluginTest