### PR TITLE
Adapt GitPluginTest regex for git plugin 4.0

### DIFF
--- a/src/test/java/plugins/GitPluginTest.java
+++ b/src/test/java/plugins/GitPluginTest.java
@@ -281,9 +281,10 @@ public class GitPluginTest extends AbstractJUnitTest {
         Build b = job.startBuild();
         b.shouldSucceed();
 
+        // Git plugin 4.0 switched from <b> to <strong>. Accept either bold or strong.
         assertThat(
                 visit(b.url("git")).getPageSource(),
-                Matchers.containsRegexp("<b>SCM:</b> " + SCM_NAME, Pattern.MULTILINE)
+                Matchers.containsRegexp("<[^>]+>SCM:</[^>]+> " + SCM_NAME, Pattern.MULTILINE)
         );
     }
 


### PR DESCRIPTION
## Adapt GitPluginTest regex for git plugin 4.0

Git plugin 4.0 uses `<strong>` instead of `<b>` tag.

`<strong>` tag is recommended over `<b>` in some online locations.  The `<b>` tag meaning has changed in HTML 5 according to https://www.w3.org/International/questions/qa-b-and-i-tags .

See [build 209 test result](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/209/testReport/junit/plugins/GitPluginTest/java_8_split9___custom_scm_name/) for an example of the failure.

Review preferred by @mikecirioli or @fcojfernandez or @rsandell or @oleg-nenashev 