### PR TITLE
Fix broken test due to maven module detection in maven parser

### DIFF
--- a/src/main/tool_installers/updates/hudson.tasks.Maven.MavenInstaller
+++ b/src/main/tool_installers/updates/hudson.tasks.Maven.MavenInstaller
@@ -1,142 +1,214 @@
-{"list": [
+{
+  "list": [
     {
-    "id": "3.2.1",
-    "name": "3.2.1",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.2.1-bin.zip"
-  },
+      "id": "3.6.3",
+      "name": "3.6.3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip"
+    },
     {
-    "id": "3.1.1",
-    "name": "3.1.1",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.1.1-bin.zip"
-  },
+      "id": "3.6.2",
+      "name": "3.6.2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip"
+    },
     {
-    "id": "3.1.0",
-    "name": "3.1.0",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.1.0-bin.zip"
-  },
+      "id": "3.6.1",
+      "name": "3.6.1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip"
+    },
     {
-    "id": "3.0.5",
-    "name": "3.0.5",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.5-bin.zip"
-  },
+      "id": "3.6.0",
+      "name": "3.6.0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip"
+    },
     {
-    "id": "3.0.4",
-    "name": "3.0.4",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.4-bin.zip"
-  },
+      "id": "3.5.4",
+      "name": "3.5.4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip"
+    },
     {
-    "id": "3.0.3",
-    "name": "3.0.3",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.3-bin.zip"
-  },
+      "id": "3.5.3",
+      "name": "3.5.3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.3/apache-maven-3.5.3-bin.zip"
+    },
     {
-    "id": "3.0.2",
-    "name": "3.0.2",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.2-bin.zip"
-  },
+      "id": "3.5.2",
+      "name": "3.5.2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.2/apache-maven-3.5.2-bin.zip"
+    },
     {
-    "id": "3.0.1",
-    "name": "3.0.1",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.1-bin.zip"
-  },
+      "id": "3.5.0",
+      "name": "3.5.0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.zip"
+    },
     {
-    "id": "3.0",
-    "name": "3.0",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip"
-  },
+      "id": "3.3.9",
+      "name": "3.3.9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip"
+    },
     {
-    "id": "2.2.1",
-    "name": "2.2.1",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.2.1-bin.zip"
-  },
+      "id": "3.3.3",
+      "name": "3.3.3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip"
+    },
     {
-    "id": "2.2.0",
-    "name": "2.2.0",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.2.0-bin.zip"
-  },
+      "id": "3.3.1",
+      "name": "3.3.1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.1/apache-maven-3.3.1-bin.zip"
+    },
     {
-    "id": "2.1.0",
-    "name": "2.1.0",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.1.0-bin.zip"
-  },
+      "id": "3.2.5",
+      "name": "3.2.5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip"
+    },
     {
-    "id": "2.0.11",
-    "name": "2.0.11",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.0.11-bin.zip"
-  },
+      "id": "3.2.3",
+      "name": "3.2.3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.3/apache-maven-3.2.3-bin.zip"
+    },
     {
-    "id": "2.0.10",
-    "name": "2.0.10",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.0.10-bin.zip"
-  },
+      "id": "3.2.2",
+      "name": "3.2.2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.2/apache-maven-3.2.2-bin.zip"
+    },
     {
-    "id": "2.0.9",
-    "name": "2.0.9",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.0.9-bin.zip"
-  },
+      "id": "3.2.1",
+      "name": "3.2.1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.1/apache-maven-3.2.1-bin.zip"
+    },
     {
-    "id": "2.0.8",
-    "name": "2.0.8",
-    "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.0.8-bin.zip"
-  },
+      "id": "3.1.1",
+      "name": "3.1.1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.1.1/apache-maven-3.1.1-bin.zip"
+    },
     {
-    "id": "2.0.7",
-    "name": "2.0.7",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.7-bin.zip"
-  },
+      "id": "3.1.0",
+      "name": "3.1.0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.1.0/apache-maven-3.1.0-bin.zip"
+    },
     {
-    "id": "2.0.6",
-    "name": "2.0.6",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.6-bin.zip"
-  },
+      "id": "3.0.5",
+      "name": "3.0.5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.5/apache-maven-3.0.5-bin.zip"
+    },
     {
-    "id": "2.0.5",
-    "name": "2.0.5",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.5-bin.zip"
-  },
+      "id": "3.0.4",
+      "name": "3.0.4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.4/apache-maven-3.0.4-bin.zip"
+    },
     {
-    "id": "2.0.4",
-    "name": "2.0.4",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.4-bin.zip"
-  },
+      "id": "3.0.3",
+      "name": "3.0.3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.3/apache-maven-3.0.3-bin.zip"
+    },
     {
-    "id": "2.0.3",
-    "name": "2.0.3",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.3-bin.zip"
-  },
+      "id": "3.0.2",
+      "name": "3.0.2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.2/apache-maven-3.0.2-bin.zip"
+    },
     {
-    "id": "2.0.2",
-    "name": "2.0.2",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.2-bin.zip"
-  },
+      "id": "3.0.1",
+      "name": "3.0.1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.1/apache-maven-3.0.1-bin.zip"
+    },
     {
-    "id": "2.0.1",
-    "name": "2.0.1",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.1-bin.zip"
-  },
+      "id": "3.0",
+      "name": "3.0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0/apache-maven-3.0-bin.zip"
+    },
     {
-    "id": "2.0",
-    "name": "2.0",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0-bin.zip"
-  },
+      "id": "2.2.1",
+      "name": "2.2.1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.2.1/apache-maven-2.2.1-bin.zip"
+    },
     {
-    "id": "1.1",
-    "name": "1.1",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-1.1.zip"
-  },
+      "id": "2.2.0",
+      "name": "2.2.0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.2.0/apache-maven-2.2.0-bin.zip"
+    },
     {
-    "id": "1.0.2",
-    "name": "1.0.2",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-1.0.2.zip"
-  },
+      "id": "2.1.0",
+      "name": "2.1.0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.1.0/apache-maven-2.1.0-bin.zip"
+    },
     {
-    "id": "1.0.1",
-    "name": "1.0.1",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-1.0.1.zip"
-  },
+      "id": "2.0.11",
+      "name": "2.0.11",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.0.11/apache-maven-2.0.11-bin.zip"
+    },
     {
-    "id": "1.0",
-    "name": "1.0",
-    "url": "http://archive.apache.org/dist/maven/binaries/maven-1.0.zip"
-  }
-]}
+      "id": "2.0.10",
+      "name": "2.0.10",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.0.10/apache-maven-2.0.10-bin.zip"
+    },
+    {
+      "id": "2.0.9",
+      "name": "2.0.9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.0.9/apache-maven-2.0.9-bin.zip"
+    },
+    {
+      "id": "2.0.8",
+      "name": "2.0.8",
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-2.0.8-bin.zip"
+    },
+    {
+      "id": "2.0.7",
+      "name": "2.0.7",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.7-bin.zip"
+    },
+    {
+      "id": "2.0.6",
+      "name": "2.0.6",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.6-bin.zip"
+    },
+    {
+      "id": "2.0.5",
+      "name": "2.0.5",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.5-bin.zip"
+    },
+    {
+      "id": "2.0.4",
+      "name": "2.0.4",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.4-bin.zip"
+    },
+    {
+      "id": "2.0.3",
+      "name": "2.0.3",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.3-bin.zip"
+    },
+    {
+      "id": "2.0.2",
+      "name": "2.0.2",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.2-bin.zip"
+    },
+    {
+      "id": "2.0.1",
+      "name": "2.0.1",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.1-bin.zip"
+    },
+    {
+      "id": "2.0",
+      "name": "2.0",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0-bin.zip"
+    },
+    {
+      "id": "1.1",
+      "name": "1.1",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-1.1.zip"
+    },
+    {
+      "id": "1.0.2",
+      "name": "1.0.2",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-1.0.2.zip"
+    },
+    {
+      "id": "1.0.1",
+      "name": "1.0.1",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-1.0.1.zip"
+    },
+    {
+      "id": "1.0",
+      "name": "1.0",
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-1.0.zip"
+    }
+  ]
+}

