### PR TITLE
Upgrade browser proxy to an active fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,14 +33,14 @@
     <findbugs.skip>true</findbugs.skip>
 
     <selenium.version>3.141.59</selenium.version>
-    <guava.version>25.0-jre</guava.version> <!-- aligned with selenium -->
+    <guava.version>28.2-jre</guava.version> <!-- aligned with selenium -->
     <aether.version>0.9.0.v20140226</aether.version>
+    <jackson.version>2.10.3</jackson.version>
     <maven.version>3.1.0</maven.version>
     <groovy.version>2.3.1</groovy.version>
     <monte.version>0.7.7.0</monte.version>
     <mockito.version>1.10.19</mockito.version>
-    <slf4j.version>1.7.25</slf4j.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.30</slf4j.version>
   </properties>
 
   <repositories>
@@ -243,7 +243,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.4</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
@@ -360,7 +360,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>2.0.3</version>
+      <version>3.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
@@ -410,9 +410,9 @@
     </dependency>
 
     <dependency>
-      <groupId>net.lightbody.bmp</groupId>
-      <artifactId>browsermob-core</artifactId>
-      <version>2.1.5</version>
+      <groupId>com.browserup</groupId>
+      <artifactId>browserup-proxy-core</artifactId>
+      <version>2.1.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.bouncycastle</groupId>
@@ -441,12 +441,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.8</version>
+        <version>3.8.1</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.10</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -15,8 +15,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
-import net.lightbody.bmp.BrowserMobProxy;
-import net.lightbody.bmp.client.ClientUtil;
+import com.browserup.bup.BrowserUpProxy;
+import com.browserup.bup.client.ClientUtil;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -142,6 +142,7 @@ public class FallbackConfig extends AbstractModule {
             ChromeOptions options = new ChromeOptions();
             options.setExperimentalOption("prefs", prefs);
             if (isCaptureHarEnabled()) {
+                options.setAcceptInsecureCerts(true);
                 options.setProxy(createSeleniumProxy(testName.get()));
             }
 
@@ -243,9 +244,9 @@ public class FallbackConfig extends AbstractModule {
     }
 
     private Proxy createSeleniumProxy(String testName) {
-        BrowserMobProxy browserMobProxy = HarRecorder.getBrowserMobProxy();
-        browserMobProxy.newHar(testName);
-        return ClientUtil.createSeleniumProxy(browserMobProxy);
+        BrowserUpProxy proxy = HarRecorder.getProxy();
+        proxy.newHar(testName);
+        return ClientUtil.createSeleniumProxy(proxy);
     }
 
     private void setDriverPropertyIfMissing(final String driverCommand, final String property) {

--- a/src/main/java/org/jenkinsci/test/acceptance/recorder/HarRecorder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/recorder/HarRecorder.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.test.acceptance.recorder;
 
-import net.lightbody.bmp.BrowserMobProxy;
-import net.lightbody.bmp.BrowserMobProxyServer;
-import net.lightbody.bmp.core.har.Har;
-import net.lightbody.bmp.proxy.CaptureType;
+import com.browserup.bup.BrowserUpProxy;
+import com.browserup.bup.BrowserUpProxyServer;
+import com.browserup.bup.proxy.CaptureType;
+import com.browserup.harreader.model.Har;
 import org.jenkinsci.test.acceptance.junit.FailureDiagnostics;
 import org.jenkinsci.test.acceptance.junit.GlobalRule;
 import org.jenkinsci.test.acceptance.utils.SystemEnvironmentVariables;
@@ -66,15 +66,20 @@ public class HarRecorder extends TestWatcher {
 
     static State CAPTURE_HAR = value(SystemEnvironmentVariables.getPropertyVariableOrEnvironment("RECORD_BROWSER_TRAFFIC", FAILURES_ONLY.getValue()));
 
-    private static BrowserMobProxy proxy;
+    private static BrowserUpProxy proxy;
 
-    public static BrowserMobProxy getBrowserMobProxy() {
+    public static BrowserUpProxy getProxy() {
         if (proxy == null) {
             // start the proxy
-            proxy = new BrowserMobProxyServer();
-            proxy.start(0);
+            proxy = new BrowserUpProxyServer();
             // enable more detailed HAR capture, if desired (see CaptureType for the complete list)
-            proxy.enableHarCaptureTypes(CaptureType.REQUEST_CONTENT, CaptureType.RESPONSE_CONTENT);
+            proxy.enableHarCaptureTypes(
+                    CaptureType.REQUEST_HEADERS,
+                    CaptureType.REQUEST_CONTENT,
+                    CaptureType.RESPONSE_HEADERS,
+                    CaptureType.RESPONSE_CONTENT
+            );
+            proxy.start();
         }
         return proxy;
     }
@@ -106,6 +111,7 @@ public class HarRecorder extends TestWatcher {
 
     private void recordHar() {
         if (proxy != null) {
+            proxy.stop();
             Har har = proxy.getHar();
             File file = diagnostics.touch("jenkins.har");
             try {

--- a/src/test/java/org/jenkinsci/test/acceptance/recorder/HarRecorderTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/recorder/HarRecorderTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.test.acceptance.recorder;
 
-import net.lightbody.bmp.BrowserMobProxy;
+import com.browserup.bup.BrowserUpProxy;
 import org.jenkinsci.test.acceptance.junit.FailureDiagnostics;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,7 +22,7 @@ public class HarRecorderTest {
         Description desc = description();
         HarRecorder harRecorder = rule(desc);
         HarRecorder.CAPTURE_HAR = HarRecorder.State.FAILURES_ONLY;
-        BrowserMobProxy proxy = HarRecorder.getBrowserMobProxy();
+        BrowserUpProxy proxy = HarRecorder.getProxy();
         proxy.newHar("jenkins");
 
         System.out.println("Good Bye World");


### PR DESCRIPTION
* [Browsermob proxy](https://github.com/lightbody/browsermob-proxy) hasn't been touched for 3 years. Migrating to [browserup proxy](https://github.com/browserup/browserup-proxy) which seems to be more active.
* Update dependencies as needed.
* trust all certificates on chrome (to align with ff behaviour)
* capture request/response headers as well