### PR TITLE
[JENKINS-56492] Fix JavadocPluginTest failures on Java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,8 +263,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <!-- For JavadocTest where Java version matters -->
-      <version>1.6</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
@@ -369,8 +368,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <!-- Updated to avoid RequireUpperBoundDeps due to version-number:1.6 -->
-      <version>3.0.1</version>
+      <version>2.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,8 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.1</version>
+      <!-- For JavadocTest where Java version matters -->
+      <version>1.6</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
@@ -368,7 +369,8 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>2.0.3</version>
+      <!-- Updated to avoid RequireUpperBoundDeps due to version-number:1.6 -->
+      <version>3.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>

--- a/src/test/java/plugins/JavadocPluginTest.java
+++ b/src/test/java/plugins/JavadocPluginTest.java
@@ -12,6 +12,8 @@ import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.MatrixConfiguration;
 import org.jenkinsci.test.acceptance.po.MatrixProject;
 import org.junit.Test;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.NoSuchFrameException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
@@ -88,21 +90,31 @@ public class JavadocPluginTest extends AbstractJUnitTest {
         job.open();
         find(by.link(JAVADOC_ACTION)).click();
 
-        VersionNumber javadocPluginVersionInstalled = jenkins.getPlugin("javadoc").getVersion();
-        JavaSpecificationVersion javaVersion = JavaSpecificationVersion.forCurrentJVM();
-        VersionNumber javadocPLuginVersionChangingLandingPage = new VersionNumber("1.5");
+        /*
+        Why do we check in such way?
 
-        // The old plugin doesn't redirect, we also need to manage each case depending on the java version used
-        if(javadocPluginVersionInstalled.isOlderThan(javadocPLuginVersionChangingLandingPage)) {
-            if (javaVersion.isOlderThanOrEqualTo(JavaSpecificationVersion.JAVA_8)) {
-                // Former behavior, javadoc generating frames and plugin without redirection
-                driver.switchTo().frame("classFrame");
-            } else {
-                // With Java11 a link to the package-summary is shown, no frames
-                find(by.partialLinkText("package-summary.html")).click();
-            }
-        }
+        The java version of the Jenkins under test could be different that the one in use by this code, the ATH code.
+        See: https://github.com/jenkinsci/acceptance-test-harness/blob/39cbea43b73d32a0912d613a41e08ba9b54aad1d/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java#L190
 
-        assertThat(driver, hasContent("com.mycompany.app"));
+        In addition, the way javadoc is generated depends on the java version and the number of packages generated, one
+        or more packages.
+        See: https://issues.jenkins-ci.org/browse/JENKINS-32619?focusedCommentId=311819&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-311819
+
+        So even though it's not the most refined way to check the right generation of the javadoc, this way doesn't
+        need to call a groovy script for checking the java version neither checking the number of packages generated.
+        */
+
+         try {
+             // Former behavior, javadoc generating frames and plugin without redirection
+             driver.switchTo().frame("classFrame");
+         } catch (NoSuchFrameException e) {
+             try {
+                 // With Java11 a link to the package-summary is shown, no frames
+                 find(by.partialLinkText("package-summary.html")).click();
+             } catch (NoSuchElementException nse) {
+             }
+         }
+
+         assertThat(driver, hasContent("com.mycompany.app"));
     }
 }

--- a/src/test/java/plugins/JavadocPluginTest.java
+++ b/src/test/java/plugins/JavadocPluginTest.java
@@ -1,7 +1,5 @@
 package plugins;
 
-import hudson.util.VersionNumber;
-import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.javadoc.JavadocPublisher;


### PR DESCRIPTION
See [[JENKINS-56492] Fix Javadoc failures on Java11](https://issues.jenkins-ci.org/browse/JENKINS-56492)

Java11 is not using frames anymore, so we need to change how we check whether the javadoc is generated correctly or not.

Tested using **VERSION_OVERRIDES** and **set-java.sh** on ATH with:
**Java 8 / Javadoc 1.3**
Frames
![java8-javadoc1 3](https://user-images.githubusercontent.com/22069922/54068838-227e5680-4251-11e9-89ee-60680cbdefcf.png)

**Java 8 / Javadoc 1.5**
Redirect but still frames
![java8-javadoc1 5](https://user-images.githubusercontent.com/22069922/54068841-29a56480-4251-11e9-96a0-1f3c73906e04.png)

**Java 11 / Javadoc 1.3**
No frames, no redirection :laughing: 
![java11-javadoc1 3](https://user-images.githubusercontent.com/22069922/54068843-33c76300-4251-11e9-9706-ab4c51ae5c91.png)

**Java 11 / Javadoc 1.5**
No frames, redirect
![java11-javadoc1 5](https://user-images.githubusercontent.com/22069922/54068845-39bd4400-4251-11e9-91c7-0711e219a458.png)

Reviews welcome: @olivergondza @raul-arabaolaza @jenkinsci/java11-support 