### PR TITLE
[JENKINS-62691] Fix bug where scroller is stuck in infinite loop

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/selenium/scroller.js
+++ b/src/main/resources/org/jenkinsci/test/acceptance/selenium/scroller.js
@@ -15,5 +15,5 @@ if(sticker == null || !sticker.contains(document.getElementById(id)) || footer.l
 }
 else{
   //it is sticker button and it is moved up (footer does not overlap)
-  return (footer[0].getBoundingClientRect().top > sticker.getBoundingClientRect().bottom)
+  return (footer[0].getBoundingClientRect().top >= sticker.getBoundingClientRect().bottom)
 }


### PR DESCRIPTION
See [JENKINS-62691](https://issues.jenkins-ci.org/browse/JENKINS-62691).

When scrolling to a form sticky button the scroller would get stuck in an infinite loop when the form buttons container touched the footer. It's better described on the issue.

#### Requesting reviewers

@EstherAF 
@bmunozm
@amuniz 