### PR TITLE
Do not use underscore as an identifier.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/Matchers.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/Matchers.java
@@ -68,7 +68,7 @@ public class Matchers {
                 try {
                     item.findElement(selector);
                     return true;
-                } catch (NoSuchElementException _) {
+                } catch (NoSuchElementException ignored) {
                     return false;
                 }
             }
@@ -105,7 +105,7 @@ public class Matchers {
                     po.open();
                     po.find(by.xpath("//div[@id='tasks']/div/a[text()='%s']", displayName));
                     return true;
-                } catch (NoSuchElementException _) {
+                } catch (NoSuchElementException ignored) {
                     return false;
                 }
             }

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/JenkinsLogWatcher.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/JenkinsLogWatcher.java
@@ -110,7 +110,7 @@ public class JenkinsLogWatcher implements LogListenable, Closeable {
         msg += "\nnow = " + new Date();
         try {
             msg += "\n" + FileUtils.readFileToString(logFile);
-        } catch (IOException _) {
+        } catch (IOException ignored) {
             // ignore
         }
         return msg;

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
@@ -355,7 +355,7 @@ public abstract class LocalController extends JenkinsController implements LogLi
         try {
             proc.exitValue();
             return null; // already dead
-        } catch (IllegalThreadStateException _) {
+        } catch (IllegalThreadStateException ignored) {
             // Process alive
         }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -228,7 +228,7 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     private boolean isDisplayed(WebElement e) {
         try {
             return e.isDisplayed();
-        } catch (StaleElementReferenceException _) {
+        } catch (StaleElementReferenceException ignored) {
             return false;
         }
     }


### PR DESCRIPTION
_ is deprecated in java8 and I beleive dissallowed in Java9
given we do not care what the variable was called change the use of _
to ignored