### PR TITLE
Trust all servers to avoid SSL errors in logs

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/recorder/HarRecorder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/recorder/HarRecorder.java
@@ -79,6 +79,7 @@ public class HarRecorder extends TestWatcher {
                     CaptureType.RESPONSE_HEADERS,
                     CaptureType.RESPONSE_CONTENT
             );
+            proxy.setTrustAllServers(true);
             proxy.start();
         }
         return proxy;


### PR DESCRIPTION
Without this property on the proxy, one will see errors in their logs when the server presents an insecure cert:

![image](https://user-images.githubusercontent.com/11740869/94147711-ab64df00-fe43-11ea-8704-8af294e65957.png)

```
2020-09-23 15:26:07,161 [LittleProxy-0-ProxyToServerWorker-0] ERROR  (ProxyToServerConnection.java:465) org.littleshoot.proxy.impl.ProxyToServerConnection - (DISCONNECTED) [id: 0xe2dbfcdd, L:0.0.0.0/0.0.0.0:51215 ! R:/35.199.14.121:443]: Caught an exception on ProxyToServerConnection
io.netty.handler.codec.DecoderException: javax.net.ssl.SSLHandshakeException: General SSLEngine problem
```