### PR TITLE
Reduce flakiness during signup: Make signup to wait until the page is loaded

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsDatabaseSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsDatabaseSecurityRealm.java
@@ -23,6 +23,8 @@
  */
 package org.jenkinsci.test.acceptance.po;
 
+import java.time.Duration;
+
 import org.openqa.selenium.NoSuchElementException;
 import hudson.util.VersionNumber;
 
@@ -81,7 +83,7 @@ public class JenkinsDatabaseSecurityRealm extends SecurityRealm {
 
         public User signup(String name) {
             control(by.input("username")).set(name);
-            control(by.name("Submit")).click();
+            control(by.name("Submit")).clickAndWaitToBecomeStale(Duration.ofSeconds(120));
 
             return new User(getJenkins(), name);
         }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsDatabaseSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsDatabaseSecurityRealm.java
@@ -83,7 +83,7 @@ public class JenkinsDatabaseSecurityRealm extends SecurityRealm {
 
         public User signup(String name) {
             control(by.input("username")).set(name);
-            control(by.name("Submit")).clickAndWaitToBecomeStale(Duration.ofSeconds(120));
+            control(by.name("Submit")).clickAndWaitToBecomeStale();
 
             return new User(getJenkins(), name);
         }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsDatabaseSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsDatabaseSecurityRealm.java
@@ -23,8 +23,6 @@
  */
 package org.jenkinsci.test.acceptance.po;
 
-import java.time.Duration;
-
 import org.openqa.selenium.NoSuchElementException;
 import hudson.util.VersionNumber;
 


### PR DESCRIPTION
The signup is a source of flakiness because the control of the `signup` function is returned before making sure that the submission finished loading. This is addressing it, with the implicit timeout of the `clickAndWaitToBecomeStale`, which is 30s.