### PR TITLE
Fix racecondition when saving forms

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
@@ -30,6 +30,8 @@ import com.google.inject.Injector;
 
 import groovy.lang.Closure;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.jenkinsci.test.acceptance.Matchers.*;
@@ -126,8 +128,9 @@ public abstract class ConfigurablePageObject extends PageObject {
     public abstract URL getConfigUrl();
 
     public void save() {
-        clickButton("Save");
-        assertThat(driver, not(hasContent("This page expects a form submission")));
+        WebElement e = find(by.button("Save"));
+        e.click();
+        waitFor(e).until(CapybaraPortingLayerImpl::isStale);
     }
 
     public void apply() {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
@@ -111,12 +111,12 @@ public class GlobalSecurityConfig extends ContainerPageObject {
         // this causes a hard to understand "TypeError: a is null"
 
         // we do no know if this will happen or not as it depends what options they may have set so we can not waitFor a eleement to be present.
-        // instead we make sure that there is no element from the intermediary page. 
+        // instead we make sure that there is no element from the intermediary page.
 
         super.save();
 
         // saving security will either cause the page to go back to /manage or to be redirected with some HTML (not a 30x) to a login page...
-        // we know we have a page load here as the submit button is stale - so we need to wait until we are sure 
+        // we know we have a page load here as the submit button is stale - so we need to wait until we are sure
         // we do not have the script redirect page by looking for the absence of a <meta> tag with attribute "http-equiv='refresh'"
         try {
             WebElement metaRefresh = findIfNotVisible(by.xpath("/html/head/meta[@http-equiv='refresh']"));


### PR DESCRIPTION
when saving the global configuration if you are going from an unsecured
to secured instance then you will have 2 page loads

the first will be the action of saving causing a navigate to /manage on
completion.  however this may now be access controlled, so rather than
the normal manage page you may get the jenkins 403 page which is a very
plain HTML page with a meta refresh and some javascript of a similar
line that will then cause the page to navigate to the login page.

so when cehcking that "the page expects a form submission" text there is
a race condition as that is performed in 2 parts.
1) getting the root element (by.css("html")
2) getting the text of that element

however if you have just secured Jenkins in the manage page then you
could get the html element of the redirect page before the javascript
kicks in, and then when getting the text of that the page has reloaded
so the element is stale.

What makes this more ugly is as we are using css matching the error is
unhelpful
`TypeError: a in null`
changing the `by.css` to an `by.xpath` getting `"/"` showed a
`StaleElementException` which led to this discovery.

so generially `save` no longer checks if the page expects a form
submission (not sure what that was expecting to catch)

and the security page object has some extra code so that we wait until
any redirect due to 403 has been handled.