### PR TITLE
[JENKINS-60102] In order to capture the right window handle to get back to, confirmAlert/handleAlert should take a Runnable.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/MatrixAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/MatrixAuthorizationStrategy.java
@@ -20,8 +20,8 @@ public class MatrixAuthorizationStrategy extends AuthorizationStrategy {
      * Adds a new user/group to this matrix.
      */
     public MatrixRow addUser(String name) {
-        this.name.resolve().findElement(by.parent()).findElement(by.button("Add user or group…")).click();
-        handleAlert(a -> {
+        runThenHandleAlert(() -> this.name.resolve().findElement(by.parent()).findElement(by.button("Add user or group…")).click(),
+                a -> {
             a.sendKeys(name);
             a.accept();
         });

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/ProjectMatrixProperty.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/ProjectMatrixProperty.java
@@ -20,8 +20,8 @@ public class ProjectMatrixProperty extends PageAreaImpl {
      * Adds a new user/group to this matrix.
      */
     public MatrixRow addUser(String name) {
-        this.name.resolve().findElement(by.parent()).findElement(by.button("Add user or group…")).click();
-        handleAlert(a -> {
+        runThenHandleAlert(() -> this.name.resolve().findElement(by.parent()).findElement(by.button("Add user or group…")).click(),
+                a -> {
             a.sendKeys(name);
             a.accept();
         });

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/mission_control/MissionControlView.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/mission_control/MissionControlView.java
@@ -319,8 +319,7 @@ public class MissionControlView extends View {
     public void reloadConfiguration() {
         getJenkins().open();
         driver.findElement(By.xpath("//a[@class='task-link' and @href='/manage']")).click();
-        driver.findElement(By.xpath("//a[@href='#']")).click();
-        handleAlert(Alert::accept);
+        runThenConfirmAlert(() -> driver.findElement(By.xpath("//a[@href='#']")).click());
         getJenkins().waitForLoad(5);
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Build.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Build.java
@@ -315,9 +315,7 @@ public class Build extends ContainerPageObject {
 
         if (isInProgress()) {
             WebElement stopButton = find(by.href("stop"));
-            stopButton.click();
-
-            handleAlert(Alert::accept);
+            runThenConfirmAlert(() -> stopButton.click());
         }
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayer.java
@@ -145,9 +145,19 @@ public interface CapybaraPortingLayer {
     /**
      * Confirms an alert giving it some time to appear
      *
-     * @param timeout Maximun time to wait for the alert to appear, in seconds
+     * @param timeout Maximum time to wait for the alert to appear, in seconds
+     * @deprecated Use {@link CapybaraPortingLayer#runThenConfirmAlert(Runnable, int)} and provide the runnable that triggers the alert.
      */
+    @Deprecated
     void confirmAlert(int timeout);
+
+    /**
+     * Do something that triggers an alert then giving it some time to appear
+     *
+     * @param runnable Something that will trigger the alert
+     * @param timeout Maximum time to wait for the alert to appear, in seconds
+     */
+    void runThenConfirmAlert(Runnable runnable, int timeout);
 
     /**
      * Get all text of the page including markup.

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -372,13 +372,22 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     }
 
     public void handleAlert(Consumer<Alert> action) {
-        String oldWindow = driver.getWindowHandle();
+        runThenHandleAlert(null, action);
+    }
 
+    public void runThenHandleAlert(Runnable runnable, Consumer<Alert> action) {
+        runThenHandleAlert(runnable, action, 10);
+    }
+
+    public void runThenHandleAlert(Runnable runnable, Consumer<Alert> action, int timeoutSeconds) {
+        String oldWindow = driver.getWindowHandle();
+        if (runnable != null) {
+            runnable.run();
+        }
         Wait<WebDriver> wait = new Wait<>(driver, time)
                 .pollingEvery(500, TimeUnit.MILLISECONDS)
-                .withTimeout(10, TimeUnit.SECONDS)
+                .withTimeout(timeoutSeconds, TimeUnit.SECONDS)
         ;
-
         Alert alert = wait.until(ExpectedConditions.alertIsPresent());
         try {
             action.accept(alert);
@@ -389,7 +398,16 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
 
     @Override
     public void confirmAlert(int timeout) {
-        handleAlert(Alert::accept);
+        runThenHandleAlert(null, Alert::accept, timeout);
+    }
+
+    public void runThenConfirmAlert(Runnable runnable) {
+        runThenHandleAlert(runnable, Alert::accept);
+    }
+
+    @Override
+    public void runThenConfirmAlert(Runnable runnable, int timeout) {
+        runThenHandleAlert(runnable, Alert::accept, timeout);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -444,8 +444,7 @@ public class Job extends TopLevelItem {
      */
     public void delete() {
         open();
-        clickLink("Delete Project");
-        confirmAlert(2);
+        runThenConfirmAlert(() -> clickLink("Delete Project"),2);
     }
 
     public static org.hamcrest.Matcher<WebDriver> disabled() {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WorkflowJob.java
@@ -104,8 +104,7 @@ public class WorkflowJob extends Job {
 
     public void delete() {
         open();
-        clickLink("Delete Pipeline");
-        confirmAlert(2);
+        runThenConfirmAlert(() -> clickLink("Delete Pipeline"),2);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Workspace.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Workspace.java
@@ -34,8 +34,7 @@ public class Workspace extends PageObject {
 
     public void wipeOut() {
         open();
-        clickLink("Wipe Out Current Workspace");
-        handleAlert(Alert::accept);
+        runThenConfirmAlert(() -> clickLink("Wipe Out Current Workspace"));
     }
 
     public static Matcher<Job> workspaceContains(final String file) {

--- a/src/test/java/core/FormValidationTest.java
+++ b/src/test/java/core/FormValidationTest.java
@@ -71,8 +71,7 @@ public class FormValidationTest extends AbstractJUnitTest {
     }
 
     private void navigateAway() {
-        jenkins.open();
-        jenkins.handleAlert(Alert::accept);
+        jenkins.runThenConfirmAlert(() -> jenkins.open());
         sleep(1000); // Needed for some reason
     }
 }


### PR DESCRIPTION
Also honors the provided timeout (#542 changed it to hardcoded 10 seconds)