### PR TITLE
[JENKINS-40228] Accommodate lack of a useSecurity checkbox

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
@@ -27,6 +27,7 @@ import java.net.URL;
 
 import org.jenkinsci.test.acceptance.plugins.authorize_project.BuildAccessControl;
 import org.jenkinsci.test.acceptance.plugins.workflow_multibranch.BranchSource;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
 /**
@@ -48,13 +49,21 @@ public class GlobalSecurityConfig extends ContainerPageObject {
     }
 
     public <T extends SecurityRealm> T useRealm(Class<T> type) {
-        control("/useSecurity").check();
+        maybeCheckUseSecurity();
         return selectFromRadioGroup(type);
     }
 
     public <T extends AuthorizationStrategy> T useAuthorizationStrategy(Class<T> type) {
-        control("/useSecurity").check();
+        maybeCheckUseSecurity();
         return selectFromRadioGroup(type);
+    }
+
+    private void maybeCheckUseSecurity() {
+        try {
+            control("/useSecurity").check();
+        } catch (NoSuchElementException x) {
+            // JENKINS-40228, OK
+        }
     }
 
     public <T extends BuildAccessControl> T addBuildAccessControl(final Class<T> type) {


### PR DESCRIPTION
As per https://github.com/jenkinsci/jenkins/pull/2930#issuecomment-558312450 you otherwise get

```
org.openqa.selenium.NoSuchElementException: Unable to locate By.cssSelector: [path='/useSecurity'] in http://127.0.0.1:50158/configureSecurity/
	at org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl.find(CapybaraPortingLayerImpl.java:203)
	at org.jenkinsci.test.acceptance.po.Control.resolve(Control.java:73)
	at org.jenkinsci.test.acceptance.po.Control.check(Control.java:91)
	at org.jenkinsci.test.acceptance.po.GlobalSecurityConfig.useRealm(GlobalSecurityConfig.java:51)
	at core.TriggerRemoteBuildsTest.triggerBuildRemotely(TriggerRemoteBuildsTest.java:46)
```