### PR TITLE
Ignore the failing test to get time to dive into it

### DIFF
--- a/src/test/java/core/FreestyleJobTest.java
+++ b/src/test/java/core/FreestyleJobTest.java
@@ -16,6 +16,7 @@ import org.jenkinsci.test.acceptance.po.StringParameter;
 import org.jenkinsci.test.acceptance.po.TimerTrigger;
 import org.jenkinsci.test.acceptance.po.UpstreamJobTrigger;
 import org.jenkinsci.test.acceptance.utils.IOUtil;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Issue;
@@ -197,6 +198,7 @@ public class FreestyleJobTest extends AbstractJUnitTest {
 
     @Test
     @Category(SmokeTest.class)
+    @Ignore("Failing when using ATH >1.63 with Caused by: org.openqa.selenium.NoSuchSessionException: Tried to run command without establishing a connection")
     public void doNotDiscardSuccessfulBuilds() {
         FreeStyleJob j = jenkins.jobs.create(FreeStyleJob.class);
 


### PR DESCRIPTION
Just in case the PRs on jenkinsci/jenkins are still failing after merging the pin to the latest ATH image and code (https://github.com/jenkinsci/jenkins/pull/3816), we can ignore the remaining failing test to avoid them to continue failing and get extra time to dive into the failure.

After merging it (if needed) we also have to change the **essentials.yml** again to refer to this commit (that actually ignores the test):
_athRevision: "b1c12c1bd9e4c1fa35d7da870ed4c4cfa529dd84"_

What a fun.

@olivergondza @jenkinsci/java11-support @raul-arabaolaza 