### PR TITLE
[JENKINS-52962] Make ath compatible with the new Login page

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/Matchers.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/Matchers.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import hudson.util.VersionNumber;
 
 /**
  * Hamcrest matchers.
@@ -238,8 +239,11 @@ public class Matchers {
         return new Matcher<Login>("has invalid login information message") {
             @Override
             public boolean matchesSafely(final Login login) {
+                String invalidLoginMessage = login.getJenkins().getVersion().isOlderThan(new VersionNumber("2.128"))
+                                             ? "Invalid login information. Please try again."
+                                             : "Invalid username or password";
                 try {
-                    login.find(by.xpath("//div[contains(text(), 'Invalid login information. Please try again.')]"));
+                    login.find(by.xpath("//div[contains(text(), '%s')]", invalidLoginMessage));
                     return true;
                 } catch (NoSuchElementException e) {
                     return false;

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsDatabaseSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsDatabaseSecurityRealm.java
@@ -24,6 +24,7 @@
 package org.jenkinsci.test.acceptance.po;
 
 import org.openqa.selenium.NoSuchElementException;
+import hudson.util.VersionNumber;
 
 @Describable({"Jenkins’ own user database", "Jenkins’s own user database"})
 public class JenkinsDatabaseSecurityRealm extends SecurityRealm {
@@ -58,7 +59,9 @@ public class JenkinsDatabaseSecurityRealm extends SecurityRealm {
 
         public Signup password(String pwd) {
             control(by.input("password1")).set(pwd);
-            control(by.input("password2")).set(pwd);
+            if (getContext().getJenkins().getVersion().isOlderThan(new VersionNumber("2.128"))) {
+                control(by.input("password2")).set(pwd);
+            }
             return this;
         }
 
@@ -78,7 +81,7 @@ public class JenkinsDatabaseSecurityRealm extends SecurityRealm {
 
         public User signup(String name) {
             control(by.input("username")).set(name);
-            clickButton("Sign up");
+            control(by.name("Submit")).click();
 
             return new User(getJenkins(), name);
         }


### PR DESCRIPTION
[JENKINS-52962](https://issues.jenkins-ci.org/browse/JENKINS-52962)

Fix for:
- password in the signup page now has only one field (no confirmation anymore)
- "Sign up" has been changed to "Create account" so use the name html field instead of text
- Text for incorrect login information has been changed from "Invalid login information. Please try again." to "Invalid username or password"

@reviewbybees 