### PR TITLE
Support installation of multiple tools versions

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ToolInstallation.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ToolInstallation.java
@@ -77,6 +77,12 @@ public abstract class ToolInstallation extends PageAreaImpl {
         final ConfigurablePageObject page = ensureConfigPage(jenkins);
 
         final String name = type.getAnnotation(ToolInstallationPageObject.class).name();
+        final Control expandButton = page.control(by.button(name + " installations..."));
+        try {
+            expandButton.click();
+        } catch (Exception e) {
+            // Ignore, this is likely because this is the first installation of this tool
+        }
         final Control button = page.control(by.button("Add " + name));
 
         String pathPrefix = button.resolve().getAttribute("path").replaceAll("repeatable-add", "tool");

--- a/src/main/java/org/jenkinsci/test/acceptance/po/ToolInstallation.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ToolInstallation.java
@@ -33,6 +33,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.utils.process.CommandBuilder;
+import org.openqa.selenium.NoSuchElementException;
 
 /**
  * @author ogondza
@@ -80,7 +81,7 @@ public abstract class ToolInstallation extends PageAreaImpl {
         final Control expandButton = page.control(by.button(name + " installations..."));
         try {
             expandButton.click();
-        } catch (Exception e) {
+        } catch (NoSuchElementException e) {
             // Ignore, this is likely because this is the first installation of this tool
         }
         final Control button = page.control(by.button("Add " + name));

--- a/src/test/java/plugins/AntPluginTest.java
+++ b/src/test/java/plugins/AntPluginTest.java
@@ -21,6 +21,9 @@ public class AntPluginTest extends AbstractJUnitTest {
     public static final String INSTALL_VERSION_1_8 = "1.8.4";
     public static final String INSTALL_NAME_1_8 = "ant_" + INSTALL_VERSION_1_8;
 
+    public static final String INSTALL_VERSION_1_10 = "1.10.5";
+    public static final String INSTALL_NAME_1_10 = "ant_" + INSTALL_VERSION_1_10;
+
     FreeStyleJob job;
 
     @Before
@@ -39,6 +42,16 @@ public class AntPluginTest extends AbstractJUnitTest {
 
         buildHelloWorld(INSTALL_NAME_1_8).shouldContainsConsoleOutput(
             "Unpacking (http|https)://archive.apache.org/dist/ant/binaries/apache-ant-" + INSTALL_VERSION_1_8 + "-bin.zip"
+        );
+    }
+    
+    @Test
+    public void autoInstallMultipleAnt() {
+        AntInstallation.install(jenkins, INSTALL_NAME_1_8, INSTALL_VERSION_1_8);
+        AntInstallation.install(jenkins, INSTALL_NAME_1_10, INSTALL_VERSION_1_10);
+
+        buildHelloWorld(INSTALL_NAME_1_10).shouldContainsConsoleOutput(
+            "Unpacking (http|https)://archive.apache.org/dist/ant/binaries/apache-ant-" + INSTALL_VERSION_1_10 + "-bin.zip"
         );
     }
 

--- a/src/test/java/plugins/AntPluginTest.java
+++ b/src/test/java/plugins/AntPluginTest.java
@@ -18,11 +18,11 @@ import java.util.regex.Pattern;
 @WithPlugins("ant")
 public class AntPluginTest extends AbstractJUnitTest {
 
-    public static final String INSTALL_VERSION_1_8 = "1.8.4";
-    public static final String INSTALL_NAME_1_8 = "ant_" + INSTALL_VERSION_1_8;
+    private static final String INSTALL_VERSION_1_8 = "1.8.4";
+    private static final String INSTALL_NAME_1_8 = "ant_" + INSTALL_VERSION_1_8;
 
-    public static final String INSTALL_VERSION_1_10 = "1.10.5";
-    public static final String INSTALL_NAME_1_10 = "ant_" + INSTALL_VERSION_1_10;
+    private static final String INSTALL_VERSION_1_10 = "1.10.5";
+    private static final String INSTALL_NAME_1_10 = "ant_" + INSTALL_VERSION_1_10;
 
     FreeStyleJob job;
 


### PR DESCRIPTION
Allow to install more than one tool of the same type, by expanding the collapsed tool area in recent Jenkins versions.

I have successfully tested the fix on our own test suite (SonarQube plugin) but I'm not very pleased by the proposed fix (try..catch) so if you know a better way, feel free to change.

I also tried to update a test to demonstrate what I'm trying to fix, but I didn't run it for real on my box. 