### PR TITLE
[JENKINS-61477] fix 2.176.x backward compatibility

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -273,7 +273,7 @@ public class PluginManager extends ContainerPageObject {
 
         // Jenkins will be restarted if necessary
         boolean hasBeenRestarted = new UpdateCenter(jenkins).waitForInstallationToComplete(specs);
-        if (!hasBeenRestarted && specs.length > 0 && !jenkins.getVersion().isOlderThan(new VersionNumber("2.189"))) {
+        if (!hasBeenRestarted && specs.length > 0 && jenkins.getVersion().isNewerThan(new VersionNumber("2.188"))) {
             jenkins.getLogger("all").waitForLogged(Pattern.compile("Completed installation of .*"), 1000);
         }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -170,7 +170,7 @@ public class PluginManager extends ContainerPageObject {
         }
         return true;
     }
-    
+
     /**
      * Installs specified plugins.
      *
@@ -273,7 +273,7 @@ public class PluginManager extends ContainerPageObject {
 
         // Jenkins will be restarted if necessary
         boolean hasBeenRestarted = new UpdateCenter(jenkins).waitForInstallationToComplete(specs);
-        if (!hasBeenRestarted && specs.length > 0) {
+        if (!hasBeenRestarted && specs.length > 0 && !jenkins.getVersion().isOlderThan(new VersionNumber("2.189"))) {
             jenkins.getLogger("all").waitForLogged(Pattern.compile("Completed installation of .*"), 1000);
         }
 
@@ -334,7 +334,7 @@ public class PluginManager extends ContainerPageObject {
                     .addBinaryBody("name", localFile, APPLICATION_OCTET_STREAM, "x.jpi")
                     .build();
             post.setEntity(e);
-    
+
             HttpResponse response = httpclient.execute(post);
             if (response.getStatusLine().getStatusCode() >= 400) {
                 throw new IOException("Failed to upload plugin: " + response.getStatusLine() + "\n" +


### PR DESCRIPTION
See discussion in SonarSource/jenkins-sonar-plugin#158.

ATH 1.73+ is not backward-compatible with Jenkins prior to 2.189, because of #566 (fix for [JENKINS-61477](https://issues.jenkins-ci.org/browse/JENKINS-61477)).
It is now waiting for a log message after installing plugins ("*Completed installation of X plugins*"), but this message has only been introduced in 2.189, via jenkinsci/jenkins@5169f14019, in jenkinsci/jenkins#4124.

This PR disables waiting for this message when using an older Jenkins version.

CC: @uhafner, @olivergondza (from #566)