### PR TITLE
Update check for Install Wizard completion to look for the target button by ID instead of the text label

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/WizardCreateAdminUser.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WizardCreateAdminUser.java
@@ -63,7 +63,7 @@ public class WizardCreateAdminUser extends PageObject {
         }
 
         driver.switchTo().defaultContent();
-        clickButton("Save and Finish");
+        clickButton("Save and Continue");
         return this;
     }
 


### PR DESCRIPTION
The label for button used to complete the install wizard has changed in the UI, causing tests that
 depend on this method to fail.  The button label is now "**Save and Continue**" (formerly "**Save and Finish**") - just updating the string that is being searched for in the test means we will be at risk of hitting this problem again the next time it changes.  

Instead the check needs to be fixed to look for the button by its ID, which should be much less likely to change.