### PR TITLE
Update warnings tests for 8.0.0 release and newer

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/warnings_ng/AnalysisSummary.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/warnings_ng/AnalysisSummary.java
@@ -103,7 +103,7 @@ public class AnalysisSummary extends PageObject {
      * @return the type of the icon that links to the info messages view
      */
     public InfoType getInfoType() {
-        String iconName = find(by.xpath("//a[@href='" + id + "/info']/i")).getAttribute("class");
+        String iconName = find(by.xpath("//a[@href='" + id + "/info']")).findElements(by.css("*")).get(1).getAttribute("href");
 
         return InfoType.valueOfClass(iconName);
     }
@@ -312,9 +312,9 @@ public class AnalysisSummary extends PageObject {
      */
     public enum InfoType {
         /** Info messages only. */
-        INFO("fa-info-circle"),
+        INFO("info-circle"),
         /** Info and error messages. */
-        ERROR("fa-exclamation-triangle");
+        ERROR("exclamation-triangle");
 
         private String iconName;
 

--- a/src/test/java/plugins/WarningsNextGenerationPluginTest.java
+++ b/src/test/java/plugins/WarningsNextGenerationPluginTest.java
@@ -64,7 +64,7 @@ import static org.jenkinsci.test.acceptance.plugins.warnings_ng.Assertions.*;
  * @author Florian Hageneder
  * @author Veronika Zwickenpflug
  */
-@WithPlugins("warnings-ng")
+@WithPlugins("warnings-ng@8.0.0")
 public class WarningsNextGenerationPluginTest extends AbstractJUnitTest {
     private static final String WARNINGS_PLUGIN_PREFIX = "/warnings_ng_plugin/";
 
@@ -290,8 +290,7 @@ public class WarningsNextGenerationPluginTest extends AbstractJUnitTest {
                 .hasInfoMessages("-> found 1 file",
                         "-> found 2 issues (skipped 0 duplicates)",
                         "Issues delta (vs. reference build): outstanding: 2, new: 0, fixed: 1")
-                .hasErrorMessages("Can't resolve absolute paths for some files:",
-                        "Can't create fingerprints for some files:");
+                .hasErrorMessages("Can't create fingerprints for some files:");
     }
 
     private void verifyCheckStyle(final Build build) {
@@ -325,8 +324,7 @@ public class WarningsNextGenerationPluginTest extends AbstractJUnitTest {
                 .hasInfoMessages("-> found 1 file",
                         "-> found 3 issues (skipped 0 duplicates)",
                         "Issues delta (vs. reference build): outstanding: 0, new: 3, fixed: 1")
-                .hasErrorMessages("Can't resolve absolute paths for some files:",
-                        "Can't create fingerprints for some files:");
+                .hasErrorMessages("Can't create fingerprints for some files:");
     }
 
     private InfoView openInfoView(final Build build, final String toolId) {


### PR DESCRIPTION
- The icon (error/info) is now an SVG icon that has a different XPath
- There are no errors reported anymore for broken absolute paths