### PR TITLE
JENKINS-62871 Fix ssh slaves with tables to divs

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshCredentialDialog.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshCredentialDialog.java
@@ -6,13 +6,11 @@ import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 import org.jenkinsci.test.acceptance.po.PageObject;
 import org.jenkinsci.test.acceptance.selenium.Scroller;
 import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshCredentialDialog.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshCredentialDialog.java
@@ -4,6 +4,7 @@ import org.jenkinsci.test.acceptance.plugins.credentials.Credential;
 import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 import org.jenkinsci.test.acceptance.po.PageObject;
+import org.jenkinsci.test.acceptance.selenium.Scroller;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
@@ -63,12 +64,8 @@ public class SshCredentialDialog extends PageAreaImpl {
 
         final Actions builder = new Actions(driver);
 
-        // move to element doesn't seem to be working properly
-        ((JavascriptExecutor) driver).executeScript(
-                "arguments[0].scrollIntoView();", addSubmitButton
-        );
-
-        builder.moveToElement(addSubmitButton).click(addSubmitButton);
+        new Scroller().scrollIntoView(addSubmitButton, driver);
+        addSubmitButton.click();
         builder.perform();
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshCredentialDialog.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshCredentialDialog.java
@@ -5,6 +5,7 @@ import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 import org.jenkinsci.test.acceptance.po.PageObject;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
@@ -61,6 +62,12 @@ public class SshCredentialDialog extends PageAreaImpl {
         final WebElement addSubmitButton = find(addSubmitButtonLocator);
 
         final Actions builder = new Actions(driver);
+
+        // move to element doesn't seem to be working properly
+        ((JavascriptExecutor) driver).executeScript(
+                "arguments[0].scrollIntoView();", addSubmitButton
+        );
+
         builder.moveToElement(addSubmitButton).click(addSubmitButton);
         builder.perform();
     }


### PR DESCRIPTION
With tables to divs the page is longer, `moveToElement` doesn't seem to work with our credentials dialog popup.

This fixes it

cc @fqueiruga @olivergondza 