### PR TITLE
Adding a test PluginManager.checkForUpdates() to reproduce 2.263 issue.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -198,8 +198,7 @@ public class MockUpdateCenter implements AutoCleaned {
         // TODO figure out how to deal with Docker-based controllers which would need to have an IP address for the host
         String override = "http://" + server.getInetAddress().getHostAddress() + ":" + server.getLocalPort() + "/update-center.json";
         LOGGER.log(Level.INFO, "replacing update site {0} with {1}", new Object[] {original, override});
-        jenkins.runScript("DownloadService.signatureCheck = false; Jenkins.instance.updateCenter.sites.replaceBy"
-                           + "([new UpdateSite(UpdateCenter.ID_DEFAULT, '%s')])", override);
+        jenkins.runScript("DownloadService.signatureCheck = false; Jenkins.instance.updateCenter.sites.replaceBy([new UpdateSite(UpdateCenter.ID_DEFAULT, '%s')])", override);
     }
 
     private ExceptionLogger serverExceptionHandler() {

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -198,7 +198,8 @@ public class MockUpdateCenter implements AutoCleaned {
         // TODO figure out how to deal with Docker-based controllers which would need to have an IP address for the host
         String override = "http://" + server.getInetAddress().getHostAddress() + ":" + server.getLocalPort() + "/update-center.json";
         LOGGER.log(Level.INFO, "replacing update site {0} with {1}", new Object[] {original, override});
-        jenkins.runScript("DownloadService.signatureCheck = false; Jenkins.instance.updateCenter.sites.replaceBy([new UpdateSite(UpdateCenter.ID_DEFAULT, '%s')])", override);
+        jenkins.runScript("DownloadService.signatureCheck = false; Jenkins.instance.updateCenter.sites.replaceBy"
+                           + "([new UpdateSite(UpdateCenter.ID_DEFAULT, '%s')])", override);
     }
 
     private ExceptionLogger serverExceptionHandler() {

--- a/src/test/java/org/jenkinsci/test/acceptance/po/PluginManagerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/po/PluginManagerTest.java
@@ -14,4 +14,9 @@ public class PluginManagerTest extends AbstractJUnitTest {
         final File plugin = new File(getClass().getResource("ant-1.0.hpi").toURI());
         jenkins.getPluginManager().installPlugin(plugin);
     }
+
+    @Test
+    public void checkForUpdate() {
+        jenkins.getPluginManager().checkForUpdates();
+    }
 }


### PR DESCRIPTION
My issue is that the page reload when click on the "Check now" button on the Plugin management page is not detected by the driver (firefox 81.0.2 and Jenkins version 2.266).

- Add a test to run PluginManager.checkForUpdates()
- Use isStale instead of previous loop on webElement to wait for page to reload
- Changed comment message, as when the check now is in error there is just an additional div hapenned to the DOM, the page is the same that when on success.