### PR TITLE
Task scanner

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/warnings/ParsersConfiguration.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/warnings/ParsersConfiguration.java
@@ -36,6 +36,7 @@ public class ParsersConfiguration extends PageAreaImpl {
     }
 
     public void add(final String name, final String script) {
+        control("/advanced-button").resolve().click();
         String path = createPageArea(PARSERS, () -> parsers.click());
         GroovyParser parser = new GroovyParser(getPage(), path);
         parser.setScript(name, script);

--- a/src/test/java/plugins/TaskScannerPluginTest.java
+++ b/src/test/java/plugins/TaskScannerPluginTest.java
@@ -738,11 +738,11 @@ public class TaskScannerPluginTest extends AbstractAnalysisTest<TaskScannerActio
                 "  for f in `ls`\n" +
                 "  do\n" +
                 "    if [ -f $f -a -r $f ]; then\n" +
-                "      if file --mime-type $f | grep -q \"^${f}: text/\"; then\n" +
+                "      if [ $f = ${f%.java*}.java ]; then\n" +
                 "        sed \"s/$OLD/$NEW/\" \"$f\" > \"${f}.new\"\n" +
                 "        mv \"${f}.new\" \"$f\"\n" +
                 "      else\n" +
-                "        echo \"Info: $f is not a text file. Skipped.\"\n" +
+                "        echo \"Info: $f is not a *.java file. Skipped.\"\n" +
                 "      fi" +
                 "    else\n" +
                 "      echo \"Error: Cannot read $f\"\n" +


### PR DESCRIPTION
If ATH is running inside container, there is no command file installed. It is used for finding *.java files and edit them. There is no need to install another package for it,  *.java files can be recognized even without it. 