### PR TITLE
[INFRA-1690] One image, change jdk at start

### DIFF
--- a/ath-container.sh
+++ b/ath-container.sh
@@ -8,8 +8,8 @@ gid=$(id -g)
 tag="jenkins/ath"
 java_version="${java_version:-8}"
 
-docker build --build-arg=uid="$uid" --build-arg=gid="$gid" --build-arg=java_version="$java_version" src/main/resources/ath-container -t "$tag"
+docker build --build-arg=uid="$uid" --build-arg=gid="$gid" src/main/resources/ath-container -t "$tag"
 
 run_opts="--interactive --tty --rm --publish-all --user ath-user --workdir /home/ath-user/ath-sources"
 run_drive_mapping="-v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/home/ath-user/ath-sources -v ${HOME}/.m2/repository:/home/ath-user/.m2/repository"
-docker run --shm-size 2g $run_opts $run_drive_mapping $tag /bin/bash
+docker run --shm-size 2g $run_opts $run_drive_mapping $tag /bin/bash -c "./set-java.sh $java_version; bash"

--- a/set-java.sh
+++ b/set-java.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# The selection used by update-alternatives for each java version
+if [ "$1" == "11" ]; then
+    # Java 11
+    selection="1"
+    runcommand="env JENKINS_OPTS=\"--enable-future-java\" ./run.sh firefox latest -DforkCount=1 -Dmaven.test.failure.ignore=true -B -Dtest=..."
+else
+    # Java 8 is set as second option, default
+    selection="2"
+    runcommand="./run.sh firefox latest -DforkCount=1 -Dmaven.test.failure.ignore=true -B -Dtest=..."
+fi
+
+# Change all java programs, not only java and javac
+# List of programs you can find at the etc/alternatives directory (due to java8 and java11)
+programs="appletviewer
+appletviewer.1.gz
+extcheck
+extcheck.1.gz
+idlj
+idlj.1.gz
+jaotc
+jar
+jar.1.gz
+jarsigner
+jarsigner.1.gz
+java
+java.1.gz
+javac
+javac.1.gz
+javadoc
+javadoc.1.gz
+javah
+javah.1.gz
+javap
+javap.1.gz
+jcmd
+jcmd.1.gz
+jconsole
+jconsole.1.gz
+jdb
+jdb.1.gz
+jdeprscan
+jdeps
+jdeps.1.gz
+jexec
+jexec-binfmt
+jhat
+jhat.1.gz
+jhsdb
+jimage
+jinfo
+jinfo.1.gz
+jjs
+jjs.1.gz
+jlink
+jmap
+jmap.1.gz
+jmod
+jps
+jps.1.gz
+jrunscript
+jrunscript.1.gz
+jsadebugd
+jsadebugd.1.gz
+jshell
+jstack
+jstack.1.gz
+jstat
+jstat.1.gz
+jstatd
+jstatd.1.gz
+keytool
+keytool.1.gz
+native2ascii
+native2ascii.1.gz
+orbd
+orbd.1.gz
+pack200
+pack200.1.gz
+policytool
+policytool.1.gz
+rmic
+rmic.1.gz
+rmid
+rmid.1.gz
+rmiregistry
+rmiregistry.1.gz
+schemagen
+schemagen.1.gz
+serialver
+serialver.1.gz
+servertool
+servertool.1.gz
+tnameserv
+tnameserv.1.gz
+unpack200
+unpack200.1.gz
+wsgen
+wsgen.1.gz
+wsimport
+wsimport.1.gz
+xjc
+xjc.1.gz"
+
+# Set to the right java version (if the program doesn't exist in this java version, it's not changed)
+for program in $programs
+do
+    # Change the links without showing the choices nor the programs not found
+    echo $selection | update-alternatives --config $program > /dev/null 2> /dev/null
+done
+
+echo
+echo Running on...
+java -version
+echo
+javac -version
+echo
+echo Start running tests with...
+echo 'eval $(./vnc.sh)'
+echo
+echo $runcommand
+echo

