### PR TITLE
[JENKINS-62867] Fixes job filtering selection in views

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/dashboard_view/controls/JobFiltersArea.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/dashboard_view/controls/JobFiltersArea.java
@@ -12,9 +12,13 @@ import org.jenkinsci.test.acceptance.po.PageObject;
  */
 public class JobFiltersArea extends PageAreaImpl {
     /**
+     * Button to add a new status filter
+     */
+    private final Control addStatusFilter = control("/hetero-list-add[jobFilters]");
+    /**
      * Dropdown to select the type of {@link StatusFilter}.
      */
-    private final Control statusFilter = control("/statusFilter");
+    private final Control statusFilter = control("/jobFilters/statusFilter");
     /**
      * Checkbox to enable recursion in subfolders.
      */
@@ -44,8 +48,8 @@ public class JobFiltersArea extends PageAreaImpl {
      * @param statusFilter the filter type to use
      */
     public void setStatusFilter(StatusFilter statusFilter) {
+        this.addStatusFilter.selectDropdownMenu("Status Filter");
         this.statusFilter.select(statusFilter.getCaption());
-
     }
 
     /**
@@ -74,10 +78,6 @@ public class JobFiltersArea extends PageAreaImpl {
      * @author peter-mueller
      */
     public static enum StatusFilter {
-        /**
-         * Present all jobs in the dashboard.
-         */
-        ALL("All selected jobs"),
         /**
          * Only show enabled jobs.
          */


### PR DESCRIPTION
[JENKINS-62867](https://issues.jenkins.io/browse/JENKINS-62867)

Since  2.239 and jenkinsci/jenkins#4466, the job filter has its own view.