### PR TITLE
Support form-element-path installation through rest api

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/controller/ExistingJenkinsController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/ExistingJenkinsController.java
@@ -20,8 +20,11 @@ public class ExistingJenkinsController extends JenkinsController {
     private final URL url;
     private boolean skipCheck;
 
+    /**
+     * Credentials before any {@link org.jenkinsci.test.acceptance.po.SecurityRealm} is applied by a test.
+     */
     @CheckForNull
-    private Credentials credentials;
+    private Credentials initialCredentials;
 
     @Inject
     private FormElementPath formElementPath;
@@ -30,11 +33,11 @@ public class ExistingJenkinsController extends JenkinsController {
         this(i, url, null, false);
     }
 
-    public ExistingJenkinsController(Injector i, String url, @CheckForNull Credentials credentials, boolean skipCheck) {
+    public ExistingJenkinsController(Injector i, String url, @CheckForNull Credentials initialCredentials, boolean skipCheck) {
         super(i);
         try {
             this.url = new URL(url);
-            this.credentials = credentials;
+            this.initialCredentials = initialCredentials;
             this.skipCheck = skipCheck;
         } catch (IOException e) {
             throw new AssertionError("Invalid URL: "+url,e);
@@ -44,7 +47,7 @@ public class ExistingJenkinsController extends JenkinsController {
     @Override
     public void startNow() {
         if (!skipCheck) {
-            formElementPath.ensure(url, credentials);
+            formElementPath.ensure(url, initialCredentials);
         }
     }
 
@@ -65,8 +68,8 @@ public class ExistingJenkinsController extends JenkinsController {
 
     @CheckForNull
     @Override
-    public Credentials getCredentials() {
-        return credentials;
+    public Credentials getInitialCredentials() {
+        return initialCredentials;
     }
 
     @Override
@@ -87,13 +90,13 @@ public class ExistingJenkinsController extends JenkinsController {
             String url = System.getenv("JENKINS_URL");
             String username = System.getenv("JENKINS_USERNAME");
             String password = System.getenv("JENKINS_PASSWORD");
-            UsernamePasswordCredentials credentials = null;
+            UsernamePasswordCredentials initialCredentials = null;
             if (username != null && password != null) {
-                credentials = new UsernamePasswordCredentials(username, password);
+                initialCredentials = new UsernamePasswordCredentials(username, password);
             }
             if (url==null)  url = "http://localhost:8080/";
 
-            return new ExistingJenkinsController(i, url, credentials, false);
+            return new ExistingJenkinsController(i, url, initialCredentials, false);
         }
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/ExistingJenkinsController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/ExistingJenkinsController.java
@@ -1,24 +1,15 @@
 package org.jenkinsci.test.acceptance.controller;
 
+import javax.annotation.CheckForNull;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
 
 import com.cloudbees.sdk.extensibility.Extension;
 import com.google.inject.Injector;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.jenkinsci.test.acceptance.utils.FormElementPath;
 
 /**
  * Run test against existing Jenkins instance.
@@ -26,14 +17,25 @@ import com.google.inject.Injector;
  * @author Kohsuke Kawaguchi
  */
 public class ExistingJenkinsController extends JenkinsController {
-    private final URL uploadUrl;
     private final URL url;
+    private boolean skipCheck;
+
+    @CheckForNull
+    private Credentials credentials;
+
+    @Inject
+    private FormElementPath formElementPath;
 
     public ExistingJenkinsController(Injector i, String url) {
+        this(i, url, null, false);
+    }
+
+    public ExistingJenkinsController(Injector i, String url, @CheckForNull Credentials credentials, boolean skipCheck) {
         super(i);
         try {
             this.url = new URL(url);
-            this.uploadUrl = new URL(url + "/pluginManager/api/xml");
+            this.credentials = credentials;
+            this.skipCheck = skipCheck;
         } catch (IOException e) {
             throw new AssertionError("Invalid URL: "+url,e);
         }
@@ -41,35 +43,9 @@ public class ExistingJenkinsController extends JenkinsController {
 
     @Override
     public void startNow() {
-        verifyThatFormPathElementPluginIsInstalled();
-    }
-
-    private void verifyThatFormPathElementPluginIsInstalled() {
-        try (CloseableHttpClient httpclient = new DefaultHttpClient()){
-            HttpPost post = new HttpPost(uploadUrl.toExternalForm());
-
-            List<NameValuePair> parameters = new ArrayList<NameValuePair>();
-            parameters.add(new BasicNameValuePair("depth", "1"));
-            parameters.add(new BasicNameValuePair("xpath", "/*/*/shortName|/*/*/version"));
-            parameters.add(new BasicNameValuePair("wrapper", "plugins"));
-            UrlEncodedFormEntity entity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            post.setEntity(entity);
-
-            HttpResponse response = httpclient.execute(post);
-            HttpEntity resEntity = response.getEntity();
-            String responseBody = EntityUtils.toString(resEntity);
-
-            if (!responseBody.contains("form-element-path")) {
-                failTestSuite(response.toString());
-            }
+        if (!skipCheck) {
+            formElementPath.ensure(url, credentials);
         }
-        catch (IOException exception) {
-            throw new AssertionError("Can't check if form-element-path plugin is installed", exception);
-        } 
-    }
-
-    private void failTestSuite(final String errorMessage) {
-        throw new RuntimeException("Test suite requires in pre-installed Jenkins plugin https://wiki.jenkins-ci.org/display/JENKINS/Form+Element+Path+Plugin\n" + errorMessage);
     }
 
     @Override
@@ -85,6 +61,12 @@ public class ExistingJenkinsController extends JenkinsController {
     @Override
     public URL getUrl() {
         return url;
+    }
+
+    @CheckForNull
+    @Override
+    public Credentials getCredentials() {
+        return credentials;
     }
 
     @Override
@@ -103,9 +85,15 @@ public class ExistingJenkinsController extends JenkinsController {
         @Override
         public JenkinsController create() {
             String url = System.getenv("JENKINS_URL");
+            String username = System.getenv("JENKINS_USERNAME");
+            String password = System.getenv("JENKINS_PASSWORD");
+            UsernamePasswordCredentials credentials = null;
+            if (username != null && password != null) {
+                credentials = new UsernamePasswordCredentials(username, password);
+            }
             if (url==null)  url = "http://localhost:8080/";
 
-            return new ExistingJenkinsController(i, url);
+            return new ExistingJenkinsController(i, url, credentials, false);
         }
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/JenkinsController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/JenkinsController.java
@@ -166,7 +166,7 @@ public abstract class JenkinsController implements IJenkinsController, AutoClean
     public abstract URL getUrl();
 
     @CheckForNull
-    public Credentials getCredentials() {
+    public Credentials getInitialCredentials() {
         return null;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/JenkinsController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/JenkinsController.java
@@ -1,18 +1,16 @@
 package org.jenkinsci.test.acceptance.controller;
 
+import javax.annotation.CheckForNull;
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import org.apache.commons.io.IOUtils;
-import org.codehaus.plexus.util.FileUtils;
+import org.apache.http.auth.Credentials;
 import org.jenkinsci.test.acceptance.guice.AutoCleaned;
 import org.jenkinsci.test.acceptance.log.LogListener;
 import org.jenkinsci.test.acceptance.log.LogPrinter;
@@ -53,7 +51,10 @@ public abstract class JenkinsController implements IJenkinsController, AutoClean
 
     private boolean isRunning;
 
+    public Injector injector;
+
     protected JenkinsController(Injector i) {
+        this.injector = i;
         i.injectMembers(this);
 
         if (isQuite) {
@@ -163,6 +164,11 @@ public abstract class JenkinsController implements IJenkinsController, AutoClean
      */
     @Override
     public abstract URL getUrl();
+
+    @CheckForNull
+    public Credentials getCredentials() {
+        return null;
+    }
 
     /**
      * Returns the short ID used to prefix log output from the process into the test.

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -92,7 +92,7 @@ public class PluginManager extends ContainerPageObject {
      * Force update the plugin update center metadata.
      */
     public void checkForUpdates() {
-        mockUpdateCenter.ensureRunning();
+        mockUpdateCenter.ensureRunning(jenkins);
         visit("advanced");
         final String current = getCurrentUrl();
         // The check now button is a form submit (POST) with a redirect to the same page only if the check is successful.

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -83,12 +83,10 @@ public class MockUpdateCenter implements AutoCleaned {
 
     private HttpServer server;
 
-    public void ensureRunning() {
+    public void ensureRunning(Jenkins jenkins) {
         if (original != null) {
             return;
         }
-        // TODO this will likely not work on arbitrary controllers, so perhaps limit to the default WinstoneController
-        Jenkins jenkins = injector.getInstance(Jenkins.class);
         List<String> sites = new UpdateCenter(jenkins).getJson("tree=sites[url]").findValuesAsText("url");
         if (sites.size() != 1) {
             // TODO ideally it would rather delegate to all of them, but that implies deprecating CachedUpdateCenterMetadataLoader.url and using whatever site(s) Jenkins itself specifies

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/AccessTokenGenerator.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/AccessTokenGenerator.java
@@ -1,0 +1,177 @@
+package org.jenkinsci.test.acceptance.utils;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.NameValuePair;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Takes static credentials and generates access tokens. Handles caching so that
+ */
+public class AccessTokenGenerator {
+    private ObjectMapper om;
+    private Map<CacheKey, Credentials> tokenCache = Collections.synchronizedMap(new HashMap<>());
+
+    public AccessTokenGenerator() {
+        om = new ObjectMapper();
+    }
+
+    public Credentials generate(@Nonnull URL url, @Nonnull Credentials credentials) throws IOException {
+        String name = credentials.getUserPrincipal().getName();
+        CacheKey key = new CacheKey(url, name);
+        if (!tokenCache.containsKey(key)) {
+            try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+                Crumb crumb = getCrumb(url, credentials, httpClient);
+                ApiTokenResponse apiTokenResponse = generateApiToken(url, credentials, httpClient, crumb);
+                tokenCache.put(key, new UsernamePasswordCredentials(name, apiTokenResponse.data.tokenValue));
+            }
+        }
+        return tokenCache.get(url);
+    }
+
+    private ApiTokenResponse generateApiToken(@Nonnull URL url, @Nonnull Credentials credentials, CloseableHttpClient httpClient, Crumb crumb) throws IOException {
+        HttpPost post = new HttpPost(new URL(url, "me/descriptorByName/jenkins.security.ApiTokenProperty/generateNewToken").toExternalForm());
+        post.setHeader(crumb.getCrumbRequestField(), crumb.getCrumb());
+        List<NameValuePair> parameters = new ArrayList<>();
+        parameters.add(new BasicNameValuePair("newTokenName", "ath-" + System.currentTimeMillis()));
+        UrlEncodedFormEntity entity = new UrlEncodedFormEntity(parameters, "UTF-8");
+        post.setEntity(entity);
+        CloseableHttpResponse postResponse = httpClient.execute(post, HttpUtils.buildHttpClientContext(url, credentials));
+        return om.readValue(postResponse.getEntity().getContent(), ApiTokenResponse.class);
+    }
+
+    private Crumb getCrumb(@Nonnull URL url, @Nonnull Credentials credentials, CloseableHttpClient httpClient) throws IOException {
+        HttpGet get = new HttpGet(new URL(url, "crumbIssuer/api/json").toExternalForm());
+        CloseableHttpResponse getResponse = httpClient.execute(get, HttpUtils.buildHttpClientContext(url, credentials));
+        int statusCode = getResponse.getStatusLine().getStatusCode();
+        if (statusCode == 200) {
+            return om.readValue(getResponse.getEntity().getContent(), Crumb.class);
+        } else {
+            throw new IOException("Got status code " + statusCode + " while getting a crumb: " + EntityUtils.toString(getResponse.getEntity()));
+        }
+    }
+
+    private static class CacheKey {
+        private final URL url;
+        private final String username;
+
+        public CacheKey(URL url, String username) {
+            this.url = url;
+            this.username = username;
+        }
+
+        public URL getUrl() {
+            return url;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CacheKey cacheKey = (CacheKey) o;
+            return Objects.equals(url, cacheKey.url) && Objects.equals(username, cacheKey.username);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(url, username);
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class Crumb {
+        private String crumb;
+        private String crumbRequestField;
+
+        public String getCrumb() {
+            return crumb;
+        }
+
+        public void setCrumb(String crumb) {
+            this.crumb = crumb;
+        }
+
+        public String getCrumbRequestField() {
+            return crumbRequestField;
+        }
+
+        public void setCrumbRequestField(String crumbRequestField) {
+            this.crumbRequestField = crumbRequestField;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class ApiTokenResponse {
+        private String status;
+        private ApiTokenResponse.Data data;
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public ApiTokenResponse.Data getData() {
+            return data;
+        }
+
+        public void setData(ApiTokenResponse.Data data) {
+            this.data = data;
+        }
+
+        private static class Data {
+            private String tokenName;
+            private String tokenUuid;
+            private String tokenValue;
+
+            public String getTokenName() {
+                return tokenName;
+            }
+
+            public void setTokenName(String tokenName) {
+                this.tokenName = tokenName;
+            }
+
+            public String getTokenUuid() {
+                return tokenUuid;
+            }
+
+            public void setTokenUuid(String tokenUuid) {
+                this.tokenUuid = tokenUuid;
+            }
+
+            public String getTokenValue() {
+                return tokenValue;
+            }
+
+            public void setTokenValue(String tokenValue) {
+                this.tokenValue = tokenValue;
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/AccessTokenGenerator.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/AccessTokenGenerator.java
@@ -25,7 +25,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Takes static credentials and generates access tokens. Handles caching so that
+ * Takes static credentials and generates access tokens.
+ * Handles caching per Jenkins instance and user.
  */
 public class AccessTokenGenerator {
     private ObjectMapper om;

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/AccessTokenGenerator.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/AccessTokenGenerator.java
@@ -45,7 +45,7 @@ public class AccessTokenGenerator {
                 tokenCache.put(key, new UsernamePasswordCredentials(name, apiTokenResponse.data.tokenValue));
             }
         }
-        return tokenCache.get(url);
+        return tokenCache.get(key);
     }
 
     private ApiTokenResponse generateApiToken(@Nonnull URL url, @Nonnull Credentials credentials, CloseableHttpClient httpClient, Crumb crumb) throws IOException {

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/FormElementPath.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/FormElementPath.java
@@ -48,14 +48,14 @@ public class FormElementPath {
             }
             if (!isFormPathElementPluginInstalled(url)) {
                 LOGGER.info("Installing form-element-path plugin from " + formElementPathPlugin);
-                uploadPlugin(url, credentials, formElementPathPlugin);
+                uploadPlugin(url, formElementPathPlugin);
             }
         } catch (IOException e) {
             throw new AssertionError("Can't check if form-element-path plugin is installed", e);
         }
     }
 
-    private static void uploadPlugin(URL url, Credentials credentials, File file) throws IOException {
+    private void uploadPlugin(URL url, File file) throws IOException {
         try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
             HttpPost post = new HttpPost(new URL(url, "pluginManager/uploadPlugin").toExternalForm());
             FileBody fileBody = new FileBody(file, ContentType.DEFAULT_BINARY);

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/FormElementPath.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/FormElementPath.java
@@ -1,0 +1,95 @@
+package org.jenkinsci.test.acceptance.utils;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.HttpMultipartMode;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.entity.mime.content.FileBody;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Ensures form-element-path plugin is running, and if not, installs it using the rest api to upload a plugin
+ */
+public class FormElementPath {
+    private static final Logger LOGGER = Logger.getLogger(FormElementPath.class.getName());
+
+    private Credentials credentials;
+
+    @Inject
+    @Named("form-element-path.hpi")
+    private File formElementPathPlugin;
+
+    @Inject
+    private AccessTokenGenerator accessToken;
+
+    public void ensure(@Nonnull URL url, @CheckForNull Credentials credentials) {
+        try {
+            if (credentials != null) {
+                this.credentials = accessToken.generate(url, credentials);
+            }
+            if (!isFormPathElementPluginInstalled(url)) {
+                LOGGER.info("Installing form-element-path plugin from " + formElementPathPlugin);
+                uploadPlugin(url, credentials, formElementPathPlugin);
+            }
+        } catch (IOException e) {
+            throw new AssertionError("Can't check if form-element-path plugin is installed", e);
+        }
+    }
+
+    private static void uploadPlugin(URL url, Credentials credentials, File file) throws IOException {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            HttpPost post = new HttpPost(new URL(url, "pluginManager/uploadPlugin").toExternalForm());
+            FileBody fileBody = new FileBody(file, ContentType.DEFAULT_BINARY);
+            MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+            builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
+            builder.addPart("upfile", fileBody);
+            post.setEntity(builder.build());
+            HttpResponse response = httpClient.execute(post, HttpUtils.buildHttpClientContext(url, credentials));
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 302) { // Redirect to updateCenter
+                throw new IOException("Could not upload plugin, received " + statusCode + ": " + EntityUtils.toString(response.getEntity()));
+            }
+        }
+    }
+
+    private boolean isFormPathElementPluginInstalled(URL url) throws IOException {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            HttpPost post = new HttpPost(new URL(url, "pluginManager/api/json").toExternalForm());
+
+            List<NameValuePair> parameters = new ArrayList<>();
+            parameters.add(new BasicNameValuePair("depth", "1"));
+            parameters.add(new BasicNameValuePair("tree", "plugins[shortName,version]"));
+            UrlEncodedFormEntity entity = new UrlEncodedFormEntity(parameters, "UTF-8");
+            post.setEntity(entity);
+
+            HttpResponse response = httpClient.execute(post, HttpUtils.buildHttpClientContext(url, credentials));
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200) {
+                throw new IOException("Could not check for form-element-path presence, received " + statusCode + ": " + EntityUtils.toString(response.getEntity()));
+            }
+            HttpEntity resEntity = response.getEntity();
+            String responseBody = EntityUtils.toString(resEntity);
+
+            return responseBody.contains("form-element-path");
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/HttpUtils.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/HttpUtils.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.test.acceptance.utils;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.net.URL;
+
+class HttpUtils {
+    private HttpUtils() {}
+
+    public static HttpClientContext buildHttpClientContext(@Nonnull URL url, @CheckForNull Credentials credentials) {
+        HttpClientContext context = HttpClientContext.create();
+        if (credentials != null) {
+            HttpHost targetHost = new HttpHost(url.getHost(), url.getPort(), url.getProtocol());
+            AuthCache authCache = new BasicAuthCache();
+            authCache.put(targetHost, new BasicScheme());
+            // Add AuthCache to the execution context
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY, credentials);
+            context.setCredentialsProvider(credentialsProvider);
+            context.setAuthCache(authCache);
+        }
+        return context;
+    }
+}


### PR DESCRIPTION
I'm running an ATH against an existing Jenkins instance running in Kubernetes. The usual workflow is to login, go through the setup wizard (once), then perform a functional test.

This PR brings a few changes to support this way of running an ATH:
* Support `form-element-path` installation through rest api
* `ExistingJenkinsController`: Initial support for authenticated Jenkins when using `TYPE=existing`
* `ExistingJenkinsController`: checking for form-element-path can be skipped. (this is called later)
* Support for access token generation