### PR TITLE
[JENKINS-58071] Add support for new github-branch-source single repo selector

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/workflow_multibranch/GithubBranchSource.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/workflow_multibranch/GithubBranchSource.java
@@ -5,6 +5,7 @@ import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 import org.jenkinsci.test.acceptance.po.WorkflowMultiBranchJob;
 import org.jenkinsci.test.acceptance.plugins.workflow_shared_library.WorkflowSharedLibrary;
+import org.jvnet.hudson.test.Issue;
 import org.openqa.selenium.support.ui.Select;
 
 import java.util.concurrent.Callable;
@@ -19,6 +20,7 @@ public class GithubBranchSource extends BranchSource {
     public final Control owner = control("repoOwner");
     public final Control repository = control("repository");
     public final Control credential = control("credentialsId" /* >= 2.2.0 */, "scanCredentialsId");
+    public final Control repositoryUrl = control("repositoryUrl"); /* As of GHBS 2.5.5 */
 
     public GithubBranchSource(WorkflowMultiBranchJob job, String path) {
         super(job, path);
@@ -40,6 +42,12 @@ public class GithubBranchSource extends BranchSource {
 
     public GithubBranchSource credential(final String credName) {
         this.credential.select(credName);
+        return this;
+    }
+
+    @Issue("JENKINS-58717")
+    public GithubBranchSource singleRepositoryUrl(final String repositoryHTTPSUrl) {
+        this.repositoryUrl.set(repositoryHTTPSUrl);
         return this;
     }
 

--- a/src/test/java/plugins/WorkflowMultibranchTest.java
+++ b/src/test/java/plugins/WorkflowMultibranchTest.java
@@ -34,7 +34,7 @@ public class WorkflowMultibranchTest extends AbstractJUnitTest {
         MavenInstallation.installMaven(jenkins, "M3", "3.3.9");
     }
 
-    @Ignore("cannot run quickly as anonymous")
+    // @Ignore("cannot run quickly as anonymous")
     @Test
     public void testMultibranchPipeline() throws IOException, MessagingException {
         final WorkflowMultiBranchJob multibranchJob = jenkins.jobs.create(WorkflowMultiBranchJob.class);

--- a/src/test/java/plugins/WorkflowMultibranchTest.java
+++ b/src/test/java/plugins/WorkflowMultibranchTest.java
@@ -24,7 +24,8 @@ import static org.jenkinsci.test.acceptance.Matchers.hasAction;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests a multibranch pipeline flow
+ * Tests a multibranch pipeline flow.
+ * Once we are testing with GitHub Branch Source 2.5.5 or greater, we should specify github-branch-source@2.5.5
  */
 @WithPlugins({"git", "javadoc@1.4", "workflow-basic-steps", "workflow-durable-task-step", "workflow-multibranch", "github-branch-source"})
 public class WorkflowMultibranchTest extends AbstractJUnitTest {
@@ -34,7 +35,7 @@ public class WorkflowMultibranchTest extends AbstractJUnitTest {
         MavenInstallation.installMaven(jenkins, "M3", "3.3.9");
     }
 
-    // @Ignore("cannot run quickly as anonymous")
+    @Ignore("cannot run quickly as anonymous")
     @Test
     public void testMultibranchPipeline() throws IOException, MessagingException {
         final WorkflowMultiBranchJob multibranchJob = jenkins.jobs.create(WorkflowMultiBranchJob.class);
@@ -59,8 +60,11 @@ public class WorkflowMultibranchTest extends AbstractJUnitTest {
 
     private void configureJobWithGithubBranchSource(final WorkflowMultiBranchJob job) {
         final GithubBranchSource ghBranchSource = job.addBranchSource(GithubBranchSource.class);
+        // TODO: Switch over to the new UI once we un-Ignore this test and run with GHBS 2.5.5 or higher
         ghBranchSource.owner("varyvoltest");
         ghBranchSource.selectRepository("maven-basic");
+        // Equivalent to the above with GHBS >= 2.5.5 will be:
+        // ghBranchSource.singleRepositoryUrl("https://github.com/varyvoltest/maven-basic.git");
     }
 
     private void assertBranchIndexing(final WorkflowMultiBranchJob job) {


### PR DESCRIPTION
# Description
This pull request adds a way for automated tests to use the new single-repository URL when creating Multibranch projects from GitHub repositories.

The new UI looks like this:

![image](https://user-images.githubusercontent.com/21689198/62159646-3568f480-b2e0-11e9-8d66-5e1a7ea7c7a3.png)

These changes allow for someone to directly supply their HTTPS GitHub URL, in much the same way they would when running `git clone https://github.com/jenkinsci/...` from a terminal. This came in the form of [PR 236 to GitHub Branch Source](https://github.com/jenkinsci/github-branch-source-plugin/pull/236), which was merged and released as [GitHub Branch Source 2.5.5](https://github.com/jenkinsci/github-branch-source-plugin/tree/github-branch-source-2.5.5).

I have intentionally not removed the `@Ignore` annotation from the test itself. The ill-performing repository selector which was fixed in GHBS PR 236 is a big improvement, but was not the only reason this test can fail. We still have the problem of anonymous scanning of GitHub, and resultant wait times for branch indexing, which cause this test to time out as written. That hasn't been changed here.

