### PR TITLE
deflake `Control.click` and `Control.selectDropdownMenu`

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
@@ -1,13 +1,15 @@
 package org.jenkinsci.test.acceptance.po;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.test.acceptance.selenium.Scroller;
 import org.openqa.selenium.By;
+import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Select;
@@ -103,7 +105,14 @@ public class Control extends CapybaraPortingLayerImpl {
      * @see #clickAndWaitToBecomeStale(Duration)
      */
     public void click() {
-        resolve().click();
+        WebElement we = resolve();
+        // button may be obscured by say the "Save Apply" screen so we wait as Selenium will do a scroll but the CSS 
+        // can take a while to update the layout \o/
+        waitFor(we).
+               withTimeout(time.seconds(1), TimeUnit.MILLISECONDS).
+               pollingEvery(time.milliseconds(100), TimeUnit.MILLISECONDS).
+               ignoring(ElementClickInterceptedException.class).
+               until(() -> {we.click(); return true;});
     }
 
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
@@ -196,6 +196,8 @@ public class Control extends CapybaraPortingLayerImpl {
     public void selectDropdownMenu(Class type) {
         click();
         WebElement we = findCaption(type,findDropDownMenuItem);
+        // the element may not yet be visible so wait for it to become shown after the click above
+        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).until(() -> we.isDisplayed());
         we.click();
         // wait until the menu is hidden
         waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).until(() -> !we.isDisplayed());
@@ -204,6 +206,8 @@ public class Control extends CapybaraPortingLayerImpl {
     public void selectDropdownMenu(String displayName) {
         click();
         WebElement we = findDropDownMenuItem.find(displayName);
+        // the element may not yet be visible so wait for it to become shown after the click above
+        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).until(() -> we.isDisplayed());
         we.click();
         // wait until the menu is hidden
         waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).until(() -> !we.isDisplayed());
@@ -231,13 +235,8 @@ public class Control extends CapybaraPortingLayerImpl {
                             ");"
             );
             // we can not use `Select` as these are YUI menus and we need to wait for it to be visible
-            WebElement context = waitFor(menuButton).
-                    pollingEvery(100, TimeUnit.MILLISECONDS).
-                    withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).
-                    ignoring(NoSuchElementException.class).
-                    until((me) -> findElement(me, by.xpath("ancestor::*[contains(@class,'yui-menu-button')]/..")));
-
-            WebElement e = findElement(context, by.link(caption));
+            WebElement menu = findElement(menuButton, by.xpath("ancestor::*[contains(@class,'yui-menu-button')]/.."));
+            WebElement e = findElement(menu, by.link(caption));
             return e;
         }
     };

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
@@ -195,15 +195,18 @@ public class Control extends CapybaraPortingLayerImpl {
      */
     public void selectDropdownMenu(Class type) {
         click();
-        findCaption(type,findDropDownMenuItem).click();
-        elasticSleep(1000);
+        WebElement we = findCaption(type,findDropDownMenuItem);
+        we.click();
+        // wait until the menu is hidden
+        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).until(() -> !we.isDisplayed());
     }
 
     public void selectDropdownMenu(String displayName) {
         click();
-        elasticSleep(1000);
-        findDropDownMenuItem.find(displayName).click();
-        elasticSleep(1000);
+        WebElement we = findDropDownMenuItem.find(displayName);
+        we.click();
+        // wait until the menu is hidden
+        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).until(() -> !we.isDisplayed());
     }
 
     /**
@@ -227,8 +230,13 @@ public class Control extends CapybaraPortingLayerImpl {
                             "    }" +
                             ");"
             );
+            // we can not use `Select` as these are YUI menus and we need to wait for it to be visible
+            WebElement context = waitFor(menuButton).
+                    pollingEvery(100, TimeUnit.MILLISECONDS).
+                    withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).
+                    ignoring(NoSuchElementException.class).
+                    until((me) -> findElement(me, by.xpath("ancestor::*[contains(@class,'yui-menu-button')]/..")));
 
-            WebElement context = findElement(menuButton, by.xpath("ancestor::*[contains(@class,'yui-menu-button')]/.."));
             WebElement e = findElement(context, by.link(caption));
             return e;
         }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
@@ -109,8 +109,8 @@ public class Control extends CapybaraPortingLayerImpl {
         // button may be obscured by say the "Save Apply" screen so we wait as Selenium will do a scroll but the CSS 
         // can take a while to update the layout \o/
         waitFor(we).
-               withTimeout(time.seconds(1), TimeUnit.MILLISECONDS).
-               pollingEvery(time.milliseconds(100), TimeUnit.MILLISECONDS).
+               withTimeout(1, TimeUnit.SECONDS).
+               pollingEvery(100, TimeUnit.MILLISECONDS).
                ignoring(ElementClickInterceptedException.class).
                until(() -> {we.click(); return true;});
     }
@@ -193,24 +193,24 @@ public class Control extends CapybaraPortingLayerImpl {
      * @param type
      *      Class with {@link Describable} annotation.
      */
-    public void selectDropdownMenu(Class type) {
+    public void selectDropdownMenu(Class<?> type) {
         click();
         WebElement we = findCaption(type,findDropDownMenuItem);
         // the element may not yet be visible so wait for it to become shown after the click above
-        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).until(() -> we.isDisplayed());
+        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(1, TimeUnit.SECONDS).until(() -> we.isDisplayed());
         we.click();
         // wait until the menu is hidden
-        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).until(() -> !we.isDisplayed());
+        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(1, TimeUnit.SECONDS).until(() -> !we.isDisplayed());
     }
 
     public void selectDropdownMenu(String displayName) {
         click();
         WebElement we = findDropDownMenuItem.find(displayName);
         // the element may not yet be visible so wait for it to become shown after the click above
-        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).until(() -> we.isDisplayed());
+        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(1, TimeUnit.SECONDS).until(() -> we.isDisplayed());
         we.click();
         // wait until the menu is hidden
-        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(time.milliseconds(1000), TimeUnit.MILLISECONDS).until(() -> !we.isDisplayed());
+        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(1, TimeUnit.SECONDS).until(() -> !we.isDisplayed());
     }
 
     /**
@@ -245,7 +245,7 @@ public class Control extends CapybaraPortingLayerImpl {
      * For alternative use when the 'yui-menu-button' doesn't exist.
      * @param type
      */
-    public void selectDropdownMenuAlt(Class type) {
+    public void selectDropdownMenuAlt(Class<?> type) {
         findCaption(type,findDropDownMenuItemBySelector);
         elasticSleep(1000);
     }


### PR DESCRIPTION
fixes various flakes.

`click()` was flaky when the WebElement had to be scrolled into view due to obsuring by the "Save" and "Apply" buttons (so we waitfor the click to happen).

the dropDown selector was flaky and would sometimes not be visible - so also changed to using waits (and update the code that was sleeping to use wait to make the tests faster where possible)