--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get clean && \
         firefox-esr \
         maven \
         unzip \
-        vnc4server
+        vnc4server \
+        openjdk-8-jdk \
+        openjdk-11-jdk
 
 # All we need is a statically linked client library - no need to install daemon deps: https://get.docker.com/builds/
 RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz && \
@@ -40,7 +42,9 @@ EXPOSE 5942
 RUN mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix/
 
 RUN groupadd ath-user -g $gid && \
-    useradd ath-user -u $uid -g $gid -m -d /home/ath-user
+    useradd ath-user -u $uid -g $gid -m -d /home/ath-user && \
+    # Give permission to modify the alternatives links to change the java version in use
+    chown ath-user:ath-user /etc/alternatives
 
 # TODO seems this can be picked up from the host, which is unwanted:
 ENV XAUTHORITY /home/ath-user/.Xauthority
@@ -51,6 +55,7 @@ RUN mkdir /home/ath-user/.vnc && (echo ath-user; echo ath-user; echo "n") | vncp
 # Default content includes x-window-manager, which is not installed, plus other stuff we do not need (vncconfig, x-terminal-emulator, etc.):
 RUN touch /home/ath-user/.vnc/xstartup && chmod a+x /home/ath-user/.vnc/xstartup
 RUN echo "exec /etc/X11/Xsession" > /home/ath-user/.Xsession && chmod +x /home/ath-user/.Xsession
+
 # Prevent xauth to complain in a confusing way
 RUN touch /home/ath-user/.Xauthority
 
@@ -60,10 +65,5 @@ RUN touch /home/ath-user/.Xauthority
 USER root
 RUN chmod ug+s "$(which docker)"
 
-# The variable seems to prevent docker to cache the install command so moving it towards the end
-ARG java_version
-RUN apt-get install -y openjdk-$java_version-jdk
-# Installing some apps like maven can cause latest java to be installed at the same time preventing us to control what is
-# used in the end. Since preventing the install is cumbersome, let's enforce the desired version through alternatives.
-RUN update-java-alternatives -s java-1.$java_version.0-openjdk-amd64
-RUN java -version
+# Java 8 by default
+RUN update-java-alternatives -s java-1.8.0-openjdk-amd64


### PR DESCRIPTION
See [[INFRA-1690] DevTools: Add support of Specifying Java Level for Test in runATH()](https://issues.jenkins-ci.org/browse/INFRA-1690)

**TL;DR**
This approach build the image with both jdks and change the java in use when starting the container.


Currently the docker image generated is failing because the Dockerfile needs the `java_version` argument to build the image correctly. In addition, we need a way to run the `runATH` step in the _pipeline-library_ using both JDKs without building the ATH on the fly.

To do that we run a script during the _run_ of the container setting all _java programs_ to the right version. In addition, print a message in the container console to help starting with the tests using the right commands depending on the JDK in use. Example with Java11:
```
Running on...
openjdk version "11.0.1" 2018-10-16
OpenJDK Runtime Environment (build 11.0.1+13-Debian-2)
OpenJDK 64-Bit Server VM (build 11.0.1+13-Debian-2, mixed mode, sharing)

javac 11.0.1

Start running tests with...
eval $(./vnc.sh)

env JENKINS_OPTS="--enable-future-java" ./run.sh firefox latest -DforkCount=1 -Dmaven.test.failure.ignore=true -B -Dtest=...
```

The instructions don't change. As usual:
* Build an get into the container:
   * Java 8: `./ath-container.sh`
   * Java 11: `java_version=11 ./ath-container.sh`

* Set vncserver:
   * `eval $(./vnc.sh)`

* Run tests:
   * Java 8: `./run.sh ...`
   * Java 11: `JENKINS_OPTS="--enable-future-java" ./run.sh ...`