### PR TITLE
[JENKINS-51489] Introducing pre configured plugins mode

### DIFF
--- a/docs/SUT-VERSIONS.md
+++ b/docs/SUT-VERSIONS.md
@@ -58,16 +58,13 @@ executed during your tests).
 Note that this option is not yet supported by all [Jenkins controllers](CONTROLLER.md), 
 so e.g. use `TYPE=winstone` in order to get the `PLUGINS_DIR` option working.
 
-### Running in pre configured plugin mode
-
-In some cases you may be running the ATH against a pre configured instance, for example you can provide a war file that
-somehow, for example by being created by the [CWP](https://github.com/jenkinsci/custom-war-packager),
-contains an already pre configured set of plugins, or against an existing environment by using some specific Controller.
-In this case you may want to ATH to not manage plugins installations at all but only validate that the existing configured
+In some cases, when you are providing the full plugins colection, you are running the ATH against a war with a pre configured
+set of plugins (for example by being created by the [CWP](https://github.com/jenkinsci/custom-war-packager))
+or running against an already existing environment, you may want the ATH to not manage plugins at all but only validate that the existing configured
 plugins are enough to run the tests.
 
-You can activate this mode with the property `pluginEvaluationOutcome`, possible values for this property are:
+You can activate this `pre configured plugins` mode with the System property `pluginEvaluationOutcome`, possible values for this property are:
 * `"skipOnInvalid"` Which means the test will be skipped if the installed plugins are not enough to cover the test requisites
 * `"failOnInvalid"` Which means the test will fail if the installed plugins are not enough to cover the test requisites
 
-This property has to be provided via [the groovy wiring script](WIRING.md) and this mode is disabled if the property is not specified
+Note this mode is disabled if the property is not specified

--- a/docs/SUT-VERSIONS.md
+++ b/docs/SUT-VERSIONS.md
@@ -60,11 +60,13 @@ so e.g. use `TYPE=winstone` in order to get the `PLUGINS_DIR` option working.
 
 ### Running in pre configured plugin mode
 
-You can provide a war file that somehow, for example by being created by the [CWP](https://github.com/jenkinsci/custom-war-packager),
-contains an already pre configured set of plugins, in this case you may want to ATH to not manage plugins installations at all
-but only validate that the existing configured plugins are enough to run the tests.
+In some cases you may be running the ATH against a pre configured instance, for example you can provide a war file that
+somehow, for example by being created by the [CWP](https://github.com/jenkinsci/custom-war-packager),
+contains an already pre configured set of plugins, or against an existing environment by using some specific Controller.
+In this case you may want to ATH to not manage plugins installations at all but only validate that the existing configured
+plugins are enough to run the tests.
 
-You can activate this mode by adding a CONFIG file with the property `pluginEvaluationOutcome`, possible values for this property are:
+You can activate this mode with the property `pluginEvaluationOutcome`, possible values for this property are:
 * `"skipOnInvalid"` Which means the test will be skipped if the installed plugins are not enough to cover the test requisites
 * `"failOnInvalid"` Which means the test will fail if the installed plugins are not enough to cover the test requisites
 

--- a/docs/SUT-VERSIONS.md
+++ b/docs/SUT-VERSIONS.md
@@ -57,3 +57,15 @@ executed during your tests).
 
 Note that this option is not yet supported by all [Jenkins controllers](CONTROLLER.md), 
 so e.g. use `TYPE=winstone` in order to get the `PLUGINS_DIR` option working.
+
+### Running in pre configured plugin mode
+
+You can provide a war file that somehow, for example by being created by the [CWP](https://github.com/jenkinsci/custom-war-packager),
+contains an already pre configured set of plugins, in this case you may want to ATH to not manage plugins installations at all
+but only validate that the existing configured plugins are enough to run the tests.
+
+You can activate this mode by adding a CONFIG file with the property `pluginEvaluationOutcome`, possible values for this property are:
+* `"skipOnInvalid"` Which means the test will be skipped if the installed plugins are not enough to cover the test requisites
+* `"failOnInvalid"` Which means the test will fail if the installed plugins are not enough to cover the test requisites
+
+This property has to be provided via [the groovy wiring script](WIRING.md) and this mode is disabled if the property is not specified

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -340,19 +340,7 @@ public class FallbackConfig extends AbstractModule {
             throw new Error("Could not find jenkins.war, use JENKINS_WAR or JENKINS_VERSION to specify it.", ex);
         }
     }
-
-    /**
-     * Switch to control if an existing plugin should be updated.
-     *
-     * <p>
-     * If true, a test will be skipped when it requires a newer version of a plugin that's already installed.
-     * If false, an existing plugin will be updated to the requirements of the test.
-     */
-    @Provides @Named("neverReplaceExistingPlugins")
-    public boolean neverReplaceExistingPlugins() {
-        return System.getenv("NEVER_REPLACE_EXISTING_PLUGINS") != null;
-    }
-
+    
     /**
      *  Provides a mechanism to create a report on which plugins were used
      *  during the test execution

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/WithPlugins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/WithPlugins.java
@@ -98,9 +98,6 @@ public @interface WithPlugins {
         @Inject @Named("ExercisedPluginReporter")
         ExercisedPluginsReporter pluginReporter;
 
-        @Inject(optional=true) @Named("neverReplaceExistingPlugins")
-        boolean neverReplaceExistingPlugins;
-
         String pluginEvaluationOutcome = System.getProperty("pluginEvaluationOutcome", PRECONFIGURED_MODE_DISABLED);
 
         @VisibleForTesting static List<PluginSpec> combinePlugins(List<WithPlugins> wp) {
@@ -188,11 +185,7 @@ public @interface WithPlugins {
                                 iterator.remove(); // Already installed
                                 break;
                             case OUTDATED:
-                                if (neverReplaceExistingPlugins) {
-                                    throw new AssumptionViolatedException(String.format(
-                                            "Test requires %s plugin", spec
-                                    ));
-                                }
+                                LOGGER.info(spec + " is outdated");
                                 break;
                             default:
                                 assert false;


### PR DESCRIPTION
[JENKINS-51489](https://issues.jenkins-ci.org/browse/JENKINS-51489)

See the linked ticket, when running against an existing environment with a preconfigured set of plugins, for example, a war file generated from [CWP](https://github.com/jenkinsci/custom-war-packager)  or an existing instance seems reasonable for the ATH to not try to install/update any plugins but only validate the existing ones to check if they are enough for the set of tests to run.

This PR introduces a new `pre-configured plugins mode` which does exactly that if you specify a `pluginEvaluationOutcome` property via the groovy wiring script the mode is activated, depending on the value (see the new docs) a test whose dependencies are not satisfied may directly fail or be skipped without the ATH trying to install/update any plugin

Note that this new mode is opt-in so no change in default behaviour is introduced 

@reviewbybees @oleg-nenashev @jglick 

cc @olivergondza 