### PR TITLE
JENKINS-62866 Fix form validation - tables to divs

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/FormValidation.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/FormValidation.java
@@ -81,7 +81,7 @@ public class FormValidation {
 
             // Wait for validation area to stop being <div></div>
             validationArea = control.waitFor().until(() -> {
-                WebElement va = element.findElement(control.by.xpath("./../../following-sibling::tr/td[2]"));
+                WebElement va = element.findElement(control.by.xpath("./../../following-sibling::tr/td[2] | ./../following-sibling::div"));
                 try {
                     va.findElement(control.by.xpath("./div"));
                     return va;


### PR DESCRIPTION
This makes tests that check form validation work when using tables to divs PR.

Specifically fixes the jcasc test

https://issues.jenkins-ci.org/browse/JENKINS-62866