### PR TITLE
Revert "Merge pull request #536 from jtnord/save-should-use-submit"

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
@@ -29,11 +29,7 @@ import java.util.concurrent.Callable;
 import com.google.inject.Injector;
 
 import groovy.lang.Closure;
-
-import org.jenkinsci.test.acceptance.utils.ElasticTime;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
-
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.jenkinsci.test.acceptance.Matchers.*;
@@ -130,10 +126,8 @@ public abstract class ConfigurablePageObject extends PageObject {
     public abstract URL getConfigUrl();
 
     public void save() {
-        WebElement e = find(by.button("Save"));
-        e.submit();
+        clickButton("Save");
         assertThat(driver, not(hasContent("This page expects a form submission")));
-        
     }
 
     public void apply() {


### PR DESCRIPTION
This reverts commit 95698c6eb8262f272da951b1e9d65bb02dd3481a, reversing
changes made to 26b15fd0763ceaef27ed1f07728e152e7df21ba0.

I'm observing erratic behaviour in ATHs, some `visit` calls are randomly failing to actually visit the page when it's run after a `save` call. I'm not sure what's really happening, but reverting this change I get consistent test runs.

/cc @olivergondza 