### PR TITLE
Fix kerberos for ATH inside container

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/KerberosContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/KerberosContainer.java
@@ -69,17 +69,6 @@ public class KerberosContainer extends DynamicDockerContainer {
         }
     }
 
-    public String getIpAddress(){
-        String address = null;
-        try {
-            address = Docker.cmd(new String[]{"inspect"}).add(getCid()).popen().asText();
-            address = address.split("IPAddress")[2].split(":")[1].split(",",2)[0].trim().replaceAll("\"", "").replaceAll(",","");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return address;
-    }
-
     private File targetDir = null;
     private File loginConf = null;
     private File krb5Conf = null;
@@ -126,7 +115,7 @@ public class KerberosContainer extends DynamicDockerContainer {
                 fw.write(resource("src/etc.krb5.conf").asText()
                         .replaceAll("__KDC_PORT__", String.valueOf(88))
                         .replaceAll("__ADMIN_PORT__", String.valueOf(749))
-                        .replaceAll("_ADDRESS_", getIpAddress())
+                        .replaceAll("_ADDRESS_", inspect().get("IPAddress").textValue())
                 );
             } catch (IOException e) {
                 throw new Error(e);
@@ -146,7 +135,7 @@ public class KerberosContainer extends DynamicDockerContainer {
             ProcessBuilder builder = new ProcessBuilder();
             builder.command("base64", "-d", "/tmp/coded").redirectOutput(new File(to)).start().waitFor();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new Error(e);
         }
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/KerberosContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/KerberosContainer.java
@@ -110,12 +110,13 @@ public class KerberosContainer extends DynamicDockerContainer {
                 throw new Error(e);
             }
 
+
             krb5Conf = new File(targetDir, "krb5.conf");
             try (FileWriter fw = new FileWriter(krb5Conf)) {
                 fw.write(resource("src/etc.krb5.conf").asText()
                         .replaceAll("__KDC_PORT__", String.valueOf(88))
                         .replaceAll("__ADMIN_PORT__", String.valueOf(749))
-                        .replaceAll("_ADDRESS_", inspect().get("IPAddress").textValue())
+                        .replaceAll("_ADDRESS_", inspect().get("NetworkSettings").get("Networks").findValue("IPAddress").asText())
                 );
             } catch (IOException e) {
                 throw new Error(e);

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/KerberosContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/KerberosContainer/Dockerfile
@@ -7,25 +7,17 @@ ENV HOST_NAME $HOST_NAME
 RUN yum -y install\
     krb5-libs\
     krb5-server\
-    krb5-workstation
+    krb5-workstation\
+    base64coder
 
+ADD src/prepare.sh /tmp/prepare_kerberos.sh
 ADD src/etc.krb5.conf /etc/krb5.conf
 ADD src/var.kerberos.krb5kdc.kadm5.acl /var/kerberos/krb5kdc/kadm5.acl
 ADD src/keytab.sh keytab.sh
 
-# Populate kdc database with principals
-RUN rm -f /dev/random && ln -s /dev/urandom /dev/random &&\
-    /usr/sbin/kdb5_util create -s -P "ATH" &&\
-    /usr/sbin/kadmin.local -w ATH -q "addprinc -pw ATH -clearpolicy -e des-cbc-md5:normal,des-cbc-crc:normal,rc4-hmac:normal user" &&\
-    /usr/sbin/kadmin.local -w ATH -q "addprinc -pw ATH -clearpolicy -e des-cbc-md5:normal,des-cbc-crc:normal,rc4-hmac:normal HTTP/${HOST_NAME}" &&\
-    sed -i "s@__KDC_PORT__@88@g; s@__ADMIN_PORT__@749@g" /etc/krb5.conf
 
-# Generate keytabs
-RUN mkdir -p /target/keytab &&\
-    bash keytab.sh /target/keytab/service HTTP/${HOST_NAME}@EXAMPLE.COM &&\
-    bash keytab.sh /target/keytab/user user@EXAMPLE.COM
 
 # Run the service
-CMD /usr/sbin/_kadmind -P /var/run/kadmind.pid &&\
-    /usr/sbin/krb5kdc -P /var/run/krb5kdc.pid &&\
-    tail -f /var/log/krb5kdc.log
+CMD sh /tmp/prepare_kerberos.sh
+
+

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/KerberosContainer/src/etc.krb5.conf
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/KerberosContainer/src/etc.krb5.conf
@@ -16,9 +16,9 @@
 [realms]
  EXAMPLE.COM = {
   # Container port 88
-  kdc = 127.0.0.1:__KDC_PORT__
+  kdc = _ADDRESS_:__KDC_PORT__
   # Container port 749
-  admin_server = 127.0.0.1:__ADMIN_PORT__
+  admin_server = _ADDRESS_:__ADMIN_PORT__
   default_domain = example.com
  }
 

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/KerberosContainer/src/prepare.sh
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/KerberosContainer/src/prepare.sh
@@ -1,0 +1,18 @@
+ADDRESS=`hostname -I`
+ADDRESS=`echo -e "${ADDRESS}" | tr -d '[:space:]'`
+rm -f /dev/random && ln -s /dev/urandom /dev/random
+/usr/sbin/kdb5_util create -s -P "ATH"
+/usr/sbin/kadmin.local -w ATH -q "addprinc -pw ATH -clearpolicy -e des-cbc-md5:normal,des-cbc-crc:normal,rc4-hmac:normal user"
+/usr/sbin/kadmin.local -w ATH -q "addprinc -pw ATH -clearpolicy -e des-cbc-md5:normal,des-cbc-crc:normal,rc4-hmac:normal HTTP/localhost"
+
+
+sed -i "s@__KDC_PORT__@88@g; s@__ADMIN_PORT__@749@g; s@_ADDRESS_@${ADDRESS}@g" /etc/krb5.conf
+mkdir -p /target/keytab
+
+bash keytab.sh /target/keytab/service HTTP/localhost@EXAMPLE.COM
+bash keytab.sh /target/keytab/user user@EXAMPLE.COM
+
+/usr/sbin/_kadmind -P /var/run/kadmind.pid && /usr/sbin/krb5kdc -P /var/run/krb5kdc.pid
+touch /tmp/kerberos_running
+tail -f /var/log/krb5kdc.log
+


### PR DESCRIPTION
Tests for kerberos ticket are failing when ATH is running inside docker. The reason is that they were written for localhost:<port> (communication between host and container) which is not the way how one container can communicate with another. 