### PR TITLE
[JENKINS-61477] Wait until plugins have been initialized

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.test.acceptance.FallbackConfig;
@@ -264,7 +265,10 @@ public class PluginManager extends ContainerPageObject {
         }
 
         // Jenkins will be restarted if necessary
-        new UpdateCenter(jenkins).waitForInstallationToComplete(specs);
+        boolean hasBeenRestarted = new UpdateCenter(jenkins).waitForInstallationToComplete(specs);
+        if (!hasBeenRestarted && specs.length > 0) {
+            jenkins.getLogger("all").waitForLogged(Pattern.compile("Completed installation of .*"), 1000);
+        }
 
         return false;
     }


### PR DESCRIPTION
Currently we start test cases if there is no progress shown
in the update manager screen. However, sometimes the plugins are
already installed but not yet initialized.

See https://issues.jenkins-ci.org/browse/JENKINS-61477