### PR TITLE
Fix selector broken by case change in plugin

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/post_build_script/PostBuildScript.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/post_build_script/PostBuildScript.java
@@ -26,7 +26,7 @@ package org.jenkinsci.test.acceptance.plugins.post_build_script;
 import org.jenkinsci.test.acceptance.po.*;
 import org.openqa.selenium.By;
 
-@Describable({"Execute Scripts", "Execute a set of scripts", "[PostBuildScript] - Execute a set of scripts"})
+@Describable({"Execute scripts", "Execute a set of scripts", "[PostBuildScript] - Execute a set of scripts"})
 public class PostBuildScript extends AbstractStep implements PostBuildStep {
     private final Control buildResult = control("buildSteps/results");
 


### PR DESCRIPTION
postbuildscript-2.11.0 changed  the string "Execute Scripts" to "Execute scripts" ([see commit](https://github.com/jenkinsci/postbuildscript-plugin/commit/8d0170cd875f7a6f755d89f3e0cbeb0a27ad4a74#diff-ebd76acd1f0295f4a5d4d9e7d79957b24d1df54421520cf75ad44f873e3d93c3)). This broke the following tests

- `PostBuildScriptPluginTest#run_post_build_step`
- `PostBuildScriptPluginTest#skip_for_jobs_that_succeeded`

This PR fixes the selector
