### PR TITLE
Try to fix stale test

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -344,6 +344,8 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
             return false;
         } catch (StaleElementReferenceException expected) {
             return true;
+        } catch (NoSuchElementException expected) {
+            return true;
         }
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -345,6 +345,7 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
         } catch (StaleElementReferenceException expected) {
             return true;
         } catch (NoSuchElementException expected) {
+            // work around https://github.com/SeleniumHQ/selenium/issues/8929
             return true;
         }
     }


### PR DESCRIPTION
After upgrading firefox to 83.0, I started seeing this stacktrace...

```
org.openqa.selenium.NoSuchElementException: 
 Web element reference not seen before: 1ec17ca6-ad5d-469a-ab36-c961982fc12a
 For documentation on this error, please visit: https://www.seleniumhq.org/exceptions/no_such_element.html
 Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
 System info: host: 'host', ip: '1.2.3.4', os.name: 'Linux', os.arch: 'amd64', os.version: '4.9.0-14-amd64', java.version: '1.8.0_275'
 Driver info: org.openqa.selenium.firefox.FirefoxDriver
 Capabilities {acceptInsecureCerts: true, browserName: firefox, browserVersion: 83.0, javascriptEnabled: true, moz:accessibilityChecks: false, moz:buildID: 20201112153044, moz:geckodriverVersion: 0.28.0, moz:headless: false, moz:processID: 2132, moz:profile: /tmp/rust_mozprofileuBQERw, moz:shutdownTimeout: 60000, moz:useNonSpecCompliantPointerOrigin: false, moz:webdriverClick: true, pageLoadStrategy: normal, platform: LINUX, platformName: LINUX, platformVersion: 4.9.0-14-amd64, proxy: Proxy(manual, http=host, rotatable: false, setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify}
 Session ID: f9c3668c-306b-4710-ae8c-749f30cf0768
 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
 	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.createException(W3CHttpResponseCodec.java:187)
 	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:122)
 	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:49)
 	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:158)
 	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:83)
 	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
 	at org.openqa.selenium.remote.RemoteWebElement.execute(RemoteWebElement.java:285)
 	at org.openqa.selenium.remote.RemoteWebElement.isEnabled(RemoteWebElement.java:156)
 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.lang.reflect.Method.invoke(Method.java:498)
 	at org.openqa.selenium.support.events.EventFiringWebDriver$EventFiringWebElement.lambda$new$0(EventFiringWebDriver.java:404)
 	at com.sun.proxy.$Proxy37.isEnabled(Unknown Source)
 	at org.openqa.selenium.support.events.EventFiringWebDriver$EventFiringWebElement.isEnabled(EventFiringWebDriver.java:457)
 	at org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl.isStale(CapybaraPortingLayerImpl.java:343)
 	at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:249)
 	at org.jenkinsci.test.acceptance.po.Control.clickAndWaitToBecomeStale(Control.java:127)
 	at org.jenkinsci.test.acceptance.po.Control.clickAndWaitToBecomeStale(Control.java:115)
 	at org.jenkinsci.test.acceptance.po.Login.doLogin(Login.java:35)
```