### PR TITLE
[JENKINS-60633] Update maven 3.6.1 url to the archive repo

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -fsSLO https://github.com/mozilla/geckodriver/releases/download/v0.26.0
     tar -xvzf geckodriver-v0.26.0-linux64.tar.gz -C /usr/local/bin
 
 # Maven in repo is not new enough for ATH
-RUN curl -ffSLO https://www.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz && \
+RUN curl -ffSLO https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz && \
     tar -xvzf apache-maven-3.6.1-bin.tar.gz -C /opt/ && \
     mv /opt/apache-maven-* /opt/maven
 ENV PATH="$PATH:/opt/maven/bin"


### PR DESCRIPTION
See [JENKINS-60633](https://issues.jenkins-ci.org/browse/JENKINS-60633)

The link to download **_Maven 3.6.1_** is broken, so I changed the link to an existing one.

I've not changed to Maven 3.6.3 because I have no enough bandwidth to check whether it's safe. It should be safe, but who knows.

@olivergondza @raul-arabaolaza @varyvol @fcojfernandez @alecharp @rsandell @batmat reviews appreciated