### PR TITLE
[JENKINS-63159] workaround tooltip preventing the click

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/MatrixAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/matrix_auth/MatrixAuthorizationStrategy.java
@@ -4,6 +4,7 @@ import org.jenkinsci.test.acceptance.po.AuthorizationStrategy;
 import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
+import org.openqa.selenium.WebElement;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -20,8 +21,13 @@ public class MatrixAuthorizationStrategy extends AuthorizationStrategy {
      * Adds a new user/group to this matrix.
      */
     public MatrixRow addUser(String name) {
-        runThenHandleAlert(() -> this.name.resolve().findElement(by.parent()).findElement(by.button("Add user or group…")).click(),
-                a -> {
+        runThenHandleAlert(() -> {
+            WebElement button = this.name.resolve().findElement(by.parent())
+                                         .findElement(by.button("Add user or group…"));
+            // JENKINS-63159 if the user has just (un)checked a permission then the button click may fail as the button
+            // is obscured by a tooltip
+            button.sendKeys(" "); // because this is reliable and button.click() is not due to the tooltip.
+        }, a -> {
             a.sendKeys(name);
             a.accept();
         });


### PR DESCRIPTION
[JENKINS-63159](https://issues.jenkins-ci.org/browse/JENKINS-63159)
whilst I have not seen this on the CI it was failing 100% of the time
locally with a test that did
```
 MatrixAuthorizationStrategy auth =
     security.useAuthorizationStrategy(MatrixAuthorizationStrategy.class);
 auth.addUser("alice").admin();
 auth.addUser("bob").developer();
```

the user bob was not added and the test timed out waiting for the alter
box.
it appears as though `click` would not work as the button was partially
obscured by the tooltip for the "administrator" permission that was just
clicked.

![image](https://user-images.githubusercontent.com/494726/88174055-82458980-cc1b-11ea-8687-11151a92a417.png)


using keyboard navigation (space) to click the button instead worked for
me.

I was running selenium/firefox with the following commands:
`docker run -d -p 4444:4444 -p 5900:5900 -e no_proxy=localhost -e SCREEN_WIDTH=1680 -e SCREEN_HEIGHT=1090 selenium/standalone-firefox-debug:2.53.1`