### PR TITLE
Fix broken split generation after Warnings plugin removal

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,14 +19,20 @@ for (int j in [8, 11]) {
                     image.inside('-v /var/run/docker.sock:/var/run/docker.sock --shm-size 2g') {
                         def exclusions = splits.get(index).join("\n")
                         writeFile file: 'excludes.txt', text: exclusions
-                        realtimeJUnit(testResults: 'target/surefire-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]) {
+                        realtimeJUnit(
+                                testResults: 'target/surefire-reports/TEST-*.xml',
+                                testDataPublishers: [[$class: 'AttachmentPublisher']],
+                                // Slow test(s) removal can causes a split to get empty which otherwise fails the build.
+                                // The build failure prevents parallel tests executor to realize the tests are gone so same
+                                // split is run to execute and report zero tests - which fails the build. Permit the test
+                                // results to be empty to break the circle: build after removal executes one empty split
+                                // but not letting the build to fail will cause next build not to try those tests again.
+                                allowEmptyResults: true
+                        ) {
                             sh """
                                 set-java.sh $javaVersion
                                 eval \$(vnc.sh)
                                 java -version
-
-                                echo "Excludes:"
-                                cat excludes.txt
 
                                 run.sh firefox latest -Dmaven.test.failure.ignore=true -DforkCount=1 -B
                             """


### PR DESCRIPTION
The plugin tests was all that was in a single split. Its removal caused our build
has entered an infinite failure loop.