### PR TITLE
Add a Release Drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+_extends: .github
+tag-template:acceptance-test-harness-$NEXT_MINOR_VERSION


### PR DESCRIPTION
Once merged, I can enable Release Drafter for this repository.
Other tools like PCT already use it, so IMHO it would be nice to enable it, even if we do not categorize pull requests here.