### PR TITLE
Define id for clear identification in form.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_slaves/SshSlaveLauncher.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_slaves/SshSlaveLauncher.java
@@ -69,6 +69,28 @@ public class SshSlaveLauncher extends ComputerLauncher {
         final UserPwdCredential cred = dia.select(UserPwdCredential.class);
         cred.username.set(username);
         cred.password.set(password);
+        //credentials are identified by their id. Set username as id so it can be found by it
+        cred.setId(username);
+        cred.add();
+        waitForCredentialVisible(username);
+        return this;
+    }
+
+    /**
+     * Add username/password and id based credentials to the configuration
+     *
+     * @param username to use
+     * @param password for the username
+     * @id for unique identification
+     * @return the SshSlaveLauncher to be configured
+     */
+    public SshSlaveLauncher pwdCredentials(String username, String password, String id) {
+        final SshCredentialDialog dia = this.addCredential();
+        final UserPwdCredential cred = dia.select(UserPwdCredential.class);
+        cred.username.set(username);
+        cred.password.set(password);
+        //credentials are identified by their id.
+        cred.setId(id);
         cred.add();
         waitForCredentialVisible(username);
         return this;

--- a/src/test/java/plugins/SubversionPluginTest.java
+++ b/src/test/java/plugins/SubversionPluginTest.java
@@ -74,7 +74,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
     }
 
     @Test
-    @WithCredentials(credentialType = WithCredentials.USERNAME_PASSWORD, values = {SvnContainer.USER, SvnContainer.PWD})
+    @WithCredentials(credentialType = WithCredentials.USERNAME_PASSWORD, values = {SvnContainer.USER, SvnContainer.PWD}, id = SvnContainer.USER)
     public void run_basic_subversion_build_userPwd() throws SubversionPluginTestException {
         final SvnContainer svnContainer = svn.get();
 
@@ -91,7 +91,7 @@ public class SubversionPluginTest extends AbstractJUnitTest {
     }
 
     @Test
-    @WithCredentials(credentialType = WithCredentials.USERNAME_PASSWORD, values = {SvnContainer.USER, SvnContainer.PWD})
+    @WithCredentials(credentialType = WithCredentials.USERNAME_PASSWORD, values = {SvnContainer.USER, SvnContainer.PWD}, id = SvnContainer.USER)
     public void run_basic_subversion_build_svn_userPwd() throws SubversionPluginTestException {
         final SvnContainer svnContainer = svn.get();
 


### PR DESCRIPTION
After merge of pull request #395 some tests which use select are broken (now the select does not search for option which contains given string, it has to match exactly). The problem is mostly in credentials select since there is used id (generated hash) or combination user name with /***** (and tests use for identification only username). I think that it is better to start use id of credentials since it is the only one unique identification for id. The most easy way how to do it is to use already implemented functionality and define which id should be used for credentials. 
Some of tests which use credentials are not broken, because they use their own implementation for identifying credentials. I let those test like they are and modify only the broken ones. I will modify them the same way after suggested change is approved.