### PR TITLE
[JENKINS-54975] Add how to run on java11

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The harness provides a variety of ways to configure the execution including:
 * [Selecting how to launch Jenkins](docs/CONTROLLER.md)
 * [Obtaining a report of plugins that were exercised](docs/EXERCISEDPLUGINSREPORTER.md)
 * [Running tests in container](docs/DOCKER.md)
+* [Running tests on Java 11 (WIP)](docs/JAVA11.md)
 * Selecting tests based on plugins they cover (TODO)
 
 ### Writing tests

--- a/docs/JAVA11.md
+++ b/docs/JAVA11.md
@@ -1,0 +1,21 @@
+# Running tests on JAVA11
+
+To run the tests using a Java 11 virtual machine:
+
+1. On the host, launch the container with Java11 VM:
+
+   ```bash
+   harry@devbox:~/acceptance-test-harness$ env java_version=11 ./ath-container.sh
+   ```
+
+1. In the container shell, set up the vnc and run the tests with Java11 support:
+
+   ```bash
+   ath-user@1803848e337f:~/ath-sources$ eval $(./vnc.sh)
+   ```
+
+   ```bash
+   ath-user@1803848e337f:~/ath-sources$ env JENKINS_OPTS="--enable-future-java" ./run.sh ...
+   ```
+
+**NOTE**: Please take into account that it's an ongoing work, so it could be changed before long.


### PR DESCRIPTION
See [[JENKINS-54975] Add how to run on java11](https://issues.jenkins-ci.org/browse/JENKINS-54975)

Add some documentation about how to run on a Java 11 VM. Added a note making it clear that it's a work in progress.

@jenkinsci/java11-support @olivergondza @reviewbybees 