### PR TITLE
BROWSER=htmlunit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,12 +92,6 @@
       <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-transport-http</artifactId>
       <version>${aether.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -170,7 +164,7 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>htmlunit-driver</artifactId>
-      <version>2.20</version>
+      <version>2.33.0</version>
     </dependency>
     <dependency>
       <groupId>com.codeborne</groupId>
@@ -216,7 +210,7 @@
     <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
-      <version>2.2</version>
+      <version>3.6</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -419,7 +413,6 @@
       <version>${assertj.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <dependencyManagement>
@@ -437,12 +430,27 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.5</version>
+        <version>3.8</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
         <version>2.8.9</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.6</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>4.4.10</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.6</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/org/jenkinsci/test/acceptance/selenium/Scroller.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/selenium/Scroller.java
@@ -2,7 +2,6 @@ package org.jenkinsci.test.acceptance.selenium;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
@@ -10,9 +9,9 @@ import org.jenkinsci.test.acceptance.junit.Wait;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsDriver;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.support.events.AbstractWebDriverEventListener;
-
-import static org.jenkinsci.test.acceptance.Matchers.pageObjectExists;
 
 /**
  * Automatically scrolls the element into view.
@@ -92,6 +91,10 @@ public class Scroller extends AbstractWebDriverEventListener {
      * or tests, there is likely a framework problem to be fixed.
      */
     public void scrollIntoView(WebElement e, WebDriver driver) {
+        if (driver instanceof HtmlUnitDriver || (driver instanceof WrapsDriver && ((WrapsDriver) driver).getWrappedDriver() instanceof HtmlUnitDriver)) {
+            return;
+        }
+
         // Do not scroll select's options into view since they are considered to be on the position where they appear when
         // select is clicked, but aligning some option with the top of the window often causes the select itself gets
         // scrolled above the window causing the very issues we are trying to avoid here...


### PR DESCRIPTION
As per https://github.com/jenkinsci/acceptance-test-harness/pull/84#discussion_r57729985 this is versioned separately, and was not compatible with the newer Selenium:

```
java.lang.NoClassDefFoundError: org/openqa/selenium/remote/SessionNotFoundException
	at org.jenkinsci.test.acceptance.FallbackConfig.createWebDriver(FallbackConfig.java:141)
```

Using the latest available version would force a Selenium upgrade (https://github.com/SeleniumHQ/htmlunit-driver/commit/dc9a3872b0be68eae438dd9bdf0cdba6e6ab9c50) so I chose something a bit older, and resolved version conflicts in favor of upper bounds.

Also disabled `Scroller` as it does not work with this driver (just times out) and is probably unnecessary anyway.

Tested on `TriggerRemoteBuildsTest`.