### PR TITLE
Make sure the test fails instead of defaulting to upstream UC when overridden

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -99,8 +99,7 @@ public class MockUpdateCenter implements AutoCleaned {
         try {
             ucm = ucmd.get(jenkins);
         } catch (IOException x) {
-            LOGGER.log(Level.WARNING, "cannot load data for mock update center", x);
-            return;
+            throw new Error("cannot load data for mock update center", x);
         }
         JSONObject all;
         try {


### PR DESCRIPTION
Useful when `-Dupdate_center_url` is overridden so this fails instead of silently using upstream UC.