### PR TITLE
[JENKINS-64038] environment variables are Strings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ for (int i = 0; i < (BUILD_NUMBER as int); i++) {
 def branches = [:]
 
 def splits
-if (env.BUILD_NUMBER == 1) {
+if (env.BUILD_NUMBER == '1') {
     node() { // When there are no previous build, we need to estimate splits from files which require workspace
         checkout scm
         splits = splitTests estimateTestsFromFiles: true, parallelism: count(10)


### PR DESCRIPTION
The initial build is not splitting correctly.

this attempts to fix that based on a guess that the if is failing as it
is comparing a String to an int.