### PR TITLE
Tomcat7Container docker image based on ubuntu:xenial

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/Tomcat7Container/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/Tomcat7Container/Dockerfile
@@ -4,10 +4,10 @@
 # The admin user has username 'admin' and password 'tomcat'
 #
 
-FROM ubuntu
+FROM ubuntu:xenial
 
 # Tomcat7 is from Universe
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise universe" >> /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu xenial universe" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y tomcat7 tomcat7-admin
 
 # configure the admin user


### PR DESCRIPTION
Solving issue when building the docker image as the `public key` is not reachable when using the generic ubuntu image. Besides that, it does allow to be more consistent and use always the same version.

* Current error:

```
Sending build context to Docker daemon  2.56 kB

Step 1/6 : FROM ubuntu
 ---> 113a43faa138
Step 2/6 : RUN echo "deb http://archive.ubuntu.com/ubuntu precise universe" >> /etc/apt/sources.list
 ---> Using cache
 ---> 54dd9361a398
Step 3/6 : RUN apt-get update && apt-get install -y tomcat7 tomcat7-admin
 ---> Running in 96f746fab525
Get:1 http://security.ubuntu.com/ubuntu bionic-security InRelease [83.2 kB]
Get:2 http://archive.ubuntu.com/ubuntu bionic InRelease [242 kB]
Get:3 http://security.ubuntu.com/ubuntu bionic-security/universe Sources [8194 B]
Get:4 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
Get:5 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [43.7 kB]
Get:6 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
Get:7 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [1075 B]
Get:8 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [139 kB]
Ign:9 http://archive.ubuntu.com/ubuntu precise InRelease
Get:10 http://archive.ubuntu.com/ubuntu bionic/universe Sources [11.5 MB]
Get:11 http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages [1344 kB]
Get:12 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [186 kB]
Get:13 http://archive.ubuntu.com/ubuntu bionic/restricted amd64 Packages [13.5 kB]
Get:14 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [11.3 MB]
Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/universe Sources [47.5 kB]
Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [149 kB]
Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [3679 B]
Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [234 kB]
Get:19 http://archive.ubuntu.com/ubuntu precise Release [49.6 kB]
Get:20 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [2807 B]
Get:21 http://archive.ubuntu.com/ubuntu precise Release.gpg [198 B]
Ign:21 http://archive.ubuntu.com/ubuntu precise Release.gpg
Reading package lists...
[91mW: GPG error: http://archive.ubuntu.com/ubuntu precise Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 40976EAF437D05B5
E: The repository 'http://archive.ubuntu.com/ubuntu precise Release' is not signed.
[0mThe command '/bin/sh -c apt-get update && apt-get install -y tomcat7 tomcat7-admin' returned a non-zero code: 100
```

This particular fix was already done for the Git docker container: https://github.com/jenkinsci/acceptance-test-harness/commit/e980cae09ec191e4ece4409f98472869d58ca994#diff-99e4a20b9a94af9e5bc33cd9b9741dc9

@reviewbybees
