### PR TITLE
Fix BuildHistoryTest by reverting "Kill SanityChecker"

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -30,6 +30,7 @@ import org.jenkinsci.test.acceptance.guice.TestName;
 import org.jenkinsci.test.acceptance.guice.TestScope;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.recorder.HarRecorder;
+import org.jenkinsci.test.acceptance.selenium.SanityChecker;
 import org.jenkinsci.test.acceptance.selenium.Scroller;
 import org.jenkinsci.test.acceptance.server.JenkinsControllerPoolProcess;
 import org.jenkinsci.test.acceptance.server.PooledJenkinsController;
@@ -300,6 +301,7 @@ public class FallbackConfig extends AbstractModule {
         }
 
         final EventFiringWebDriver d = new EventFiringWebDriver(base);
+        d.register(new SanityChecker());
         d.register(new Scroller());
 
         try {

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/DiagnosticRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/DiagnosticRule.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.test.acceptance.controller.JenkinsController;
 import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
+import org.jenkinsci.test.acceptance.selenium.SanityChecker;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.openqa.selenium.NoSuchElementException;
@@ -29,7 +30,7 @@ public class DiagnosticRule extends TestWatcher {
     protected void failed(Throwable t, Description description) {
         takeScreenshot();
 
-        if (causedBy(t, NoSuchElementException.class)) {
+        if (causedBy(t, NoSuchElementException.class) || causedBy(t, SanityChecker.Failure.class)) {
             writeHtmlPage();
         }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/selenium/SanityChecker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/selenium/SanityChecker.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.test.acceptance.selenium;
+
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.UnhandledAlertException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.events.AbstractWebDriverEventListener;
+
+/**
+ * Make sure there are no exceptions shown after user interaction.
+ *
+ * @author ogondza
+ */
+public class SanityChecker extends AbstractWebDriverEventListener {
+    private final static By SPECIFIER = By.xpath(
+            "//h1/span[contains(., 'Oops!')]/../following-sibling::div/h2[text()='Stack trace']/following-sibling::pre"
+    );
+
+    @Override
+    public void afterNavigateTo(String url, WebDriver driver) {
+        checkSanity(driver);
+    }
+
+    @Override
+    public void beforeNavigateTo(String url, WebDriver driver) {
+        checkSanity(driver);
+    }
+
+    @Override
+    public void beforeClickOn(WebElement element, WebDriver driver) {
+        checkSanity(driver);
+    }
+
+    private void checkSanity(WebDriver driver) {
+        if (isFastPath(driver)) return;
+
+        // Exception
+        List<WebElement> elements = driver.findElements(SPECIFIER);
+        if (!elements.isEmpty()) {
+            String trace = elements.get(0).getText();
+            throw new Failure("Jenkins error detected at " + driver.getCurrentUrl() + ":\n" + trace);
+        }
+
+        // POST required
+        WebElement postForm = driver.findElement(By.cssSelector("form > input[value='Try POSTing']"));
+        if (postForm != null) throw new Failure("Post required at " + driver.getCurrentUrl());
+    }
+
+    /**
+     * Quickly determine if the driver is definitely in the safe state.
+     *
+     * <p>
+     * The expectation is that the most of the time this would return true,
+     * and reduces the overhead of {@link SanityChecker}.
+     */
+    private boolean isFastPath(WebDriver driver) {
+        try {
+            final String pageSource = driver.getPageSource();
+            return !(pageSource.contains("Oops!") || pageSource.contains("Try POSTing"));
+        } catch (UnhandledAlertException ex) {
+            // If alert is expected we can not check sanity and should leave it alone for test to handle. If it is not
+            // expected, the code is likely going to fail anyway but it is better to do on less surprising place
+            return true;
+        }
+    }
+
+    public static final class Failure extends RuntimeException {
+
+        private static final long serialVersionUID = 4077465978093533078L;
+
+        public Failure(String msg) {
+            super(msg);
+        }
+    }
+}


### PR DESCRIPTION
Tests on class BuildHistoryTest are failing consistently. The error on every PR build:

https://ci.jenkins.io/job/Core/job/acceptance-test-harness/view/change-requests/job/PR-604/3/testReport/core/BuildHistoryTest/java_8_split9___global_build_history/

```
org.openqa.selenium.UnhandledAlertException: 
Dismissed user prompt dialog: SyntaxError: JSON.parse: unexpected end of data at line 1 column 1 of the JSON data: 

...

*** Element info: {Using=xpath, value=//a[@href][img/@alt = 'Console output']}
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:120)
...


```

After bisecting the commits, if we revert https://github.com/jenkinsci/acceptance-test-harness/commit/b80802be284831729f47c4d2f7d4d9df04633851 the tests pass again. I cannot figure out the concrete problem though, it seems like a race condition. If you just remove `|| causedBy(t, SanityChecker.Failure.class` on `DiagnosticRule` the tests fail again.

Filing this to avoid the tests failures.

cc: @olivergondza, @imonteroperez, @bmunozm, @raul-arabaolaza