### PR TITLE
[JENKINS-57804] Fix typo in the name of the checkbox that enables user signup for the HudsonSecurityRealm page object

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsDatabaseSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsDatabaseSecurityRealm.java
@@ -34,7 +34,7 @@ public class JenkinsDatabaseSecurityRealm extends SecurityRealm {
     }
 
     public void allowUsersToSignUp(boolean allow) {
-        control("allowSignup").check(allow);
+        control("allowsSignup").check(allow);
     }
 
     public Signup signup() {


### PR DESCRIPTION
[JENKINS-57804](https://issues.jenkins-ci.org/browse/JENKINS-57804)

The page object that can be used to configure the JenkinsDatabaseSecurityRealm in acceptance tests has a typo in the element name used to enable/disable the ability for users to self-register (ie. signup) when using this realm. The jelly form control is named "allowsSignup" but the pageobject references it using the name "allowSignup". This causes any ATH tests that rely on manipulating that element to fail with an element not found/Timeout exception.

[This was brought to light as the result of a recent change that forces the UI behavior to disable user signup by default (as a security precaution)](https://github.com/jenkinsci/jenkins/pull/3954/files#diff-aec8de1c6c772be0d3ecb3573c46ead8L29), which in turn caused some tests, which expected this to be enabled by default, to break.

This PR addresses that by fixing the name of the control used by the page object.  I've no idea if which spelling was intended to be correct, but this was the on that was inconsistent with the rest.