### PR TITLE
Add an alternative `click(Duration timeout)` method for pageobject controls

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -340,6 +340,22 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     }
 
     /**
+     * Returns {@code true} if the webElement is stale (that is accessing it would cause a
+     * @{link StaleElementReferenceException} to be thrown
+     * @param element the element to check.
+     * @return {@code true} iff the element is stale.
+     */
+    protected static boolean isStale(WebElement element) {
+        try {
+            // Calling any method forces a staleness check
+            element.isEnabled();
+            return false;
+        } catch (StaleElementReferenceException expected) {
+            return true;
+        }
+    }
+
+    /**
      * Executes JavaScript.
      */
     @Override

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.test.acceptance.po;
 
+import java.time.Duration;
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
@@ -94,9 +95,38 @@ public class Control extends CapybaraPortingLayerImpl {
         check(resolve(), state);
     }
 
+    /**
+     * sends a click on the underlying element.
+     * You should not use this on any page where the click will cause another page to be loaded as it will not
+     * gaurantee that the new page has been loaded.
+     * @see #clickAndWaitToBecomeStale()
+     * @see #clickAndWaitToBecomeStale(Duration)
+     */
     public void click() {
         resolve().click();
     }
+
+
+    /**
+     * like click but will block for up to 30 seconds until the underlying web element has become stale.
+     * see https://blog.codeship.com/get-selenium-to-wait-for-page-load/
+     */
+    public void clickAndWaitToBecomeStale() {
+        clickAndWaitToBecomeStale(Duration.ofSeconds(30));
+    }
+
+    /**
+     * like click but will block until the underlying web element has become stale.
+     * see https://blog.codeship.com/get-selenium-to-wait-for-page-load/
+     * @param timeout the amount of time to wait
+     */
+    public void clickAndWaitToBecomeStale(Duration timeout) {
+        WebElement webElement = resolve();
+        // webElement.submit() despite advertising it does exactly this just blows up :(
+        webElement.submit();
+        waitFor(webElement).withTimeout(timeout).until(Control::isStale);
+    }
+
 
     /**
      * The existing {@link org.jenkinsci.test.acceptance.po.Control#set(String)}

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
@@ -99,8 +99,7 @@ public class Control extends CapybaraPortingLayerImpl {
      * sends a click on the underlying element.
      * You should not use this on any page where the click will cause another page to be loaded as it will not
      * gaurantee that the new page has been loaded.
-     * @see #clickAndWaitToBecomeStale()
-     * @see #clickAndWaitToBecomeStale(Duration)
+     * @see #click(Duration)
      */
     public void click() {
         resolve().click();
@@ -108,25 +107,15 @@ public class Control extends CapybaraPortingLayerImpl {
 
 
     /**
-     * like click but will block for up to 30 seconds until the underlying web element has become stale.
-     * see https://blog.codeship.com/get-selenium-to-wait-for-page-load/
-     */
-    public void clickAndWaitToBecomeStale() {
-        clickAndWaitToBecomeStale(Duration.ofSeconds(30));
-    }
-
-    /**
      * like click but will block until the underlying web element has become stale.
      * see https://blog.codeship.com/get-selenium-to-wait-for-page-load/
      * @param timeout the amount of time to wait
      */
-    public void clickAndWaitToBecomeStale(Duration timeout) {
+    public void click(Duration timeout) {
         WebElement webElement = resolve();
-        // webElement.submit() despite advertising it does exactly this just blows up :(
-        webElement.submit();
+        webElement.click();
         waitFor(webElement).withTimeout(timeout).until(Control::isStale);
     }
-
 
     /**
      * The existing {@link org.jenkinsci.test.acceptance.po.Control#set(String)}

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -32,7 +32,7 @@ public class Login extends PageObject {
         cUser.set(user);
         cPassword.set(password);
         // for some reason submit it just bogus...
-        cLogin.clickAndWaitToBecomeStale();
+        cLogin.click(Duration.ofSeconds(30));
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -1,6 +1,9 @@
 package org.jenkinsci.test.acceptance.po;
 
+import java.time.Duration;
+
 import org.junit.Assert;
+import org.openqa.selenium.WebElement;
 
 import static org.jenkinsci.test.acceptance.Matchers.hasInvalidLoginInformation;
 import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;
@@ -28,7 +31,8 @@ public class Login extends PageObject {
     public Login doLogin(String user, String password){
         cUser.set(user);
         cPassword.set(password);
-        cLogin.click();
+        // for some reason submit it just bogus...
+        cLogin.clickAndWaitToBecomeStale();
         return this;
     }
 
@@ -40,7 +44,10 @@ public class Login extends PageObject {
     public Login doLoginDespiteNoPaths(String user, String password){
         driver.findElement(by.name("j_username")).sendKeys(user);
         driver.findElement(by.name("j_password")).sendKeys(password);
-        driver.findElement(by.name("Submit")).click();
+        WebElement we = driver.findElement(by.name("Submit"));
+        // for some reason submit() is bogus
+        we.click();
+        cUser.waitFor(we).withTimeout(Duration.ofSeconds(30)).until(CapybaraPortingLayerImpl::isStale);
         return this;
     }
 


### PR DESCRIPTION
Add an alternative `click(Duration timeout)` method for pageobject controls that lets you wait up to a specified amount of time for a new page to load before continuing execution.  See #521 for additional details and discussion