### PR TITLE
[JENKINS-62481] Fix AuditTrailPluginTest

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/audit_trail/AuditTrailGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/audit_trail/AuditTrailGlobalConfiguration.java
@@ -1,20 +1,20 @@
 package org.jenkinsci.test.acceptance.plugins.audit_trail;
 
 import org.jenkinsci.test.acceptance.po.Control;
-import org.jenkinsci.test.acceptance.po.GlobalPluginConfiguration;
 import org.jenkinsci.test.acceptance.po.JenkinsConfig;
+import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 
 /**
  * Global configuration section of the audit-trail plugin.
  *
  * @author Kohsuke Kawaguchi
  */
-public class AuditTrailGlobalConfiguration extends GlobalPluginConfiguration {
+public class AuditTrailGlobalConfiguration extends PageAreaImpl {
 
     public final Control addLogger = control("hetero-list-add[loggers]");
 
     public AuditTrailGlobalConfiguration(JenkinsConfig context) {
-        super(context, "audit-trail");
+        super(context, "/hudson-plugins-audit_trail-AuditTrailPlugin");
     }
 
     // TODO


### PR DESCRIPTION
The failure was happening because the PO `AuditTrailGlobalConfiguration` was using a wrong selector to find an HTML input (`GlobalPluginConfiguration`)

Replace invalid selector in `AuditTrailGlobalConfiguration`, with the current one.

The failure was reproduced with jenkins-core 2.204.5 and 2.222.3, and the fix has been validated against those lines too.