### PR TITLE
jenkins.getCurrentUser() can use an incorrect context

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -20,7 +20,7 @@ public class Login extends PageObject {
     private Control cLogin = control(by.name("Submit"));
 
     public Login(Jenkins jenkins) {
-        super(jenkins.injector, jenkins.url("login"));
+        super(jenkins, jenkins.url("login"));
     }
 
     /**


### PR DESCRIPTION
https://github.com/jenkinsci/acceptance-test-harness/pull/631 checks the logged in user by the `getJenkins().getCurrentUser()`. Some internal testing using SSO, probed that method will fail in such situation. The reason is that the injector is retrieving always the same jenkins instance instead of the actual instance where the Login happened.

@jtnord @amuniz 