### PR TITLE
[JENKINS-51484] Rename Job is failing when the job is in a folder

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
@@ -54,7 +54,7 @@ public abstract class TopLevelItem extends ContainerPageObject {
             waitFor(by.button("Yes")).click();
         } else {
             open();
-            control(by.href("/job/" + oldName + "/confirm-rename")).click();
+            control(by.href(url.getPath() + "confirm-rename")).click();
             WebElement renameButton = waitFor(by.button("Rename"), 5);
             control(by.name("newName")).set(newName);
             renameButton.click();


### PR DESCRIPTION
See [JENKINS-51484](https://issues.jenkins-ci.org/browse/JENKINS-51484)

The `TopLevelItem.renameTo` method has been updated because of [JENKINS-22936](https://issues.jenkins-ci.org/browse/JENKINS-22936). The href used to locate the Rename link is valid in general, but fails when the job is located in a folder. 

@reviewbybees @olivergondza @raul-arabaolaza 
