### PR TITLE
[JENKINS-62868] Delete one Git ancestry strategy test

### DIFF
--- a/src/test/java/plugins/GitPluginTest.java
+++ b/src/test/java/plugins/GitPluginTest.java
@@ -313,40 +313,6 @@ public class GitPluginTest extends AbstractJUnitTest {
     }
 
     @Test
-    public void ancestry_strategy_to_choose_build() {
-        final String TEST_BRANCH = "testBranch";
-
-        GitRepo repo = buildGitRepo();
-        repo.createBranch(TEST_BRANCH);
-        repo.changeAndCommitFoo("Commit1 on master");
-        repo.checkout(TEST_BRANCH);
-        repo.changeAndCommitFoo("commit1 on " + TEST_BRANCH);
-        String sha1 = repo.getLastSha1();
-        repo.changeAndCommitFoo("commit2 on " + TEST_BRANCH);
-
-        repo.transferToDockerContainer(host, port);
-
-        job.useScm(GitScm.class)
-                .url(repoUrl)
-                .branch("")
-                .credentials(USERNAME)
-                .chooseBuildStrategy("Ancestry", 1, sha1);
-
-        job.save();
-        Build b = job.startBuild();
-        b.shouldSucceed();
-        // TODO Multiple selected branches create multiple builds, these should also be verified
-
-        assertThat(
-                b.getConsole(),
-                Matchers.containsRegexp(
-                        "Checking out Revision .* \\(origin/"+TEST_BRANCH+"\\)",
-                        Pattern.MULTILINE
-                )
-        );
-    }
-
-    @Test
     public void inverse_strategy_to_choose_build() {
         final String BRANCH_NAME = "secondBranch";
 


### PR DESCRIPTION
## [JENKINS-62868](https://issues.jenkins-ci.org/browse/JENKINS-62868) Git ancestry strategy well tested in plugin tests

Table to div UI changes probably broke this UI test.  Already have strong coverage for ancestry strategy in the git plugin tests.  There are two other build chooser strategy tests in this suite.  More valuable to spend our time on other areas.