### PR TITLE
Added support to copy files on Windows.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -223,7 +223,12 @@ public class Job extends TopLevelItem {
      * base64 and put it as a heredoc in the shell script.
      */
     public void copyResource(Resource resource, String fileName) {
-        addShellStep(copyResourceShell(resource, fileName));
+        if (SystemUtils.IS_OS_WINDOWS) {
+            addBatchStep(copyResourceBatch(resource, fileName));
+        }
+        else {
+            addShellStep(copyResourceShell(resource, fileName));
+        }
     }
 
     protected String copyResourceShell(Resource resource, String fileName) {
@@ -240,6 +245,15 @@ public class Job extends TopLevelItem {
         } catch (IOException e) {
             throw new AssertionError(e);
         }
+    }
+
+    protected String copyResourceBatch(Resource resource, String fileName) {
+        String path = resource.url.getPath();
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        path = path.replace("/", "\\");
+        return "xcopy \"" + path + "\" . /E /Y";
     }
 
     public void copyResource(Resource resource) {


### PR DESCRIPTION
In order to let the warnings tests run on Windows copying of resources need to be platform aware.