### PR TITLE
Fix Matrix Project failure after 1.15 (slave -> agent)

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/LabelAxis.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/LabelAxis.java
@@ -6,7 +6,7 @@ import org.openqa.selenium.lift.Matchers;
 /**
  * @author Kohsuke Kawaguchi
  */
-@Describable("Slaves")
+@Describable({"Agents", "Slaves"}) // Agents for Matrix Project Plugin >= 1.15
 public class LabelAxis extends Axis {
     public LabelAxis(PageObject context, String path) {
         super(context, path);


### PR DESCRIPTION
Theses changes https://github.com/jenkinsci/matrix-project-plugin/pull/64 released on [Matrix Project Plugin 1.15](https://github.com/jenkinsci/matrix-project-plugin/releases/tag/matrix-project-1.15) make https://github.com/jenkinsci/acceptance-test-harness/blob/000ee55fab1ef9497e3f81ccecdad7cac3a2e22a/src/test/java/plugins/MatrixPluginTest.java#L107 to fail because the change on the terminology from `slave` to `agent`. 

Added `Agents` to allow the tests pass on older versions of the plugin.