### PR TITLE
File command is missing, use another way how to select wanted files.

### DIFF
--- a/src/test/java/plugins/TaskScannerPluginTest.java
+++ b/src/test/java/plugins/TaskScannerPluginTest.java
@@ -735,15 +735,11 @@ public class TaskScannerPluginTest extends AbstractAnalysisTest<TaskScannerActio
                 "for t in \"todo\" \"TODO\" \"XXX\" \"fixme\" \"FIXME\" \"Deprecated\"\n" +
                 "do\n" +
                 "  OLD=$t\n" +
-                "  for f in `ls`\n" +
+                "  for f in `ls *.java`\n" +
                 "  do\n" +
                 "    if [ -f $f -a -r $f ]; then\n" +
-                "      if [ $f = ${f%.java*}.java ]; then\n" +
                 "        sed \"s/$OLD/$NEW/\" \"$f\" > \"${f}.new\"\n" +
                 "        mv \"${f}.new\" \"$f\"\n" +
-                "      else\n" +
-                "        echo \"Info: $f is not a *.java file. Skipped.\"\n" +
-                "      fi" +
                 "    else\n" +
                 "      echo \"Error: Cannot read $f\"\n" +
                 "    fi\n" +

--- a/src/test/java/plugins/TaskScannerPluginTest.java
+++ b/src/test/java/plugins/TaskScannerPluginTest.java
@@ -738,11 +738,11 @@ public class TaskScannerPluginTest extends AbstractAnalysisTest<TaskScannerActio
                 "  for f in `ls`\n" +
                 "  do\n" +
                 "    if [ -f $f -a -r $f ]; then\n" +
-                "      if file --mime-type $f | grep -q \"^${f}: text/\"; then\n" +
+                "      if [ $f = ${f%.java*}.java ]; then\n" +
                 "        sed \"s/$OLD/$NEW/\" \"$f\" > \"${f}.new\"\n" +
                 "        mv \"${f}.new\" \"$f\"\n" +
                 "      else\n" +
-                "        echo \"Info: $f is not a text file. Skipped.\"\n" +
+                "        echo \"Info: $f is not a *.java file. Skipped.\"\n" +
                 "      fi" +
                 "    else\n" +
                 "      echo \"Error: Cannot read $f\"\n" +


### PR DESCRIPTION
If ATH is running inside container, there is no command file installed. It is used for finding *.java files and edit them. There is no need to install another package for it, *.java files can be recognized even without it. 