### PR TITLE
Move LDAP default configuration to Docker fixture.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer.java
@@ -34,8 +34,11 @@ public class LdapContainer extends DockerContainer {
         return "jenkins";
     }
 
+    /**
+     * @return default ldap connection details from current running docker LdapContainer.
+     */
     public LdapDetails createDefault() {
-        return new LdapDetails(getHost(), getPort(), getManagerDn(),getManagerPassword(), getRootDn());
+        return new LdapDetails(getHost(), getPort(), getManagerDn(), getManagerPassword(), getRootDn());
     }
 
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer.java
@@ -2,6 +2,7 @@ package org.jenkinsci.test.acceptance.docker.fixtures;
 
 import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
+import org.jenkinsci.test.acceptance.plugins.ldap.LdapDetails;
 
 /**
  * openLDAP (slapd) Container with a small user directory.
@@ -31,6 +32,10 @@ public class LdapContainer extends DockerContainer {
 
     public String getManagerPassword() {
         return "jenkins";
+    }
+
+    public LdapDetails createDefault() {
+        return new LdapDetails(getHost(), getPort(), getManagerDn(),getManagerPassword(), getRootDn());
     }
 
 }

--- a/src/test/java/plugins/LdapPluginTest.java
+++ b/src/test/java/plugins/LdapPluginTest.java
@@ -56,7 +56,7 @@ public class LdapPluginTest extends AbstractJUnitTest {
      * @return default ldap connection details
      */
     private LdapDetails createDefaults(LdapContainer ldapContainer) {
-        return new LdapDetails(ldapContainer.getHost(), ldapContainer.getPort(), ldapContainer.getManagerDn(), ldapContainer.getManagerPassword(), ldapContainer.getRootDn());
+        return ldapContainer.createDefault();
     }
     
     /**


### PR DESCRIPTION
Moving default creation of LDAP data to the docker fixture to allows to use it easily in tests.