--- a/src/test/java/plugins/WarningsNextGenerationPluginTest.java
+++ b/src/test/java/plugins/WarningsNextGenerationPluginTest.java
@@ -441,6 +441,10 @@ public class WarningsNextGenerationPluginTest extends AbstractJUnitTest {
         Build build = buildFailingJob(job);
         build.open();
 
+        System.out.println("-------------- Console Log ----------------");
+        System.out.println(build.getConsole());
+        System.out.println("-------------------------------------------");
+
         AnalysisSummary summary = new AnalysisSummary(build, MAVEN_ID);
         assertThat(summary).isDisplayed()
                 .hasTitleText("Maven: 2 warnings")

--- a/src/test/java/plugins/WarningsNextGenerationPluginTest.java
+++ b/src/test/java/plugins/WarningsNextGenerationPluginTest.java
@@ -43,6 +43,7 @@ import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.Slave;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
 
+import static org.jenkinsci.test.acceptance.plugins.maven.MavenInstallation.*;
 import static org.jenkinsci.test.acceptance.plugins.warnings_ng.Assertions.*;
 
 /**
@@ -438,23 +439,24 @@ public class WarningsNextGenerationPluginTest extends AbstractJUnitTest {
 
         job.save();
 
-        Build build = buildFailingJob(job);
-        build.open();
+        Build build = buildJob(job).shouldSucceed();
 
         System.out.println("-------------- Console Log ----------------");
         System.out.println(build.getConsole());
         System.out.println("-------------------------------------------");
 
+        build.open();
+        
         AnalysisSummary summary = new AnalysisSummary(build, MAVEN_ID);
         assertThat(summary).isDisplayed()
-                .hasTitleText("Maven: 2 warnings")
+                .hasTitleText("Maven: 4 warnings")
                 .hasNewSize(0)
                 .hasFixedSize(0)
                 .hasReferenceBuild(0);
 
         AnalysisResult mavenDetails = summary.openOverallResult();
         assertThat(mavenDetails).hasActiveTab(Tab.MODULES)
-                .hasTotal(2)
+                .hasTotal(4)
                 .hasOnlyAvailableTabs(Tab.MODULES, Tab.TYPES, Tab.ISSUES);
 
         IssuesTable issuesTable = mavenDetails.openIssuesTable();
@@ -553,12 +555,8 @@ public class WarningsNextGenerationPluginTest extends AbstractJUnitTest {
     }
 
     private MavenModuleSet createMavenProject() {
-        MavenInstallation.installSomeMaven(jenkins);
+        MavenInstallation.installMaven(jenkins, DEFAULT_MAVEN_ID, "3.6.3");
         return jenkins.getJobs().create(MavenModuleSet.class);
-    }
-
-    private Build buildFailingJob(final Job job) {
-        return buildJob(job).shouldFail();
     }
 
     private Build buildJob(final Job job) {

--- a/src/test/java/plugins/WarningsNextGenerationPluginTest.java
+++ b/src/test/java/plugins/WarningsNextGenerationPluginTest.java
@@ -427,7 +427,7 @@ public class WarningsNextGenerationPluginTest extends AbstractJUnitTest {
      * Creates and builds a maven job and verifies that all warnings are shown in the summary and details views.
      */
     @Test
-    @WithPlugins("maven-plugin")
+    @WithPlugins({"maven-plugin", "analysis-model-api@7.0.4"})
     public void should_show_maven_warnings_in_maven_project() {
         MavenModuleSet job = createMavenProject();
         copyResourceFilesToWorkspace(job, SOURCE_VIEW_FOLDER + "pom.xml");
@@ -449,9 +449,9 @@ public class WarningsNextGenerationPluginTest extends AbstractJUnitTest {
                 .hasReferenceBuild(0);
 
         AnalysisResult mavenDetails = summary.openOverallResult();
-        assertThat(mavenDetails).hasActiveTab(Tab.TYPES)
+        assertThat(mavenDetails).hasActiveTab(Tab.MODULES)
                 .hasTotal(2)
-                .hasOnlyAvailableTabs(Tab.TYPES, Tab.ISSUES);
+                .hasOnlyAvailableTabs(Tab.MODULES, Tab.TYPES, Tab.ISSUES);
 
         IssuesTable issuesTable = mavenDetails.openIssuesTable();
 

--- a/src/test/resources/warnings_ng_plugin/source-view/pom.xml
+++ b/src/test/resources/warnings_ng_plugin/source-view/pom.xml
@@ -20,4 +20,30 @@
     </plugins>
   </build>
 
+  <repositories>
+    <repository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+  <distributionManagement>
+    <repository>
+      <id>Central Maven repository</id>
+      <name>Central Maven repository https</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+  </distributionManagement>
+
 </project>


### PR DESCRIPTION
Since [analysis-model-7.0.0](https://github.com/jenkinsci/analysis-model/releases/tag/analysis-model-7.0.0) the Maven parser detects the module a warning is from. So a new tab will be shown in the test.