### PR TITLE
Fail fast and clean when BROWSER_DISPLAY and BROWSER are both undefined

### DIFF
--- a/src/main/resources/ath-container/run.sh
+++ b/src/main/resources/ath-container/run.sh
@@ -33,6 +33,11 @@ function download() {
     fi
 }
 
+if [ -z "$DISPLAY" ] && [ -z "$BROWSER_DISPLAY" ]; then
+    echo >&2 "Neither DISPLAY nor BROWSER_DISPLAY defined. Is the VNC server running?"
+    exit 1
+fi
+
 browser=$1
 war=$2
 if [ ! -f $war ]; then


### PR DESCRIPTION
Faster and cleaner than:

```
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------< org.jenkins-ci:acceptance-test-harness >---------------
[INFO] Building Acceptance Test Harness 1.69-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/com/github/jnr/jffi/maven-metadata.xml
Downloading from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/com/github/jnr/jffi/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/com/github/jnr/jffi/maven-metadata.xml (1.0 kB at 2.3 kB/s)
Downloaded from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/com/github/jnr/jffi/maven-metadata.xml (1.0 kB at 1.5 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/github/jnr/jnr-x86asm/maven-metadata.xml
Downloading from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/com/github/jnr/jnr-x86asm/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/com/github/jnr/jnr-x86asm/maven-metadata.xml (362 B at 5.9 kB/s)
Downloaded from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/com/github/jnr/jnr-x86asm/maven-metadata.xml (362 B at 1.1 kB/s)
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:display-info (display-info) @ acceptance-test-harness ---
[INFO] Maven Version: 3.6.1
[INFO] JDK Version: 1.8.0_222 normalized as: 1.8.0-222
[INFO] OS Info: Arch: amd64 Family: unix Name: linux Version: 5.3.4-arch1-1-arch
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (display-info) @ acceptance-test-harness ---
[INFO] artifact com.github.jnr:jffi: checking for updates from repo.jenkins-ci.org
[INFO] artifact com.github.jnr:jffi: checking for updates from central
[INFO] artifact com.github.jnr:jnr-x86asm: checking for updates from repo.jenkins-ci.org
[INFO] artifact com.github.jnr:jnr-x86asm: checking for updates from central
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[INFO] 
[INFO] --- gmaven-plugin:1.5-jenkins-3:generateStubs (default) @ acceptance-test-harness ---
[INFO] No sources found for Java stub generation
[INFO] 
[INFO] --- maven-antrun-plugin:1.7:run (default) @ acceptance-test-harness ---
[INFO] Executing tasks

main:
[INFO] Executed tasks
[INFO] 
[INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ acceptance-test-harness ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 61 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.0:compile (default-compile) @ acceptance-test-harness ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 456 source files to /home/ath-user/sources/target/classes
[INFO] /home/ath-user/sources/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java: Some input files use or override a deprecated API.
[INFO] /home/ath-user/sources/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java: Recompile with -Xlint:deprecation for details.
[INFO] /home/ath-user/sources/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java: Some input files use unchecked or unsafe operations.
[INFO] /home/ath-user/sources/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- gmaven-plugin:1.5-jenkins-3:compile (default) @ acceptance-test-harness ---
[INFO] No sources found to compile
[INFO] 
[INFO] --- animal-sniffer-maven-plugin:1.17:check (check) @ acceptance-test-harness ---
[INFO] Resolved signature org.codehaus.mojo.signature:java18 version as 1.0 from dependencyManagement
[INFO] Checking unresolved references to org.codehaus.mojo.signature:java18:1.0
[INFO] 
[INFO] --- gmaven-plugin:1.5-jenkins-3:generateTestStubs (default) @ acceptance-test-harness ---
[INFO] No sources found for Java stub generation
[INFO] 
[INFO] --- assertj-assertions-generator-maven-plugin:2.1.0:generate-assertions (default) @ acceptance-test-harness ---
Downloading from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/org/assertj/assertj-core/maven-metadata.xml
Downloaded from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/org/assertj/assertj-core/maven-metadata.xml (1.8 kB at 5.7 kB/s)
[INFO] Removing previously generated sources in /home/ath-user/sources/target/generated-test-sources/assertj-assertions
[INFO] 

====================================
AssertJ assertions generation report
====================================

--- Generator input parameters ---

The following templates will replace the ones provided by AssertJ when generating AssertJ assertions :
- Using custom template for 'assertions entry point class' loaded from /home/ath-user/sources/etc/templates/assertions_entry_point_class_template.txt

Generating AssertJ assertions for classes in following packages and subpackages:
- org.jenkinsci.test.acceptance.plugins.warnings_ng

Input classes excluded from assertions generation:
- org.jenkinsci.test.acceptance.plugins.warnings_ng.ScrollerUtilAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.AnalysisResultTabAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.SourceViewAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.AnalysisSummaryQualityGateResultAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.IssuesTableAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.IssuesRecorderAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.SoftAssertions
- org.jenkinsci.test.acceptance.plugins.warnings_ng.DryIssuesTableRowAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.IssuesTableIssuesTableRowTypeAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.InfoViewAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.AnalysisSummaryInfoTypeAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.IssuesRecorderQualityGateTypeAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.ConsoleLogViewAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.DefaultWarningsTableRowAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.IssuesRecorderStaticAnalysisToolAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.AnalysisSummaryAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.Assertions
- org.jenkinsci.test.acceptance.plugins.warnings_ng.AbstractIssuesTableRowAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.DetailsTableRowAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.TableViewAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.AnalysisResultAssert
- org.jenkinsci.test.acceptance.plugins.warnings_ng.AbstractNonDetailsIssuesTableRowAssert

--- Generator results ---

Directory where custom assertions files have been generated:
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions

Custom assertions files generated:
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/AbstractIssuesTableRowAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/AbstractNonDetailsIssuesTableRowAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/AnalysisResultAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/AnalysisResultTabAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/AnalysisSummaryAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/AnalysisSummaryInfoTypeAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/AnalysisSummaryQualityGateResultAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/ConsoleLogViewAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/DefaultWarningsTableRowAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/DetailsTableRowAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/DryIssuesTableRowAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/InfoViewAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/IssuesRecorderAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/IssuesRecorderQualityGateTypeAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/IssuesRecorderStaticAnalysisToolAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/IssuesTableAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/IssuesTableIssuesTableRowTypeAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/ScrollerUtilAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/SourceViewAssert.java
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/TableViewAssert.java

Assertions entry point class has been generated in file:
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/Assertions.java

SoftAssertions entry point class has been generated in file:
- /home/ath-user/sources/target/generated-test-sources/assertj-assertions/org/jenkinsci/test/acceptance/plugins/warnings_ng/SoftAssertions.java

[INFO] 
[INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ acceptance-test-harness ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 142 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.0:testCompile (default-testCompile) @ acceptance-test-harness ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 124 source files to /home/ath-user/sources/target/test-classes
[INFO] /home/ath-user/sources/src/test/java/plugins/MSBuildPluginTest.java: Some input files use or override a deprecated API.
[INFO] /home/ath-user/sources/src/test/java/plugins/MSBuildPluginTest.java: Recompile with -Xlint:deprecation for details.
[INFO] /home/ath-user/sources/src/test/java/plugins/LdapPluginTest.java: /home/ath-user/sources/src/test/java/plugins/LdapPluginTest.java uses unchecked or unsafe operations.
[INFO] /home/ath-user/sources/src/test/java/plugins/LdapPluginTest.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- gmaven-plugin:1.5-jenkins-3:testCompile (default) @ acceptance-test-harness ---
[INFO] No sources found to compile
[INFO] 
[INFO] --- maven-surefire-plugin:3.0.0-M1:test (default-test) @ acceptance-test-harness ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running plugins.PublishOverSSHPluginTest
=== Starting test ssh_key_path_and_no_password_publishing(plugins.PublishOverSSHPluginTest): 12:59:25
No pooled jenkins controller listening on socket /home/ath-user/jenkins.sock
Oct 08, 2019 12:59:26 PM org.jenkinsci.test.acceptance.controller.LocalController postConstruct
INFO: Running with given plugins: []
Failed to open connection to "session" message bus: Unable to autolaunch a dbus-daemon without a $DISPLAY for X11
1570539566601	mozrunner::runner	INFO	Running command: "/usr/bin/firefox" "-marionette" "-foreground" "-no-remote" "-profile" "/tmp/rust_mozprofile.8nKpp0MfdUmi"
Failed to open connection to "session" message Rbuunsn:i nUgn awbilteh otuot  aau1t1oyl asuunpcpho rat !d
bus-daemon without a $DISPLAY for X11
Error: no DISPLAY environment variable specified
--- Test failed: ssh_key_path_and_no_password_publishing(plugins.PublishOverSSHPluginTest): Guice provision errors:

1) Error in custom provider, org.openqa.selenium.WebDriverException: invalid argument: can't kill an exited process
Build info: version: '3.14.0', revision: 'aacccce0', time: '2018-08-02T20:19:58.91Z'
System info: host: '7f4b7e4a4ba3', ip: '172.17.0.2', os.name: 'Linux', os.arch: 'amd64', os.version: '5.3.4-arch1-1-ARCH', java.version: '1.8.0_222'
Driver info: driver.version: FirefoxDriver
remote stacktrace: 
  at org.jenkinsci.test.acceptance.FallbackConfig.createWebDriver(Unknown Source) (via modules: org.jenkinsci.test.acceptance.guice.World -> com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> org.jenkinsci.test.acceptance.FallbackConfig)
  at org.jenkinsci.test.acceptance.FallbackConfig.createWebDriver(Unknown Source) (via modules: org.jenkinsci.test.acceptance.guice.World -> com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> org.jenkinsci.test.acceptance.FallbackConfig)
  while locating org.openqa.selenium.WebDriver
    for field at org.jenkinsci.test.acceptance.junit.DiagnosticRule.driver(Unknown Source)
  while locating org.jenkinsci.test.acceptance.junit.DiagnosticRule

1 error: 12:59:26
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.212 s <<< FAILURE! - in plugins.PublishOverSSHPluginTest
[ERROR] ssh_key_path_and_no_password_publishing(plugins.PublishOverSSHPluginTest)  Time elapsed: 1.147 s  <<< ERROR!
com.google.inject.ProvisionException: 
Guice provision errors:

1) Error in custom provider, org.openqa.selenium.WebDriverException: invalid argument: can't kill an exited process
Build info: version: '3.14.0', revision: 'aacccce0', time: '2018-08-02T20:19:58.91Z'
System info: host: '7f4b7e4a4ba3', ip: '172.17.0.2', os.name: 'Linux', os.arch: 'amd64', os.version: '5.3.4-arch1-1-ARCH', java.version: '1.8.0_222'
Driver info: driver.version: FirefoxDriver
remote stacktrace: 
  at org.jenkinsci.test.acceptance.FallbackConfig.createWebDriver(Unknown Source) (via modules: org.jenkinsci.test.acceptance.guice.World -> com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> org.jenkinsci.test.acceptance.FallbackConfig)
  at org.jenkinsci.test.acceptance.FallbackConfig.createWebDriver(Unknown Source) (via modules: org.jenkinsci.test.acceptance.guice.World -> com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> org.jenkinsci.test.acceptance.FallbackConfig)
  while locating org.openqa.selenium.WebDriver
    for field at org.jenkinsci.test.acceptance.junit.DiagnosticRule.driver(Unknown Source)
  while locating org.jenkinsci.test.acceptance.junit.DiagnosticRule

1 error
	at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:1009)
	at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1035)
	at org.jenkinsci.test.acceptance.junit.JenkinsAcceptanceTestRule$1.addRule(JenkinsAcceptanceTestRule.java:151)
	at org.jenkinsci.test.acceptance.junit.JenkinsAcceptanceTestRule$1.collectGlobalRules(JenkinsAcceptanceTestRule.java:125)
	at org.jenkinsci.test.acceptance.junit.JenkinsAcceptanceTestRule$1.decorateWithRules(JenkinsAcceptanceTestRule.java:92)
	at org.jenkinsci.test.acceptance.junit.JenkinsAcceptanceTestRule$1.evaluate(JenkinsAcceptanceTestRule.java:58)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
Caused by: org.openqa.selenium.WebDriverException: invalid argument: can't kill an exited process
Build info: version: '3.14.0', revision: 'aacccce0', time: '2018-08-02T20:19:58.91Z'
System info: host: '7f4b7e4a4ba3', ip: '172.17.0.2', os.name: 'Linux', os.arch: 'amd64', os.version: '5.3.4-arch1-1-ARCH', java.version: '1.8.0_222'
Driver info: driver.version: FirefoxDriver
remote stacktrace: 
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.openqa.selenium.remote.W3CHandshakeResponse.lambda$new$0(W3CHandshakeResponse.java:57)
	at org.openqa.selenium.remote.W3CHandshakeResponse.lambda$getResponseFunction$2(W3CHandshakeResponse.java:104)
	at org.openqa.selenium.remote.ProtocolHandshake.lambda$createSession$0(ProtocolHandshake.java:122)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:958)
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:531)
	at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:125)
	at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:73)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:136)
	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:83)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:548)
	at org.openqa.selenium.remote.RemoteWebDriver.startSession(RemoteWebDriver.java:212)
	at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:130)
	at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:140)
	at org.jenkinsci.test.acceptance.FallbackConfig.createWebDriver(FallbackConfig.java:111)
	at org.jenkinsci.test.acceptance.FallbackConfig.createWebDriver(FallbackConfig.java:201)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.google.inject.internal.ProviderMethod.get(ProviderMethod.java:115)
	at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
	at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:54)
	at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:66)
	at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:46)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1057)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at org.jenkinsci.test.acceptance.guice.TestLifecycle$1.get(TestL
ifecycle.java:61)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
	at com.google.inject.internal.SingleFieldInjector.inject(SingleFieldInjector.java:54)
	at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:132)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:117)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:88)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:279)
	at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:1000)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1050)
	at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:996)
	... 22 more

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   PublishOverSSHPluginTest.ssh_key_path_and_no_password_publishing » Provision G...
[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.319 s
[INFO] Finished at: 2019-10-08T12:59:27Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M1:test (default-test) on project acceptance-test-harness: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/ath-user/sources/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```