### PR TITLE
[JENKINS-51292] attempt to fix random failures in GitCOntainer

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/Dockerfile
@@ -5,16 +5,14 @@
 
 FROM ubuntu:xenial
 
-# install SSHD
-RUN apt-get update && apt-get install -y openssh-server
-
 RUN mkdir -p /var/run/sshd
 
-# install git
-RUN apt-get install -y git
-
-# install zip
-RUN apt-get install -y zip
+# install SSHD, Git and zip
+RUN apt-get update && apt-get install -y \
+    openssh-server \
+    git \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
 
 # create a git user and create .ssh dir
 RUN useradd git -d /home/git && \


### PR DESCRIPTION
[JENKINS-51292](https://issues.jenkins-ci.org/browse/JENKINS-51292)
Should fix random issues where the cache was populated from a different
build long ago such as that observed in the referenced issue.

```
java.lang.Error: Failed to build image (100): 3e22c64d038a
	at com.cloudbees.CustomTest.setUp(CustomTest.java:62)

Sending build context to Docker daemon 6.144 kB

Step 1/11 : FROM ubuntu:xenial
 ---> f975c5035748
Step 2/11 : RUN echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" > /etc/apt/sources.list
 ---> Using cache
 ---> e62553aa9c43
Step 3/11 : RUN apt-get update && apt-get install -y openssh-server
 ---> Using cache
 ---> 381056e8680f
Step 4/11 : RUN mkdir -p /var/run/sshd
 ---> Using cache
 ---> aa5449fdb24d
Step 5/11 : RUN apt-get install -y git
 ---> Running in 9b6376facb5c
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 git : Depends: liberror-perl but it is not going to be installed
[91mE: Unable to correct problems, you have held broken packages.
[0mThe command '/bin/sh -c apt-get install -y git' returned a non-zero code: 100
Sending build context to Docker daemon 6.144 kB
```
@fcojfernandez 