### PR TITLE
Ignore the test - deprecated features which is tested was removed.

### DIFF
--- a/src/test/java/plugins/JobDslPluginTest.java
+++ b/src/test/java/plugins/JobDslPluginTest.java
@@ -28,6 +28,7 @@ import org.jenkinsci.test.acceptance.po.ListView;
 import org.jenkinsci.test.acceptance.po.PluginManager;
 import org.jenkinsci.test.acceptance.po.View;
 import org.jenkinsci.test.acceptance.update_center.PluginSpec;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -501,6 +502,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * If the function is used, the build will be marked as unstable.
      */
     @Test @WithPlugins("config-file-provider")
+    @Ignore
     public void should_unstable_on_deprecated_features() {
         FreeStyleJob seedJob = createSeedJob();
         JobDslBuildStep jobDsl = seedJob.addBuildStep(JobDslBuildStep.class);

--- a/src/test/java/plugins/JobDslPluginTest.java
+++ b/src/test/java/plugins/JobDslPluginTest.java
@@ -502,7 +502,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * If the function is used, the build will be marked as unstable.
      */
     @Test @WithPlugins("config-file-provider")
-    @Ignore
+    @Ignore //customConfigFile  has been removed since job-dsl-1.66
     public void should_unstable_on_deprecated_features() {
         FreeStyleJob seedJob = createSeedJob();
         JobDslBuildStep jobDsl = seedJob.addBuildStep(JobDslBuildStep.class);


### PR DESCRIPTION
This deprecated feature was removed by commit  https://github.com/jenkinsci/job-dsl-plugin/commit/db9ca7d1b27f2daaad5bd13d733e51868ae9afdd#diff-4383c503e803309dfcf3aa10c24d9c25.
I know that purpose of this test is to test that it provides different build result if deprecated feature is used (to make it more visible for user). But this change is more then half year old and no one modified the test and it is failing since that. If someone wishes to have this behavior be tested and rewrite it to other deprecated feature, he can. But until it happens I suggest to skip this tests. 