### PR TITLE
 Do not install form-element-path for tests annotated with @WithInstallWizard

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
@@ -128,12 +128,21 @@ public abstract class LocalController extends JenkinsController implements LogLi
         }
 
         LOGGER.info("Running with given plugins: " + Arrays.toString(pluginDir.list()));
+    }
 
-        try {
-            FileUtils.copyFile(formElementPathPlugin, new File(pluginDir, "path-element.hpi"));
-        } catch (IOException e) {
-            throw new RuntimeException(String.format("Failed to copy form path element file %s to plugin dir %s.",
-                    formElementPathPlugin, pluginDir),e);
+    private void installFormElementPath(File pluginDir) {
+        if (runInstallWizard) {
+            out.println("Skipping installation of form-element-path.jpi");
+        } else {
+            out.println("Installing form-element-path.jpi");
+            try {
+                FileUtils.copyFile(formElementPathPlugin, new File(pluginDir, "form-element-path.jpi"));
+            } catch (IOException e) {
+                String msg = String.format(
+                        "Failed to copy form-element-path file %s to plugin dir %s.", formElementPathPlugin, pluginDir
+                );
+                throw new RuntimeException(msg, e);
+            }
         }
     }
 
@@ -183,8 +192,9 @@ public abstract class LocalController extends JenkinsController implements LogLi
         } catch (Exception e) {
             throw new IOException(e.getMessage(), e);
         }
-    }
 
+        installFormElementPath(new File(jenkinsHome, "plugins"));
+    }
 
     public File getJavaHome() {
         String javaHome = getenv("JENKINS_JAVA_HOME");

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/WithInstallWizard.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/WithInstallWizard.java
@@ -21,6 +21,9 @@ import com.google.inject.Inject;
 /**
  * Enables the install wizard to run the test. This is only possible for LocalControllers. Otherwise the test is
  * skipped.
+ *
+ * Note the Jenkins will not have form-element-path installed automatically preventing {@link org.jenkinsci.test.acceptance.po.Control}
+ * and {@link org.jenkinsci.test.acceptance.po.PageArea} to use "path" based navigation.
  */
 @Retention(RUNTIME)
 @Target({ TYPE, METHOD })
@@ -29,7 +32,7 @@ import com.google.inject.Inject;
 @RuleAnnotation(value = WithInstallWizard.RuleImpl.class, priority = -10) // Run before Jenkins startup
 public @interface WithInstallWizard {
     
-    public class RuleImpl implements TestRule {
+    class RuleImpl implements TestRule {
         @Inject
         JenkinsController controller;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/machine/RemoteJenkinsProvider.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/machine/RemoteJenkinsProvider.java
@@ -77,7 +77,7 @@ public class RemoteJenkinsProvider extends JenkinsProvider {
         String pluginDir = jenkinsHome +"plugins/";
         String path = JenkinsResolver.JENKINS_TEMP_DIR+"form-element-path.hpi";
 
-        //install form-path-element plugin
+        //install form-element-path plugin
         new PluginDownloader("form-element-path").materialize(machine, path);
         try (Ssh ssh = machine.connect()) {
             ssh.executeRemoteCommand("mkdir -p " + pluginDir);

--- a/src/main/java/org/jenkinsci/test/acceptance/po/WizardCustomizeJenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WizardCustomizeJenkins.java
@@ -24,15 +24,16 @@
 
 package org.jenkinsci.test.acceptance.po;
 
-import static org.jenkinsci.test.acceptance.Matchers.hasContent;
-
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.NoSuchFrameException;
 import org.openqa.selenium.WebElement;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
+import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 
 /**
  * Page object for Wizard Customize Jenkins Page.
@@ -72,6 +73,7 @@ public class WizardCustomizeJenkins extends PageObject {
                         return element != null;
                     } finally {
                         driver.switchTo().defaultContent();
+                        assertThat(driver, not(hasContent("Installation Failures")));
                     }
                 })
         ;


### PR DESCRIPTION
Early installation of form-element-path causes to install implied dependencies - 
in version that was detached. This can easily cause such plugin need to be updated
for other plugins to install correctly. While Plugin Manager is ready for this and
handle it well, Setup Wizard is reporting an issue and demand Jenkins to be restarted.

Note its page objects _can_ be made more robust to restart if needed, but since
it would happen every time, it would just obscure real issues this can detect. Not
to mention this is running Setup Wizard out of its expected mode of execution, as
it does not expect any plugins to be present effectively testing corner case rather
that main code paths.

Alternative [approach](https://github.com/jenkinsci/form-element-path-plugin/pull/8/files#r292442826) used in the past was bumping form-element-path every time
plugin gets detached from core so it never have any implied dependencies to cause
problems. But the downside is someone has to update that plugin every time there
is a plugin detached from core, and it prevents the plugin load for older cores
making older cores essentially untestable with ATH!

This is essentially taking a trade-off of never using form-element-path for wizard
tests over getting them broken every so often _and_ restricting ATH usage to quite
recent cores.

@amuniz @vilacides @jglick @jtnord, PTAL