### PR TITLE
failure stacktrace is no longer trimmed by surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -530,6 +530,7 @@
           </systemPropertyVariables>
           <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
           <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+          <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1798 -->
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
workaround https://issues.apache.org/jira/browse/SUREFIRE-1798