### PR TITLE
Fix a test failure because of an error css changed

### DIFF
--- a/src/test/java/core/FreestyleJobTest.java
+++ b/src/test/java/core/FreestyleJobTest.java
@@ -1,5 +1,6 @@
 package core;
 
+import hudson.util.VersionNumber;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.SmokeTest;
@@ -300,8 +301,9 @@ public class FreestyleJobTest extends AbstractJUnitTest {
         trigger.spec.set("not_a_time");
         clickButton("Apply");
 
-        By error = by.css("#error-description pre");
-
+        String errorElementCSS = jenkins.getVersion().isOlderThan(new VersionNumber("2.235")) ? "#error-description pre" : ".validation-error-area .error";
+        By error = by.css(errorElementCSS);
+        
         assertThat(waitFor(error).getText(), containsString("Invalid input: \"not_a_time\""));
         clickLink("Close");
 


### PR DESCRIPTION
The css classes of the error shown when the format of the build schedule field is wrong has changed. This PR distinguish both formats depending on the Jenkins version.

Error displayed:
![Screenshot from 2020-06-16 12-32-59](https://user-images.githubusercontent.com/22069922/84766824-b9e46480-afd1-11ea-8689-54bf5dbe436b.png)

New css:
![Screenshot from 2020-06-16 12-33-15](https://user-images.githubusercontent.com/22069922/84766837-bc46be80-afd1-11ea-8222-367c24e5e964.png)
