### PR TITLE
[JENKINS-56928] Scroll to select to avoid overlap

### DIFF
--- a/src/test/java/plugins/NodeLabelParameterPluginTest.java
+++ b/src/test/java/plugins/NodeLabelParameterPluginTest.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.test.acceptance.Matcher;
 import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.jenkinsci.test.acceptance.selenium.Scroller;
 import org.jvnet.hudson.test.Issue;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.nodelabelparameter.LabelParameter;
@@ -455,6 +456,10 @@ public class NodeLabelParameterPluginTest extends AbstractJUnitTest {
         assertThat("Amount of possible nodes does not match", p.getPossibleNodesOptions().size(), is(4));
 
         p.allowMultiple.check();
+
+        //JENKINS-56928: Avoid the control to be overlapped by the config tab menu
+        Scroller s = new Scroller();
+        s.beforeClickOn(p.allowedNodes.resolve(), driver);
         p.allowedNodes.select(s1.getName());
         p.allowedNodes.select(s2.getName());
 


### PR DESCRIPTION
**See [[JENKINS-56928] Fix NodeLabelParameterPluginTest # run_on_online_slave_and_master_with_node_restriction. Fail with element not clickable because other obscures it](https://issues.jenkins-ci.org/browse/JENKINS-56928)**

Added a scroll to the select before clicking it to avoid the failure:

`Element <select name="allowedSlaves"> is not clickable at point (728.5,57.69999694824219) because another element <div class="tab config-section-activator config_build_triggers"> obscures it`

@jenkinsci/java11-support @olivergondza @raul-arabaolaza 