### PR TITLE
Attach support bundle after running the test

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The harness provides a variety of ways to configure the execution including:
 * [Running tests in container](docs/DOCKER.md)
 * [Running tests on Java 11 (WIP)](docs/JAVA11.md)
 * [Debugging tests in container](docs/DOCKER.md#debugging-tests-in-a-docker-container)
+* [Capture a support bundle](docs/SUPPORT-BUNDLE.md)
 * Selecting tests based on plugins they cover (TODO)
 
 ## Creating tests

--- a/docs/SUPPORT-BUNDLE.md
+++ b/docs/SUPPORT-BUNDLE.md
@@ -1,0 +1,6 @@
+# Support bundle
+
+If [support-core](https://github.com/jenkinsci/support-core-plugin) plugin is installed during the test execution, a support bundle will be captured and attached to the test scenario.
+This behaviour is executed only in CI environment, and is disabled when running a test locally.
+
+The behaviour can be overridden if necessary by setting the environment variable `CAPTURE_SUPPORT_BUNDLE=true` or `CAPTURE_SUPPORT_BUNDLE=false` depending on the desired behaviour.

--- a/pom.xml
+++ b/pom.xml
@@ -595,6 +595,26 @@
 
   <profiles>
     <profile>
+      <id>disable-support-bundle-locally</id>
+      <activation>
+        <property>
+          <name>!env.BUILD_URL</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <environmentVariables>
+                <CAPTURE_SUPPORT_BUNDLE>false</CAPTURE_SUPPORT_BUNDLE>
+              </environmentVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!--
         Since the overall test suite runs a couple of hours you can use the predefined
         set of "Smoke Tests" to get a first impression if everything is still running as expected.

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
@@ -2,11 +2,14 @@ package org.jenkinsci.test.acceptance.junit;
 
 import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
 import org.jenkinsci.test.acceptance.po.Jenkins;
+import org.jenkinsci.test.acceptance.utils.SupportBundleRequest;
+import org.junit.After;
 import org.junit.Rule;
 import org.openqa.selenium.WebDriver;
 
 import javax.inject.Inject;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
 
@@ -28,6 +31,9 @@ public class AbstractJUnitTest extends CapybaraPortingLayerImpl {
      */
     @Inject
     public Jenkins jenkins;
+
+    @Inject
+    private FailureDiagnostics diagnostics;
 
     /**
      * This field receives a valid web driver object you can use to talk to Jenkins.
@@ -55,5 +61,11 @@ public class AbstractJUnitTest extends CapybaraPortingLayerImpl {
 
     protected void interrupt() {
         throw new RuntimeException("INTERACTIVE debugging");
+    }
+
+    @After
+    public void captureSupportBundle() {
+        File file = diagnostics.touch("support-bundle.zip");
+        jenkins.generateSupportBundle(SupportBundleRequest.builder().includeDefaultComponents().setOutputFile(file).build());
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.test.acceptance.junit;
 import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.recorder.SupportBundle;
+import org.jenkinsci.test.acceptance.utils.SupportBundleRequest;
 import org.junit.After;
 import org.junit.Rule;
 import org.openqa.selenium.WebDriver;
@@ -71,6 +72,6 @@ public class AbstractJUnitTest extends CapybaraPortingLayerImpl {
 
     @After
     public void injectSpec() {
-        supportBundle.setSpec(Collections.singletonMap("support-bundle.zip", jenkins));
+        supportBundle.addSpec(jenkins, SupportBundleRequest.builder().includeDefaultComponents().setOutputFile(diagnostics.touch("support-bundle.zip")).build());
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.logging.Logger;
 
 /**
  * Convenience base class to derive your plain-old JUnit tests from.
@@ -22,6 +23,7 @@ import java.net.ServerSocket;
  * @author Kohsuke Kawaguchi
  */
 public class AbstractJUnitTest extends CapybaraPortingLayerImpl {
+    private static final Logger LOGGER = Logger.getLogger(AbstractJUnitTest.class.getName());
 
     @Rule
     public JenkinsAcceptanceTestRule rules = new JenkinsAcceptanceTestRule();
@@ -65,7 +67,13 @@ public class AbstractJUnitTest extends CapybaraPortingLayerImpl {
 
     @After
     public void captureSupportBundle() {
-        File file = diagnostics.touch("support-bundle.zip");
-        jenkins.generateSupportBundle(SupportBundleRequest.builder().includeDefaultComponents().setOutputFile(file).build());
+        try {
+            jenkins.getPlugin("support-core");
+            File file = diagnostics.touch("support-bundle.zip");
+            jenkins.generateSupportBundle(SupportBundleRequest.builder().includeDefaultComponents().setOutputFile(file).build());
+        } catch (IllegalArgumentException e) {
+            LOGGER.info("support-core plugin not installed, skipping support bundle");
+        }
+
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
@@ -2,7 +2,7 @@ package org.jenkinsci.test.acceptance.junit;
 
 import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
 import org.jenkinsci.test.acceptance.po.Jenkins;
-import org.jenkinsci.test.acceptance.utils.SupportBundleRequest;
+import org.jenkinsci.test.acceptance.recorder.SupportBundle;
 import org.junit.After;
 import org.junit.Rule;
 import org.openqa.selenium.WebDriver;
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.Collections;
 import java.util.logging.Logger;
 
 /**
@@ -36,6 +37,9 @@ public class AbstractJUnitTest extends CapybaraPortingLayerImpl {
 
     @Inject
     private FailureDiagnostics diagnostics;
+
+    @Rule(order = 0) // enclosed by JenkinsAcceptanceTestRule so that we have a valid Jenkins + webdriver
+    public SupportBundle supportBundle = new SupportBundle();
 
     /**
      * This field receives a valid web driver object you can use to talk to Jenkins.
@@ -66,14 +70,7 @@ public class AbstractJUnitTest extends CapybaraPortingLayerImpl {
     }
 
     @After
-    public void captureSupportBundle() {
-        try {
-            jenkins.getPlugin("support-core");
-            File file = diagnostics.touch("support-bundle.zip");
-            jenkins.generateSupportBundle(SupportBundleRequest.builder().includeDefaultComponents().setOutputFile(file).build());
-        } catch (IllegalArgumentException e) {
-            LOGGER.info("support-core plugin not installed, skipping support bundle");
-        }
-
+    public void injectSpec() {
+        supportBundle.setSpec(Collections.singletonMap("support-bundle.zip", jenkins));
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/recorder/SupportBundle.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/recorder/SupportBundle.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.test.acceptance.recorder;
+
+import org.jenkinsci.test.acceptance.guice.World;
+import org.jenkinsci.test.acceptance.junit.FailureDiagnostics;
+import org.jenkinsci.test.acceptance.po.Jenkins;
+import org.jenkinsci.test.acceptance.utils.SupportBundleRequest;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class SupportBundle extends TestWatcher {
+    private static final Logger LOGGER = Logger.getLogger(SupportBundle.class.getName());
+
+    @Inject
+    private FailureDiagnostics diagnostics;
+
+    private Map<String,Jenkins> spec = new HashMap<>();
+
+    public SupportBundle() {}
+
+    public void setSpec(@Nonnull Map<String, Jenkins> spec) {
+        this.spec.putAll(spec);
+    }
+
+    @Override
+    protected void failed(Throwable e, Description description) {
+        World.get().getInjector().injectMembers(this);
+        for (Map.Entry<String, Jenkins> entry: spec.entrySet()) {
+            try {
+                entry.getValue().getPlugin("support-core");
+                File file = diagnostics.touch(entry.getKey());
+                entry.getValue().generateSupportBundle(SupportBundleRequest.builder().includeDefaultComponents().setOutputFile(file).build());
+            } catch (IllegalArgumentException _) {
+                LOGGER.info("support-core plugin not installed, skipping support bundle");
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/recorder/SupportBundle.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/recorder/SupportBundle.java
@@ -2,6 +2,7 @@ package org.jenkinsci.test.acceptance.recorder;
 
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.utils.SupportBundleRequest;
+import org.jenkinsci.test.acceptance.utils.SystemEnvironmentVariables;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
@@ -11,6 +12,8 @@ import java.util.logging.Logger;
 
 public class SupportBundle extends TestWatcher {
     private static final Logger LOGGER = Logger.getLogger(SupportBundle.class.getName());
+
+    private static Boolean CAPTURE_SUPPORT_BUNDLE = Boolean.parseBoolean(SystemEnvironmentVariables.getPropertyVariableOrEnvironment("CAPTURE_SUPPORT_BUNDLE", "true"));
 
     private static class SupportBundleSpec {
         private Jenkins instance;
@@ -32,13 +35,17 @@ public class SupportBundle extends TestWatcher {
 
     @Override
     protected void failed(Throwable e, Description description) {
-        for (SupportBundleSpec spec : specs) {
-            try {
-                spec.instance.getPlugin("support-core");
-                spec.instance.generateSupportBundle(spec.request);
-            } catch (IllegalArgumentException _) {
-                LOGGER.info("support-core plugin not installed, skipping support bundle");
+        if (CAPTURE_SUPPORT_BUNDLE) {
+            for (SupportBundleSpec spec : specs) {
+                try {
+                    spec.instance.getPlugin("support-core");
+                    spec.instance.generateSupportBundle(spec.request);
+                } catch (IllegalArgumentException _) {
+                    LOGGER.info("support-core plugin not installed, skipping support bundle");
+                }
             }
+        } else {
+            LOGGER.info("Support bundle collection disabled.");
         }
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/SupportBundleRequest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/SupportBundleRequest.java
@@ -1,0 +1,142 @@
+package org.jenkinsci.test.acceptance.utils;
+
+import org.openqa.selenium.json.Json;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SupportBundleRequest {
+    private final File outputFile;
+
+    private final Payload payload;
+
+    private SupportBundleRequest(File outputFile, Payload payload) {
+        this.outputFile = outputFile;
+        this.payload = payload;
+    }
+
+    public String getJsonParameter() {
+        return new Json().toJson(payload);
+    }
+
+    public File getOutputFile() {
+        return outputFile;
+    }
+
+    // https://github.com/jenkinsci/support-core-plugin/blob/25ddb2f2fec34068c098b8b42cd682d38de9c36e/src/main/java/com/cloudbees/jenkins/support/SupportAction.java#L231-L249
+    public static class Selection {
+        private final String name;
+        private final boolean selected;
+
+
+        public Selection(String name, boolean selected) {
+            this.name = name;
+            this.selected = selected;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean isSelected() {
+            return selected;
+        }
+    }
+
+    public static class Payload{
+        private final List<Selection> components;
+
+        public Payload(List<Selection> components) {
+            this.components = components;
+        }
+
+        public List<Selection> getComponents() {
+            return components;
+        }
+    }
+
+    public static class Builder {
+        private File outputFile;
+
+        private Set<String> includedComponents = new HashSet<>();
+
+        private Set<String> excludedComponents = new HashSet<>();
+
+        public Builder setOutputFile(File outputFile) {
+            this.outputFile = outputFile;
+            return this;
+        }
+
+        public Builder includeComponents(String... components) {
+            for (String c : components) {
+                includedComponents.add(c);
+            }
+            return this;
+        }
+
+        public Builder excludeComponents(String... components) {
+            for (String c : components) {
+                excludedComponents.add(c);
+            }
+            return this;
+        }
+
+        public Builder includeDefaultComponents() {
+            return includeComponents("AgentsConfigFile",
+                    "ConfigFileComponent",
+                    "OtherConfigFilesComponent",
+                    "AboutBrowser",
+                    "AboutJenkins",
+                    "AboutUser",
+                    "AdministrativeMonitors",
+                    "BuildQueue",
+                    "DumpExportTable",
+                    "EnvironmentVariables",
+                    "FileDescriptorLimit",
+                    "GCLogs",
+                    "HeapUsageHistogram",
+                    "ItemsContent",
+                    "Agents",
+                    "Master",
+                    "JenkinsLogs",
+                    "LoadStats",
+                    "LoggerManager",
+                    "Metrics",
+                    "NetworkInterfaces",
+                    "NodeMonitors",
+                    "ReverseProxy",
+                    "RootCAs",
+                    "RunningBuilds",
+                    "SlaveCommandStatistics",
+                    "SlaveLogs",
+                    "SystemProperties",
+                    "ThreadDumps",
+                    "UpdateCenter",
+                    "ComponentImpl",
+                    "SlowRequestComponent",
+                    "DeadlockRequestComponent");
+        }
+
+        private Payload buildPayload() {
+            List<Selection> components = new ArrayList<>();
+            for (String i : includedComponents) {
+                components.add(new Selection(i, true));
+            }
+            for (String x : excludedComponents) {
+                components.add(new Selection(x, false));
+            }
+            return new Payload(components);
+        }
+
+        public SupportBundleRequest build() {
+            return new SupportBundleRequest(outputFile, buildPayload());
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+}


### PR DESCRIPTION
Collect a support bundle a after a failing test.

I found this very useful to investigate flaky tests as it collects way
more information than the standard output.