### PR TITLE
UI for adding user changed.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/MatrixAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/MatrixAuthorizationStrategy.java
@@ -4,13 +4,18 @@ import org.jenkinsci.test.acceptance.po.AuthorizationStrategy;
 import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 @Describable("Matrix-based security")
 public class MatrixAuthorizationStrategy extends AuthorizationStrategy {
-    private final Control name = control("/");
+    private final Control name = control("/data");
 
     public MatrixAuthorizationStrategy(GlobalSecurityConfig context, String path) {
         super(context, path);
@@ -20,8 +25,11 @@ public class MatrixAuthorizationStrategy extends AuthorizationStrategy {
      * Adds a new user/group to this matrix.
      */
     public MatrixRow addUser(String name) {
-        this.name.set(name);
-        this.name.resolve().findElement(by.parent()).findElement(by.button("Add")).click();
+        this.name.resolve().findElement(by.parent()).findElement(by.button("Add user or group…")).click();
+        WebDriverWait wait = new WebDriverWait(driver, 10);
+        Alert promptAlert = wait.until(ExpectedConditions.alertIsPresent());
+        promptAlert.sendKeys(name);
+        promptAlert.accept();
         return getUser(name);
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/ProjectMatrixProperty.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/ProjectMatrixProperty.java
@@ -3,6 +3,11 @@ package org.jenkinsci.test.acceptance.plugins.matrix_auth;
 import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.PageAreaImpl;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -10,7 +15,7 @@ import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 public class ProjectMatrixProperty extends PageAreaImpl {
     public final Control enable = control("useProjectSecurity");
 
-    public final Control name = control(/* 2.x */"useProjectSecurity/[1]", /* 1.x */"useProjectSecurity/");
+    public final Control name = control(/* 2.x */"useProjectSecurity/[1]/data", /* 1.x */"useProjectSecurity/data");
 
     public ProjectMatrixProperty(Job job) {
         super(job, "/properties/hudson-security-AuthorizationMatrixProperty");
@@ -20,8 +25,11 @@ public class ProjectMatrixProperty extends PageAreaImpl {
      * Adds a new user/group to this matrix.
      */
     public MatrixRow addUser(String name) {
-        this.name.set(name);
-        this.name.resolve().findElement(by.parent()).findElement(by.button("Add")).click();
+        this.name.resolve().findElement(by.parent()).findElement(by.button("Add user or group…")).click();
+        WebDriverWait wait = new WebDriverWait(driver, 10);
+        Alert promptAlert = wait.until(ExpectedConditions.alertIsPresent());
+        promptAlert.sendKeys(name);
+        promptAlert.accept();
         return getUser(name);
     }
 


### PR DESCRIPTION
UI for adding user in matrix authentication plugin has changed. This fix should work for Jenkins version 2.60+ and plugin version 2.3+. I do not think that we need backward compatibility for previous versions of plugins or Jenkins (I do not like to have a lot of if/else for due to jenkins/plugin version), anyone with different opinion?