### PR TITLE
[JENKINS-52779] Fix Login#doLogin with the new Login page

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.test.acceptance.po;
 
 import org.junit.Assert;
+import org.openqa.selenium.By;
 
 import static org.jenkinsci.test.acceptance.Matchers.hasInvalidLoginInformation;
 import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;
@@ -12,9 +13,9 @@ import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;
  */
 public class Login extends PageObject {
 
-    private Control cUser = control("/j_username");
-    private Control cPassword = control("/j_password");
-    private Control cLogin = control("/Submit");
+    private Control cUser = control(By.name("j_username"));
+    private Control cPassword = control(By.name("j_password"));
+    private Control cLogin = control(By.name("Submit"));
 
     public Login(Jenkins jenkins) {
         super(jenkins.injector, jenkins.url("login"));
@@ -40,7 +41,7 @@ public class Login extends PageObject {
     public Login doLoginDespiteNoPaths(String user, String password){
         driver.findElement(by.name("j_username")).sendKeys(user);
         driver.findElement(by.name("j_password")).sendKeys(password);
-        clickButton("log in");
+        driver.findElement(by.name("Submit")).click();
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.test.acceptance.po;
 
 import org.junit.Assert;
-import org.openqa.selenium.By;
 
 import static org.jenkinsci.test.acceptance.Matchers.hasInvalidLoginInformation;
 import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;
@@ -13,9 +12,9 @@ import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;
  */
 public class Login extends PageObject {
 
-    private Control cUser = control(By.name("j_username"));
-    private Control cPassword = control(By.name("j_password"));
-    private Control cLogin = control(By.name("Submit"));
+    private Control cUser = control(by.name("j_username"));
+    private Control cPassword = control(by.name("j_password"));
+    private Control cLogin = control(by.name("Submit"));
 
     public Login(Jenkins jenkins) {
         super(jenkins.injector, jenkins.url("login"));


### PR DESCRIPTION
[Issue detail](https://issues.jenkins-ci.org/browse/JENKINS-52779)

Login was relying on https://plugins.jenkins.io/form-element-path and path selectors.
This is not working anymore with the new Login page introduced by https://github.com/jenkinsci/jenkins/commit/90670e05c17b34270cda9436eaf877cc72a341ec.

As the form elements attributes has not been changed by the new Login page, use By.name selectors so it's working with both new and old Login pages.

@reviewbybees 