### PR TITLE
[JENKINS-64038] we need to split the tests when there are no reference builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ if (currentBuild.previousNotFailedBuild == null) {
         splits = splitTests estimateTestsFromFiles: true, parallelism: count(10)
     }
 } else {
-    echo "reference build should be : ${currentBuild.previousNotFailedBuild}"
+    echo "reference build should be : ${currentBuild.previousNotFailedBuild.projectName}:${currentBuild.previousNotFailedBuild.number}, with state ${currentBuild.previousNotFailedBuild.result}"
     splits = splitTests count(10)
 }
 for (int i = 0; i < splits.size(); i++) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ def needSplittingFromWorkspace = true
 for (build = currentBuild.previousCompletedBuild; build != null; build = build.previousCompletedBuild) {
     if (build.resultIsBetterOrEqualTo("UNSTABLE")) {
         // we have a reference build
-        echo "not splitting from workkspace, reference build should be : ${currentBuild.previousNotFailedBuild.projectName}:${currentBuild.previousNotFailedBuild.number}, with state ${currentBuild.previousNotFailedBuild.result}"
+        echo "not splitting from workkspace, reference build should be : ${build.previousNotFailedBuild.projectName}:${build.previousNotFailedBuild.number}, with state ${build.previousNotFailedBuild.result}"
         needSplittingFromWorkspace = false
         break
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ for (int i = 0; i < (BUILD_NUMBER as int); i++) {
 def branches = [:]
 
 def splits
-if (env.BUILD_NUMBER == '1') {
+if (currentBuild.previousNotFailedBuild != null) {
     node() { // When there are no previous build, we need to estimate splits from files which require workspace
         checkout scm
         splits = splitTests estimateTestsFromFiles: true, parallelism: count(10)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ def needSplittingFromWorkspace = true
 for (build = currentBuild.previousCompletedBuild; build != null; build = build.previousCompletedBuild) {
     if (build.resultIsBetterOrEqualTo("UNSTABLE")) {
         // we have a reference build
-        echo "not splitting from workkspace, reference build should be : ${build.previousNotFailedBuild.projectName}:${build.previousNotFailedBuild.number}, with state ${build.previousNotFailedBuild.result}"
+        echo "not splitting from workspace, reference build should be : ${build.projectName}:${build.number}, with state ${build.result}"
         needSplittingFromWorkspace = false
         break
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ for (int i = 0; i < (BUILD_NUMBER as int); i++) {
 def branches = [:]
 
 def splits
-if (currentBuild.previousNotFailedBuild != null) {
+if (currentBuild.previousNotFailedBuild == null) {
     node() { // When there are no previous build, we need to estimate splits from files which require workspace
         checkout scm
         splits = splitTests estimateTestsFromFiles: true, parallelism: count(10)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ if (currentBuild.previousNotFailedBuild == null) {
         splits = splitTests estimateTestsFromFiles: true, parallelism: count(10)
     }
 } else {
+    echo "reference build should be : ${currentBuild.previousNotFailedBuild}"
     splits = splitTests count(10)
 }
 for (int i = 0; i < splits.size(); i++) {


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-64038

if previous builds are aborted or failed and the `splitTests` step has
no reference we still need to split the tests - so fallback in any case
there is not a previously completed non failed build.

this is an obvious improvement over #612 