### PR TITLE
[JENKINS-52906] Global configuration for Jira is now in a specific class

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/jira/JiraGlobalConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/jira/JiraGlobalConfig.java
@@ -13,7 +13,7 @@ public class JiraGlobalConfig extends PageAreaImpl {
 
     @Inject
     public JiraGlobalConfig(Jenkins jenkins) {
-        super(jenkins, "/hudson-plugins-jira-JiraProjectProperty");
+        super(jenkins, "/hudson-plugins-jira-JiraGlobalConfiguration");
     }
 
     // TODO: make this work properly when the site exists already

--- a/src/test/java/plugins/JiraPluginTest.java
+++ b/src/test/java/plugins/JiraPluginTest.java
@@ -25,7 +25,7 @@ import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.fail;
 
-@WithPlugins({"jira", "git"})
+@WithPlugins({"jira@3.0.7", "git"})
 @Category(DockerTest.class)
 @WithDocker
 @Since( "2.73.3" )


### PR DESCRIPTION
This [jenkinsci/jira-plugin#a06acf](https://github.com/jenkinsci/jira-plugin/commit/a06acf0770aace33de71f06a54d171d50785118d) and the JCasC support done by @casz, the global configuration of Jira in Jenkins is located in its own class.