### PR TITLE
Remove broken waiting for the save button to become stale

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
@@ -26,11 +26,12 @@ package org.jenkinsci.test.acceptance.po;
 import java.net.URL;
 import java.util.concurrent.Callable;
 
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
 import com.google.inject.Injector;
 
 import groovy.lang.Closure;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
@@ -130,7 +131,6 @@ public abstract class ConfigurablePageObject extends PageObject {
     public void save() {
         WebElement e = find(by.button("Save"));
         e.click();
-        waitFor(e).until(CapybaraPortingLayerImpl::isStale);
     }
 
     public void apply() {


### PR DESCRIPTION
The line
```
waitFor(e).until(CapybaraPortingLayerImpl::isStale);
```
 breaks my UI tests for Jenkins 2.263.x (it works with Jenkins 2.249.x):
- https://github.com/jenkinsci/warnings-ng-plugin/pull/758
- https://github.com/jenkinsci/git-forensics-plugin/pull/210

See https://github.com/jenkinsci/acceptance-test-harness/pull/604 for original PR.