### PR TITLE
Removed *.log from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 jenkins*.war
 *.swp
 *.swn
-*.log
 *~
 .vagrant
 iso


### PR DESCRIPTION
Removed *.log from gitignore since TextFinder plugin already uses this suffix (and IntelliJ complains about these problems). Maybe other plugins (like the warnings plugin) will use this suffix as well in the future. If we really want to ignore *.log files we should prefix them in the .gitignore with a path.