### PR TITLE
Configuration form does not have to have name "config"

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/CredentialsPage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/CredentialsPage.java
@@ -82,4 +82,8 @@ public class CredentialsPage extends ConfigurablePageObject {
         waitFor(by.name("_.id"));
         return wd;
     }
+
+    public String getFormName() {
+        return "update";
+    }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
@@ -104,8 +104,16 @@ public abstract class ConfigurablePageObject extends PageObject {
             return;
         }
         visit(getConfigUrl());
-        waitFor(By.xpath("//form[contains(@name, 'config')]"), 10);
-        waitFor(By.xpath("//span[contains(@class, 'submit-button')]//button[contains(text(), 'Save')]"), 5);
+        waitFor(By.xpath("//form[contains(@name, '" + getFormName() + "')]"), 10);
+        waitFor(By.xpath("//span[contains(@class, 'submit-button')]//button[contains(text(), '" + getSubmitButtonText() + "')]"), 5);
+    }
+
+    public String getFormName(){
+        return "config";
+    }
+
+    public String getSubmitButtonText(){
+        return "Save";
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/po/View.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/View.java
@@ -105,6 +105,14 @@ public abstract class View extends ContainerPageObject {
         descrElem.sendKeys(description);
     }
 
+    public String getFormName(){
+        return "viewConfig";
+    }
+
+    public String getSubmitButtonText(){
+        return "OK";
+    }
+
     public static Matcher<View> containsColumnHeaderTooltip(String tooltip) {
         return new Matcher<View>("Contains ToolTip " + tooltip) {
             @Override


### PR DESCRIPTION
Allow to define configuration form name and text of the submit button. It does not work with views extensions as well with credentials.