### PR TITLE
upgrade selenium to 3.141.59

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <java.level>8</java.level>
     <findbugs.skip>true</findbugs.skip>
 
-    <selenium.version>3.14.0</selenium.version>
+    <selenium.version>3.141.59</selenium.version>
     <guava.version>25.0-jre</guava.version> <!-- aligned with selenium -->
     <aether.version>0.9.0.v20140226</aether.version>
     <maven.version>3.1.0</maven.version>
@@ -212,6 +212,12 @@
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
       <version>3.6</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <!--  to match upper bounds -->
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -129,9 +129,9 @@ public class FallbackConfig extends AbstractModule {
             GeckoDriverService service = builder.build();
             return new FirefoxDriver(service, firefoxOptions);
         case "firefox-container":
-            return createContainerWebDriver(cleaner, "selenium/standalone-firefox-debug:3.14.0", new FirefoxOptions());
+            return createContainerWebDriver(cleaner, "selenium/standalone-firefox-debug:3.141.59", new FirefoxOptions());
         case "chrome-container":
-            return createContainerWebDriver(cleaner, "selenium/standalone-chrome-debug:3.14.0", new ChromeOptions());
+            return createContainerWebDriver(cleaner, "selenium/standalone-chrome-debug:3.141.59", new ChromeOptions());
         case "ie":
         case "iexplore":
         case "iexplorer":

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/ElasticTime.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/ElasticTime.java
@@ -59,7 +59,16 @@ public class ElasticTime {
     }
 
     public long milliseconds(long ms) {
-        double actualSeconds = concurrency * factor;
+        double actualSeconds = getSlowDownFactor();
         return Math.round(ms * actualSeconds);
+    }
+    
+    /**
+     * Get the factor by which we slow down time.
+     * Default is {@code 1.0} (no difference). Use {@code >1} in case of slower environment, {@<1} in case of faster one.
+     * @return the factor by which we slow down time.
+     */
+    public double getSlowDownFactor() {
+        return concurrency * factor;
     }
 }


### PR DESCRIPTION
Upgrades selenium to `3.141.59` 

I don't actually need this - but in the process of actually trying to work out what the issue I was observing was I tried using the latest - turns out the issue was with the docker container & env I was using to run firefox.

so no urgency, but would probably need doing at some point so filing so that the work does not have to be duplicated.