### PR TITLE
Speedup shell commands by trying CodeMirror as first alternative.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ShellBuildStep.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ShellBuildStep.java
@@ -7,18 +7,16 @@ import org.openqa.selenium.NoSuchElementException;
  */
 @Describable("Execute shell")
 public class ShellBuildStep extends AbstractStep implements BuildStep {
-
     public ShellBuildStep(Job parent, String path) {
         super(parent, path);
     }
 
     public void command(String command) {
         try {
-
-            control("command").set(command);
-        } catch (NoSuchElementException e) {
-
             new CodeMirror(this, "command").set(command);
+        }
+        catch (NoSuchElementException e) {
+            control("command").set(command);
         }
     }
 }


### PR DESCRIPTION
Currently a shell build step tries to set the "command" control as first alternative. If it is not available then the CodeMirror is used instead. 

However, on my machine with my Jenkins setup the CodeMirror is the preferred way to access the command. Otherwise the tests just wait for the command timeout and then use the CodeMirror. So I flipped the alternatives: First the code mirror is used, and then if not available the command control. 

This speeds up my tests by a couple of seconds for each shell command (there are quite a lot).

