### PR TITLE
Skip tests which require adding a user with matrix-auth plugin if version < 2.3

### DIFF
--- a/src/test/java/plugins/JobDslPluginTest.java
+++ b/src/test/java/plugins/JobDslPluginTest.java
@@ -81,7 +81,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * Verifies that all configurations, done on the job configuration page,
      * are saved correctly.
      */
-    @Test @WithPlugins({"matrix-auth","mock-security-realm"})
+    @Test @WithPlugins({"matrix-auth@2.3","mock-security-realm"})
     public void should_save_configurations() {
         FreeStyleJob seedJob = createSeedJob();
         JobDslBuildStep jobDsl = seedJob.addBuildStep(JobDslBuildStep.class);
@@ -559,7 +559,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * wont be executed, because they are not approved.
      * If script security for Job DSL scripts is disabled, the script can be executed.
      */
-    @Test @WithPlugins({"matrix-auth","mock-security-realm"})
+    @Test @WithPlugins({"matrix-auth@2.3","mock-security-realm"})
     public void should_use_script_security() {
         GlobalSecurityConfig sc = setUpSecurity();
 
@@ -595,7 +595,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * security is enabled, it is not possible to import Groovy classes from the
      * workspace.
      */
-    @Test @WithPlugins({"matrix-auth","mock-security-realm"})
+    @Test @WithPlugins({"matrix-auth@2.3","mock-security-realm"})
     public void should_disallow_importing_groovy_classes_when_script_security_enabled() {
         GlobalSecurityConfig sc = setUpSecurity();
 
@@ -626,7 +626,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * Administrators can approve scripts in the 'Script Approval' of the
      * 'Manage Jenkins' area. Approved scripts can be executed.
      */
-    @Test @WithPlugins({"matrix-auth","mock-security-realm"})
+    @Test @WithPlugins({"matrix-auth@2.3","mock-security-realm"})
     public void should_use_script_approval() {
         setUpSecurity();
 
@@ -667,7 +667,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * will be automatically approved. Afterwards the script
      * can be executed.
      */
-    @Test @WithPlugins({"matrix-auth","mock-security-realm"})
+    @Test @WithPlugins({"matrix-auth@2.3","mock-security-realm"})
     public void should_approve_administrator_script_automatically() {
         setUpSecurity();
 
@@ -703,7 +703,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * scripts saved by non administrators can run in a Groovy sandbox
      * without approval. All Job DSL methods are whitelisted by default.
      */
-    @Test @WithPlugins({"matrix-auth","mock-security-realm","authorize-project"})
+    @Test @WithPlugins({"matrix-auth@2.3","mock-security-realm","authorize-project"})
     public void should_use_grooy_sandbox_whitelisted_content() {
         GlobalSecurityConfig sc = setUpSecurity();
         runBuildAsUserWhoTriggered(sc);
@@ -733,7 +733,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * Administrators can approve this content in the 'Script Approval' of the
      * 'Manage Jenkins' area. Approved scripts can be executed.
      */
-    @Test @WithPlugins({"matrix-auth","mock-security-realm","authorize-project"})
+    @Test @WithPlugins({"matrix-auth@2.3","mock-security-realm","authorize-project"})
     public void should_use_grooy_sandbox_no_whitelisted_content() {
         GlobalSecurityConfig sc = setUpSecurity();
         runBuildAsUserWhoTriggered(sc);
@@ -772,7 +772,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * Verifies that Groovy sandbox can only used if 'Access Control for Builds'
      * is configured. The DSL job needs to run as a particular user.
      */
-    @Test @WithPlugins({"matrix-auth","mock-security-realm","authorize-project"})
+    @Test @WithPlugins({"matrix-auth@2.3","mock-security-realm","authorize-project"})
     public void should_run_grooy_sandbox_as_particular_user() {
         GlobalSecurityConfig sc = setUpSecurity();
 

--- a/src/test/java/plugins/MatrixAuthPluginTest.java
+++ b/src/test/java/plugins/MatrixAuthPluginTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertFalse;
 /**
  * @author Kohsuke Kawaguchi
  */
-@WithPlugins({"matrix-auth","mock-security-realm"})
+@WithPlugins({"matrix-auth@2.3","mock-security-realm"})
 public class MatrixAuthPluginTest extends AbstractJUnitTest {
     /**
      * Test scenario:

--- a/src/test/java/plugins/SAMLPluginTest.java
+++ b/src/test/java/plugins/SAMLPluginTest.java
@@ -39,7 +39,7 @@ public class SAMLPluginTest extends AbstractJUnitTest {
     private static final String SERVICE_PROVIDER_ID = "jenkins-dev";
 
     @Test @WithDocker
-    @WithPlugins({"saml", "matrix-auth"})
+    @WithPlugins({"saml", "matrix-auth@2.3"})
     public void authenticationOK() throws IOException, InterruptedException {
         jenkins.open(); // navigate to root
         String rootUrl = jenkins.getCurrentUrl();
@@ -62,7 +62,7 @@ public class SAMLPluginTest extends AbstractJUnitTest {
     }
 
     @Test @WithDocker
-    @WithPlugins({"saml", "matrix-auth"})
+    @WithPlugins({"saml", "matrix-auth@2.3"})
     public void authenticationOKFromURL() throws IOException, InterruptedException {
         jenkins.open(); // navigate to root
         String rootUrl = jenkins.getCurrentUrl();
@@ -85,7 +85,7 @@ public class SAMLPluginTest extends AbstractJUnitTest {
     }
 
     @Test @WithDocker
-    @WithPlugins({"saml", "matrix-auth"})
+    @WithPlugins({"saml", "matrix-auth@2.3"})
     public void authenticationOKPostBinding() throws IOException, InterruptedException {
         jenkins.open(); // navigate to root
         String rootUrl = jenkins.getCurrentUrl();
@@ -109,7 +109,7 @@ public class SAMLPluginTest extends AbstractJUnitTest {
     }
 
     @Test @WithDocker
-    @WithPlugins({"saml", "matrix-auth"})
+    @WithPlugins({"saml", "matrix-auth@2.3"})
     public void authenticationFail() throws IOException, InterruptedException {
         jenkins.open(); // navigate to root
         String rootUrl = jenkins.getCurrentUrl();

--- a/src/test/java/plugins/ScriptSecurityPluginTest.java
+++ b/src/test/java/plugins/ScriptSecurityPluginTest.java
@@ -35,7 +35,7 @@ import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
 import org.junit.Before;
 import org.junit.Test;
 
-@WithPlugins({"script-security", "mock-security-realm", "matrix-auth", "groovy-postbuild"})
+@WithPlugins({"script-security", "mock-security-realm", "matrix-auth@2.3", "groovy-postbuild"})
 public class ScriptSecurityPluginTest extends AbstractJUnitTest {
     /** Admin user. */
     private static final String ADMIN = "admin";

--- a/src/test/java/plugins/WarningsPluginTest.java
+++ b/src/test/java/plugins/WarningsPluginTest.java
@@ -313,7 +313,7 @@ public class WarningsPluginTest extends AbstractAnalysisTest<WarningsAction> {
      *
      * @throws UnsupportedEncodingException if the created URL is invalid
      */
-    @Test @WithPlugins({"mock-security-realm", "matrix-auth"})
+    @Test @WithPlugins({"mock-security-realm", "matrix-auth@2.3"})
     public void should_validate_parser_script() throws UnsupportedEncodingException {
         loginAsAdmin();
 
@@ -333,7 +333,7 @@ public class WarningsPluginTest extends AbstractAnalysisTest<WarningsAction> {
      *
      * @throws MalformedURLException if the URL is invalid
      */
-    @Test @WithPlugins({"mock-security-realm", "matrix-auth"})
+    @Test @WithPlugins({"mock-security-realm", "matrix-auth@2.3"})
     public void should_require_script_permission() throws MalformedURLException {
         loginAsUser();
 


### PR DESCRIPTION
As https://github.com/jenkinsci/acceptance-test-harness/pull/446 is introducing a non backward compatible change with matrix-auth plugin < 2.3, skipping the tests accordingly so if we run them with an older version, they won't fail.

@reviewbybees 