### PR TITLE
ath-container, remove pinned version for firefox-esr

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get clean && \
         git \
         imagemagick \
         iptables \
-        firefox-esr=52.9.0esr-1~deb9u1 \
+        firefox-esr \
         maven \
         openjdk-8-jdk \
         unzip \


### PR DESCRIPTION
I don't know why firefox-esr was pinned down to that specific version
but what I know is that the docker image doesn't build [anymore](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/view/change-requests/job/PR-458/2/console) .
A small comment would been usefull. 
@raul-arabaolaza apparently you recently made that change 
`2018-10-28 19:16:55 +0100 16)         firefox-esr=52.9.0esr-1~deb9u1 \`