### PR TITLE
Update page object for ssh-credentials 1.16

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshPrivateKeyCredential.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshPrivateKeyCredential.java
@@ -30,6 +30,7 @@ public class SshPrivateKeyCredential extends BaseStandardCredentials {
 
     public Direct selectEnterDirectly() {
         WebElement e = choose("Enter directly");
+        find(by.input("./@class='secret-update-btn'")).click();
         return new Direct(getPage(), e.getAttribute("path"));
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshPrivateKeyCredential.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshPrivateKeyCredential.java
@@ -5,6 +5,7 @@ import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 import org.jenkinsci.test.acceptance.po.PageObject;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 /**
@@ -30,7 +31,11 @@ public class SshPrivateKeyCredential extends BaseStandardCredentials {
 
     public Direct selectEnterDirectly() {
         WebElement e = choose("Enter directly");
-        find(by.input("./@class='secret-update-btn'")).click();
+        WebElement button = getElement(By.className("secret-update-btn"));
+        if (button != null) {
+            // for ssh-credentials >= 1.16
+            button.click();
+        }
         return new Direct(getPage(), e.getAttribute("path"));
     }
 


### PR DESCRIPTION
This updates the page object so that it clicks the button hiding the textarea before trying to refer to the otherwise nonexisting input field.

Compare to https://github.com/jenkinsci/jenkins/blob/master/test/src/test/java/lib/form/SecretTextareaTest.java

@reviewbybees @jeffret-b @Wadeck 