### PR TITLE
Be sure "Check Now" button action is finished before continue with a test

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.time.temporal.ChronoUnit;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +26,7 @@ import org.jenkinsci.test.acceptance.update_center.UpdateCenterMetadataProvider;
 import org.junit.internal.AssumptionViolatedException;
 import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
 import com.google.inject.Inject;
@@ -95,23 +97,23 @@ public class PluginManager extends ContainerPageObject {
         // The check now button is a form submit (POST) with a redirect to the same page only if the check is successful.
         // We use the button itself to detect when the page has changed, which happens after the refresh has been done
         // And we check for the presence of the button again
-        clickLink("Check now");
+        WebElement checkButton = find(by.link("Check now"));
+        checkButton.click();
         // The wait criteria is: we have left the current page and returned to the same one
-        waitFor(find(by.link("Check now"))).withTimeout(30, TimeUnit.SECONDS).until(webElement -> {
+        waitFor(checkButton).withTimeout(java.time.Duration.of(time.seconds(30), ChronoUnit.MILLIS)).until(webElement -> {
             try {
-                try {
-                    // We interact with the element just to detect if it is stale
-                    webElement.findElement(by.id("it does not matter"));
-                } catch(StaleElementReferenceException e) {
-                    // with this exception we know we've left the original page
-                    // we look for an element in the page to check for success
-                    if (current.equals(getCurrentUrl())) {
-                        return true;
-                    }
+                // We interact with the element just to detect if it is stale
+                webElement.findElement(by.id("it does not matter"));
+            } catch(StaleElementReferenceException e) {
+                // with this exception we know we've left the original page
+                // we look for an element in the page to check for success
+                if (current.equals(getCurrentUrl())) {
+                    return true;
                 }
-            } catch(Exception e) {
+            } catch(NoSuchElementException e) {
+                return false;
             }
-            return true;
+            return false;
         });
         updated = true;
     }


### PR DESCRIPTION
Be sure "check for updates" is working consistently, clicking the button, and waiting until the page is refresh. This will avoid some flakiness in testing.

Tested in Java8 and Java11

cc/ @batmat @varyvol @raul-arabaolaza @imonteroperez 