### PR TITLE
Make the exception a bit more helpful

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
@@ -84,7 +84,7 @@ public class Jenkins extends Node implements Container {
                 );
             }
         } catch (IOException ex) {
-            throw new AssertionError(ex);
+            throw new AssertionError("Caught an IOException, Jenkins URL was " + url, ex);
         }
         int space = text.indexOf(' ');
         if (space != -1) {


### PR DESCRIPTION
I got the following unhelpful stacktrace during a run...

```
Caused by: java.lang.AssertionError: java.net.MalformedURLException: Illegal character in URL
 	at org.jenkinsci.test.acceptance.po.Jenkins.getVersionNumber(Jenkins.java:87)
 	at org.jenkinsci.test.acceptance.po.Jenkins.lambda$waitForStarted$0(Jenkins.java:103)
 	at org.jenkinsci.test.acceptance.junit.Wait$1.apply(Wait.java:94)
 	at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:260)
 	... 26 more
 Caused by: java.net.MalformedURLException: Illegal character in URL
 	at sun.net.www.protocol.https.HttpsURLConnectionImpl.checkURL(HttpsURLConnectionImpl.java:87)
 	at sun.net.www.protocol.https.HttpsURLConnectionImpl.<init>(HttpsURLConnectionImpl.java:99)
 	at sun.net.www.protocol.https.Handler.openConnection(Handler.java:62)
 	at sun.net.www.protocol.https.Handler.openConnection(Handler.java:57)
 	at java.net.URL.openConnection(URL.java:991)
 	at org.jenkinsci.test.acceptance.utils.IOUtil.openConnection(IOUtil.java:62)
 	at org.jenkinsci.test.acceptance.po.Jenkins.getVersionNumber(Jenkins.java:77)
 	... 29 more
```