### PR TITLE
Better UC updated status check logic

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -18,7 +18,6 @@ import org.jenkinsci.test.acceptance.update_center.PluginMetadata;
 import org.jenkinsci.test.acceptance.update_center.PluginSpec;
 import org.jenkinsci.test.acceptance.update_center.UpdateCenterMetadata.UnableToResolveDependencies;
 import org.jenkinsci.test.acceptance.update_center.UpdateCenterMetadataProvider;
-import org.jenkinsci.test.acceptance.utils.ElasticTime;
 import org.junit.internal.AssumptionViolatedException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
@@ -257,7 +256,6 @@ public class PluginManager extends ContainerPageObject {
             System.out.println("Plugins to be updated: " + update);
             if (!update.isEmpty()) {
                 visit(""); // Updates tab
-                driver.navigate().refresh();
                 for (PluginSpec n : update) {
                     tickPluginToInstall(n);
                 }
@@ -273,7 +271,7 @@ public class PluginManager extends ContainerPageObject {
 
     private void tickPluginToInstall(PluginSpec spec) {
         String name = spec.getName();
-        check(waitFor(by.xpath("//input[starts-with(@name,'plugin.%s.')]", name), 30));
+        check(find(by.xpath("//input[starts-with(@name,'plugin.%s.')]", name)));
         final VersionNumber requiredVersion = spec.getVersionNumber();
         if (requiredVersion != null) {
             final VersionNumber availableVersion = getAvailableVersionForPlugin(name);


### PR DESCRIPTION
Previously the stale check was not working properly, if the button status check failed with something different than `StaleElementException` the error was swallowed by the outer catch and `true` was returned making the callers believe the UC finished updating when it was not.

Not apparent in ci.jenkins.io but in other testing infra with custom wars using more than one update center for example.