### PR TITLE
[JENKINS-52119] Fix URL for downloading Atlassian SDK

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer/Dockerfile
@@ -12,7 +12,7 @@ FROM ubuntu:xenial
 ENV JIRA_VERSION 6.3
 
 # base package installation
-RUN apt-get update -y && apt-get install -y apt-transport-https && echo "deb https://sdkrepo.atlassian.com/debian/ stable contrib" >> /etc/apt/sources.list && apt-get update
+RUN apt-get update -y && apt-get install -y apt-transport-https && echo "deb https://packages.atlassian.com/atlassian-sdk-deb stable contrib" >> /etc/apt/sources.list && apt-get update
 RUN apt-get install -y --allow-unauthenticated openjdk-8-jdk atlassian-plugin-sdk netcat
 
 # this will install the whole thing, launches Tomcat,


### PR DESCRIPTION
# Description

See [JENKINS-52119](https://issues.jenkins-ci.org/browse/JENKINS-52119). This simple PR updates the URL from which the Atlassian SDK is downloaded.

Before this PR, if you don't already have the docker image downloaded from previous work, the test will fail as follows:
```
Building Docker image `docker build -t jenkins/jira:2b315e26c84f /tmp/Dockerfile8883778022481754579dir`: logfile is at target/diagnostics/jira_ticket_gets_updated_with_a_build_link(plugins.JiraPluginTest)/docker-JiraContainer.build.log
master55986|Jun 21, 2018 4:09:13 PM jenkins.metrics.api.Metrics$HealthChecker execute
master55986|WARNING: Some health checks are reporting as unhealthy: [backup : Last backup failed: null]
[[ATTACHMENT|/tmp/dockerhome/acceptance-test-harness/target/diagnostics/jira_ticket_gets_updated_with_a_build_link(plugins.JiraPluginTest)/docker-JiraContainer.build.log]]
[[ATTACHMENT|/tmp/dockerhome/acceptance-test-harness/target/diagnostics/jira_ticket_gets_updated_with_a_build_link(plugins.JiraPluginTest)/screenshot.png]]
Cleaning up temporary JENKINS_HOME failed, retrying in 5 sec.
--- Test failed: jira_ticket_gets_updated_with_a_build_link(plugins.JiraPluginTest): Failed to build image (100): 2b315e26c84f: 16:09:24
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 101.046 sec <<< FAILURE! - in plugins.JiraPluginTest
jira_ticket_gets_updated_with_a_build_link(plugins.JiraPluginTest)  Time elapsed: 100.986 sec  <<< ERROR!
java.lang.Error: Failed to build image (100): 2b315e26c84f
(snip)
```
This PR fixes the problem and allows the docker image to be built successfully.