### PR TITLE
[JENKINS-62822] Add PasswordParameter overriding the 'default' control path

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PasswordParameter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PasswordParameter.java
@@ -1,0 +1,28 @@
+package org.jenkinsci.test.acceptance.po;
+
+import hudson.util.VersionNumber;
+
+@Describable("Password Parameter")
+public class PasswordParameter extends Parameter {
+
+    public PasswordParameter(Job job, String path) {
+        super(job, path);
+    }
+
+    @Override
+    public void fillWith(Object v) {
+        control("value").set(v.toString());
+    }
+
+    //since JENKINS-61808 and jenkins 2.236 the path for "Default" input changed
+    @Override
+    public Parameter setDefault(String value) {
+        if (injector.getInstance(Jenkins.class).getVersion().isOlderThan(new VersionNumber("2.236"))){
+            return super.setDefault(value);
+        } else {
+            //the control path changed after JENKINS-61808 and 2.236
+            control("defaultValueAsSecret").set(value);
+            return this;
+        }
+    }
+}

--- a/src/test/java/core/FreestyleJobTest.java
+++ b/src/test/java/core/FreestyleJobTest.java
@@ -12,6 +12,7 @@ import org.jenkinsci.test.acceptance.po.BuildWithParameters;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.ListView;
+import org.jenkinsci.test.acceptance.po.PasswordParameter;
 import org.jenkinsci.test.acceptance.po.ShellBuildStep;
 import org.jenkinsci.test.acceptance.po.StringParameter;
 import org.jenkinsci.test.acceptance.po.TimerTrigger;
@@ -154,6 +155,7 @@ public class FreestyleJobTest extends AbstractJUnitTest {
         FreeStyleJob j = jenkins.jobs.create(FreeStyleJob.class);
         j.configure();
         j.addParameter(StringParameter.class).setName("text").setDefault("foo").setDescription("Bar");
+        j.addParameter(PasswordParameter.class).setName("password").setDefault("foopass").setDescription("apass");
         j.addShellStep("echo \">$text<\"");
         j.save();
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-62822

The path to the default value of the Password parameters on Jobs value changed with https://github.com/jenkinsci/jenkins/pull/4630/files#diff-bb80f35e7698754c0c72d989e4f04406.

The ATH PO for the [Parameter](https://github.com/jenkinsci/acceptance-test-harness/blob/master/src/main/java/org/jenkinsci/test/acceptance/po/Parameter.java) was previously providing a `setDefaultValue` compatible, but with this change the path to the input is no longer valid. Now it has to be [`defaultValueAsSecret`](https://github.com/daniel-beck/jenkins/blob/13d242af0472e99757770846dc9a0022df40ada2/core/src/main/resources/hudson/model/PasswordParameterDefinition/config.jelly#L32)



As there was no default implementation for the Password parameter, any downstream test had to create it, and with this change, those implementations are failing. 

As this Password parameter is implemented in jenkins core, it makes sense to provide its PO upstream and deal with any breaking change here.

