### PR TITLE
Display maven and JDK versions from `run.sh`

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -94,4 +94,4 @@ shift 2
 
 set -x
 
-BROWSER=$browser JENKINS_WAR=$war mvn test "$@"
+BROWSER=$browser JENKINS_WAR=$war mvn --show-version test "$@"


### PR DESCRIPTION
Can we useful as we're adding JDK 11 support and people use this for various JDK versions and be able to check they're actually running what they think.

cc @jenkinsci/java11-support @olivergondza 