### PR TITLE
[JENKINS-50790] Temporarily override pageLoadTimeout for available plugins

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -80,6 +80,8 @@ public class FallbackConfig extends AbstractModule {
 
     public static final String DOM_MAX_SCRIPT_RUN_TIME = "dom.max_script_run_time";
     public static final String DOM_MAX_CHROME_SCRIPT_RUN_TIME = "dom.max_chrome_script_run_time";
+    public static int PAGE_LOAD_TIMEOUT = 30;
+    public static int IMPLICIT_WAIT_TIMEOUT = 1;
 
     @Override
     protected void configure() {
@@ -193,8 +195,8 @@ public class FallbackConfig extends AbstractModule {
         d.register(new Scroller());
 
         try {
-            d.manage().timeouts().pageLoadTimeout(time.seconds(30), TimeUnit.MILLISECONDS);
-            d.manage().timeouts().implicitlyWait(time.seconds(1), TimeUnit.MILLISECONDS);
+            d.manage().timeouts().pageLoadTimeout(time.seconds(PAGE_LOAD_TIMEOUT), TimeUnit.MILLISECONDS);
+            d.manage().timeouts().implicitlyWait(time.seconds(IMPLICIT_WAIT_TIMEOUT), TimeUnit.MILLISECONDS);
         } catch (UnsupportedCommandException e) {
             // sauce labs RemoteWebDriver doesn't support this
             System.out.println(base + " doesn't support page load timeout");

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -80,8 +80,8 @@ public class FallbackConfig extends AbstractModule {
 
     public static final String DOM_MAX_SCRIPT_RUN_TIME = "dom.max_script_run_time";
     public static final String DOM_MAX_CHROME_SCRIPT_RUN_TIME = "dom.max_chrome_script_run_time";
-    public static int PAGE_LOAD_TIMEOUT = 30;
-    public static int IMPLICIT_WAIT_TIMEOUT = 1;
+    public static final int PAGE_LOAD_TIMEOUT = 30;
+    public static final int IMPLICIT_WAIT_TIMEOUT = 1;
 
     @Override
     protected void configure() {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -228,12 +228,16 @@ public class PluginManager extends ContainerPageObject {
                 }
             }
         } else {
+
             // JENKINS-50790 It seems that this page takes too much time to load when running in the new ci.jenkins.io
-            driver.manage().timeouts().pageLoadTimeout(time.seconds(60), TimeUnit.MILLISECONDS);
-            visit("available");
-            driver.manage().timeouts().pageLoadTimeout(time.seconds(FallbackConfig.PAGE_LOAD_TIMEOUT), TimeUnit.MILLISECONDS);
+            try {
+                driver.manage().timeouts().pageLoadTimeout(time.seconds(60), TimeUnit.MILLISECONDS);
+                visit("available");
+            } finally {
+                driver.manage().timeouts().pageLoadTimeout(time.seconds(FallbackConfig.PAGE_LOAD_TIMEOUT), TimeUnit.MILLISECONDS);
+            }
             // End JENKINS-50790
-            
+
             final ArrayList<PluginSpec> update = new ArrayList<>();
             for (final PluginSpec n : specs) {
                 switch (installationStatus(n)) {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -14,6 +14,7 @@ import java.util.logging.Logger;
 
 import com.google.common.base.Predicate;
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.test.acceptance.FallbackConfig;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.update_center.PluginMetadata;
 import org.jenkinsci.test.acceptance.update_center.PluginSpec;
@@ -227,8 +228,12 @@ public class PluginManager extends ContainerPageObject {
                 }
             }
         } else {
+            // JENKINS-50790 It seems that this page takes too much time to load when running in the new ci.jenkins.io
+            driver.manage().timeouts().pageLoadTimeout(time.seconds(60), TimeUnit.MILLISECONDS);
             visit("available");
-
+            driver.manage().timeouts().pageLoadTimeout(time.seconds(FallbackConfig.PAGE_LOAD_TIMEOUT), TimeUnit.MILLISECONDS);
+            // End JENKINS-50790
+            
             final ArrayList<PluginSpec> update = new ArrayList<>();
             for (final PluginSpec n : specs) {
                 switch (installationStatus(n)) {

--- a/src/test/java/plugins/GitPluginTest.java
+++ b/src/test/java/plugins/GitPluginTest.java
@@ -249,12 +249,11 @@ public class GitPluginTest extends AbstractJUnitTest {
     public void create_tag_for_build() {
         GitRepo repo = buildGitRepo();
         repo.transferToDockerContainer(host, port);
-
         job.useScm(GitScm.class)
                 .url(repoUrl)
                 .credentials(USERNAME)
+                .customNameAndMail("fake", "fake@mail.com")
                 .createTagForBuild();
-
         job.addShellStep("git tag -n1");
         job.save();
         Build b = job.startBuild();


### PR DESCRIPTION
[JENKINS-50790](https://issues.jenkins-ci.org/browse/JENKINS-50790)

This should fix most of GitPluginTest and some others that are failing due to the
available plugins taking too much time to load on ci.jenkins.io

@reviewbybees 