### PR TITLE
Add the ability to run tests using docker image running as root

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -53,3 +53,6 @@ RUN touch /home/ath-user/.Xauthority
 # have in ENTRYPOINT as the container is started as ath-user.
 USER root
 RUN chmod ug+s "$(which docker)"
+
+# Make sure you can start vnc as root also
+RUN (echo ath-user; echo ath-user; echo "n") | vncpasswd 


### PR DESCRIPTION
The docker image was intended to be run as a concrete user, which is specified at build time, having the ability to be run also as root makes it much more portable and for example makes trivial to use this image in a kubernetes cluster via [kubernetes-plugin](https://github.com/jenkinsci/kubernetes-plugin) with something similar to this:

```
def podLabel = "ath-pod-${UUID.randomUUID().toString()}"
def containerLabel = "ath-container-${UUID.randomUUID().toString()}"
podTemplate(label: podLabel, yaml: """
apiVersion: v1
kind: Pod
spec:
  containers:
  - image: jenkins/ath
    name: ${containerLabel}
    tty: true
    volumeMounts:
    - mountPath: /var/run/docker.sock
      name: docker-sock
  volumes:
  - name: docker-sock
    hostPath:
      path: /var/run/docker.sock
""", nodeUsageMode: "EXCLUSIVE") {
            node(podLabel) {
                container(containerLabel) {
                    sh 'eval "$(./vnc.sh)" && export DISPLAY=$BROWSER_DISPLAY && ./run.sh firefox 2.121'
                }
            }
        }
    } 
}
```

If you need to run this image as another user you have a lot of problems related to permissions and access which compromise the portability of this image across different CI environments