### PR TITLE
Update the maven version used in the ath docker image

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -24,8 +24,8 @@ RUN curl -fsSLO https://github.com/mozilla/geckodriver/releases/download/v0.22.0
     tar -xvzf geckodriver-v0.22.0-linux64.tar.gz -C /usr/local/bin
 
 # Maven in repo is not new enough for ATH
-RUN curl -ffSLO https://www.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz && \
-    tar -xvzf apache-maven-3.6.0-bin.tar.gz -C /opt/ && \
+RUN curl -ffSLO https://www.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz && \
+    tar -xvzf apache-maven-3.6.1-bin.tar.gz -C /opt/ && \
     mv /opt/apache-maven-* /opt/maven
 ENV PATH="$PATH:/opt/maven/bin"
 


### PR DESCRIPTION
Maven version `3.6.0` is no longer available from https://www.apache.org/dist/maven/maven-3/, this PR updates the `Dockerfile` to use `v3.6.1`