### PR TITLE
Explore ATH run against containerized selenium

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ The simplest way to start the harness is calling `BROWSER=firefox JENKINS_VERSIO
 takes hours to run due to the number of covered components/use-cases, the cost of Jenkins setup, and selenium interactions.
 That can be avoided by selecting a subset of tests to be run - smoke tests for instance.
 
-## Further Reading
-
-### Running tests
+## Running tests
 
 The harness provides a variety of ways to configure the execution including:
 
@@ -30,7 +28,7 @@ The harness provides a variety of ways to configure the execution including:
 * [Debugging tests in container](docs/DOCKER.md#debugging-tests-in-a-docker-container)
 * Selecting tests based on plugins they cover (TODO)
 
-### Writing tests
+## Creating tests
 
 Given how long it takes for the suite to run, test authors are advised to focus on the most popular plugins and
 use-cases to maximize the value of the test suite. Tests that can or already are written as a part of core/plugin tests
@@ -39,6 +37,7 @@ condition testing, etc.). Individual maintainers are expected to update their te
 well as ensuring the tests does not produce false positives. Tests identified to violate this guideline might be removed
 without author's notice for the sake of suite reliability.
 
+* [Selenium test in plugin repository](docs/EXTERNAL.md)
 * [Docker fixtures](docs/FIXTURES.md)
 * [Page objects](docs/PAGE-OBJECTS.md)
     * [Mix-ins](docs/MIXIN.md)
@@ -49,7 +48,6 @@ without author's notice for the sake of suite reliability.
 * [Testing slaves](docs/SLAVE.md)
 * [Testing emails](docs/EMAIL.md)
 * [Hamcrest matchers](docs/MATCHERS.md)
-* [How to use this from your own module](docs/EXTERNAL.md)
 * [EC2 provider configuration](docs/EC2-CONFIG.md)
 * [Investigation](docs/INVESTIGATION.md)
 

--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -16,6 +16,8 @@ The following values are available:
           for example `http://0.0.0.0:32779/wd/hub`
           when using something like
           [selenium/standalone-firefox-debug](https://hub.docker.com/r/selenium/standalone-firefox-debug/))_
+ * `firefox-container` and `chrome-container`
+        Running the browser inside selenium provided per-test container.
 
 For example, to run tests with Safari, you'd execute:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Existing tests that do not adhere to these guidelines will be reevaluated and pr
 Test is determined fragile/broken when it is failing despite no defects are present in tested component.
 
 - JIRA issue will be created notifying author of the test or plugin authors.
-  - Test can be fixed or moved away to the sources of the plugin.
+  - Test can be fixed or moved away to the [sources of the plugin](EXTERNAL.md).
 - Test would be `@Ignore`d while the JIRA is open
 - At the end of the time period, the test would be removed from ATH.
   - Test can still be resurrected from history if needed - in ATH or plugin itself.

--- a/docs/EXTERNAL.md
+++ b/docs/EXTERNAL.md
@@ -1,173 +1,52 @@
-# How to use this from your own module
+# Using ATH in plugin codebase
 
-You may wish to write Jenkins-based acceptance tests that are not kept in this repository.
-For example, you may have proprietary plugins which you plan to test using this harness.
+You may wish to write Selenium-based UI tests that are not kept in this repository.
+For example, you may have proprietary plugins which you plan to test using this harness or that the plugin does not comply with [contributing guidelines](CONTRIBUTING.md).
 This is easily accomplished.
 
 ## Basic setup
 
-Just create a Maven project (with the default `jar` packaging) depending on the harness:
+Acceptance test harness in known not to coexist well with Jenkins plugin sources. That is why it is recommended to split
+the sources to plugin and UI tests to individual maven modules. 
 
-```
-  <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>acceptance-test-harness</artifactId>
-      <version>…</version>
-    </dependency>
-  </dependencies>
+```xml
+    <modules>
+        <module>plugin</module>
+        <module>ui-tests</module>
+    </modules>
 ```
 
-You may want to specify Java 8 or even 11 sources:
-
-```
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-```
-
-Now just create page objects in `src/main/java/`, tests in `src/test/java/`, and other classes and resources as usual.
+The `plugin` would be an ordinary Jenkins plugin module, while the `ui-tests` will contain the dependency to `acceptance-test-harness` and you UI tests.
+Now just create page objects in `ui-tests/src/main/java/`, tests in `ui-tests/src/test/java/`, and other classes and resources as usual.
 You can of course reuse `AbstractJUnitTest`, page objects, fixtures, etc. from the OSS test harness.
 
-## JUT server
+The tests themselves will be executed by (in `ui-tests/pom.xml`):
 
-If you would like to use the [JUT server](PRELAUNCH.md), add this snippet:
-
-```
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>appassembler-maven-plugin</artifactId>
-        <version>1.8</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>assemble</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <programs>
-            <program>
-              <mainClass>org.jenkinsci.test.acceptance.server.JenkinsControllerPoolProcess</mainClass>
-              <id>jut-server</id>
-            </program>
-          </programs>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <version>3.0.0-M4</version>
+    <configuration>
+        <reuseForks>false</reuseForks>
+        <environmentVariables><!-- read by ATH -->
+            <!-- Jenkins version to be used for ATH run -->
+            <JENKINS_VERSION>${jenkins.version}</JENKINS_VERSION>
+            <!-- Use local version of the plugin over the released one ATH would otherwise use-->
+            <LOCAL_JARS>../plugin/target/XXX.hpi</LOCAL_JARS>
+            <!-- Run the web browser in a container -->
+            <BROWSER>firefox-container</BROWSER>
+        </environmentVariables>
+    </configuration>
+</plugin>
 ```
 
-And create a `jut-server.sh` in the root of your project:
+Other configuration environment variables for ATH can be used as well - not all make sense in this use case, though.
 
-    #!/bin/bash
-    DIR="$( cd "$( dirname "$0" )" && pwd )"
-    CMD="$DIR/target/appassembler/bin/jut-server"
-    if [ ! -s $CMD ]
-    then
-      mvn package -DskipTests -f "$DIR/pom.xml"
-    fi
-    sh "$CMD" "$@"
+It is advised not to release the aggregating parent and the ui-tests module. Also, the tests in `ui-tests` cannot work on
+Windows so they need to be skipped conditionally.
 
-## Controlling test output
+See existing plugins to be used as an example:
 
-The following profile is recommended:
-
-```
-  <profiles>
-    <profile>
-      <id>all-tests</id>
-      <activation>
-        <property>
-          <name>!test</name>
-        </property>
-      </activation>
-      <properties>
-        <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-      </properties>
-    </profile>
-  </profiles>
-```
-
-This ensures that test output is printed to standard output when running a single test, typically while under development;
-yet output is suppressed when running _all_ tests, when it would be noisy (especially when using multiple threads).
-
-## Releasing project versions
-
-If you plan to use `maven-release-plugin` on your own project for some reason, you may add:
-
-```
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <arguments>-DskipTests</arguments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-```
-
-... since you would not want to run acceptance tests during the release.
-(Without some environment variables they would fail anyway.)
-
-## Selecting the browser and Jenkins WAR from Maven profiles
-
-If you like to activate Maven profiles from `~/.m2/settings.xml` with `-P` to run with specific environments, try:
-
-```
-  <profiles>
-    <profile>
-      <id>BROWSER</id>
-      <activation>
-        <property>
-          <name>BROWSER</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <environmentVariables>
-                <BROWSER>${BROWSER}</BROWSER>
-              </environmentVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>JENKINS_WAR</id>
-      <activation>
-        <property>
-          <name>JENKINS_WAR</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <environmentVariables>
-                <JENKINS_WAR>${JENKINS_WAR}</JENKINS_WAR>
-              </environmentVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-```
+- [openstack-cloud](https://github.com/jenkinsci/openstack-cloud-plugin/)
+- [kerberos-sso](https://github.com/jenkinsci/kerberos-sso-plugin/)

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
     <dependency>
       <groupId>org.jenkins-ci.test</groupId>
       <artifactId>docker-fixtures</artifactId>
-      <version>1.8</version>
+      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>com.github.olivergondza.dumpling</groupId>

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -190,20 +190,20 @@ public class FallbackConfig extends AbstractModule {
 
             if (!IOUtil.isTcpPortFree(4444)) throw new IllegalStateException("Port 4444 is occupied");
 
-            new Docker().cmd("pull", image).popen().verifyOrDieWith("Failed to pull image " + image);
-            // TODO document why host network is needed
-            String[] args = {"run", "-d", /*"-p=4444:4444",*/ "-v", "--shm-size=2g", "--network=host", image};
+            Docker.cmd("pull", image).popen().verifyOrDieWith("Failed to pull image " + image);
+            // TODO document why host network is needed (proxy UC reachable by browser)
+            String[] args = {"run", "-d", /*"-p=4444:4444",*/ "--shm-size=2g", "--network=host", image};
 
-            ProcessInputStream popen = new Docker().cmd(args).popen();
+            ProcessInputStream popen = Docker.cmd(args).popen();
             popen.waitFor();
             String cid = popen.verifyOrDieWith("Failed to run selenium container").trim();
 
-            new ProcessBuilder(new Docker().cmd("logs", "-f", cid).toCommandArray()).redirectErrorStream(true).redirectOutput(log.toFile()).start();
+            new ProcessBuilder(Docker.cmd("logs", "-f", cid).toCommandArray()).redirectErrorStream(true).redirectOutput(log.toFile()).start();
 
             Closeable cleanContainer = () -> {
                 try {
-                    new Docker().cmd("kill", cid).popen().verifyOrDieWith("Failed to kill " + cid);
-                    new Docker().cmd("rm", cid).popen().verifyOrDieWith("Failed to rm " + cid);
+                    Docker.cmd("kill", cid).popen().verifyOrDieWith("Failed to kill " + cid);
+                    Docker.cmd("rm", cid).popen().verifyOrDieWith("Failed to rm " + cid);
                 } catch (IOException | InterruptedException e) {
                     throw new Error("Failed removing container", e);
                 }

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
-import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
@@ -316,30 +315,6 @@ public abstract class LocalController extends JenkinsController implements LogLi
         return env;
     }
 
-    /**
-     * Gives random available port in the given range.
-     *
-     * @param from if <=0 then default value 49152 is used
-     * @param to   if <=0 then default value 65535 is used
-     */
-    protected int randomLocalPort(int from, int to){
-        from = (from <=0) ? 49152 : from;
-        to = (to <= 0) ? 65535 : to;
-
-
-        while(true){
-            int candidate = (int) ((Math.random() * (to-from)) + from);
-            if(isFreePort(candidate)){
-                return candidate;
-            }
-            LOGGER.info(String.format("Port %s is in use", candidate));
-        }
-    }
-
-    protected int randomLocalPort(){
-        return randomLocalPort(-1,-1);
-    }
-
     private void diagnoseFailedLoad(Exception cause) throws IOException {
         String td = getThreaddump();
         if (td != null) {
@@ -401,16 +376,6 @@ public abstract class LocalController extends JenkinsController implements LogLi
         }
 
         return null;
-    }
-
-    private boolean isFreePort(int port){
-        try {
-            ServerSocket ss = new ServerSocket(port);
-            ss.close();
-            return true;
-        } catch (IOException ex) {
-            return false;
-        }
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
+import org.jenkinsci.test.acceptance.utils.IOUtil;
 import org.jenkinsci.utils.process.CommandBuilder;
 import org.jenkinsci.utils.process.ProcessInputStream;
 
@@ -37,7 +38,7 @@ public class WinstoneController extends LocalController {
     @Inject
     public WinstoneController(Injector i) {
         super(i);
-        httpPort = randomLocalPort();
+        httpPort = IOUtil.randomTcpPort();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/test/acceptance/guice/Cleaner.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/guice/Cleaner.java
@@ -31,6 +31,11 @@ public class Cleaner {
             public void evaluate() throws Throwable {
                 r.run();
             }
+
+            @Override
+            public String toString() {
+                return r.toString();
+            }
         });
     }
 
@@ -39,6 +44,11 @@ public class Cleaner {
             @Override
             public void evaluate() throws Throwable {
                 c.close();
+            }
+
+            @Override
+            public String toString() {
+                return c.toString();
             }
         });
     }
@@ -49,9 +59,15 @@ public class Cleaner {
             public void evaluate() throws Throwable {
                 c.call();
             }
+
+            @Override
+            public String toString() {
+                return c.toString();
+            }
         });
     }
     public void performCleanUp() {
+        LOGGER.info("Performing cleanup tasks in order: " + tasks);
         for (Statement task : tasks) {
             try {
                 task.evaluate();

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/IOUtil.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/IOUtil.java
@@ -26,14 +26,17 @@ package org.jenkinsci.test.acceptance.utils;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.ServerSocket;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
 public class IOUtil {
 
-    private final static ElasticTime time = new ElasticTime();
+    private static final Logger LOGGER = Logger.getLogger(IOUtil.class.getName());
+    private static final ElasticTime time = new ElasticTime();
 
     /**
      * Get First existing file or directory.
@@ -72,5 +75,42 @@ public class IOUtil {
             sb.append(line).append(newline);
         }
         return sb.toString();
+    }
+
+    /**
+     * Gives random available TCP port in the given range.
+     *
+     * @param from if <=0 then default value 49152 is used
+     * @param to   if <=0 then default value 65535 is used
+     */
+    public static int randomTcpPort(int from, int to){
+        from = (from <=0) ? 49152 : from;
+        to = (to <= 0) ? 65535 : to;
+
+
+        while(true){
+            int candidate = (int) ((Math.random() * (to-from)) + from);
+            if(isTcpPortFree(candidate)){
+                return candidate;
+            }
+            LOGGER.info(String.format("Port %s is in use", candidate));
+        }
+    }
+
+    /**
+     * Gives random available TCP port.
+     */
+    public static int randomTcpPort(){
+        return randomTcpPort(-1,-1);
+    }
+
+    public static boolean isTcpPortFree(int port){
+        try {
+            ServerSocket ss = new ServerSocket(port);
+            ss.close();
+            return true;
+        } catch (IOException ex) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Permit ATH to utilize [selenium containers](https://github.com/SeleniumHQ/docker-selenium) to host browser, driver and selenium server. This si tangential to what ath-container do, but it integrates nicely with `buildPlugin`.

This is intended to be a way to use ATH from plugins source code.

Downstream PRs:
- https://github.com/jenkinsci/kerberos-sso-plugin/pull/19
- https://github.com/jenkinsci/openstack-cloud-plugin/pull/288
- https://github.com/jenkinsci/jms-messaging-plugin/pull/164