### PR TITLE
reduce flakiness of doSuccesfulLogin

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -1,14 +1,17 @@
 package org.jenkinsci.test.acceptance.po;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasInvalidLoginInformation;
 import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Page object for login page.
@@ -35,12 +38,9 @@ public class Login extends PageObject {
         cPassword.set(password);
         // for some reason submit it just bogus...
         cLogin.clickAndWaitToBecomeStale();
-        // Wait for the redirect to root page.
-        waitFor().withTimeout(30, TimeUnit.SECONDS).ignoring(AssertionError.class).until(() -> {
-            assertEquals(getJenkins().url.toExternalForm(), driver.getCurrentUrl());
-            return true;
-        });
-
+        // Wait for the redirect to happen
+        WebDriverWait wait = new WebDriverWait(driver, 30); // seconds
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("jenkins")));
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -44,9 +44,7 @@ public class Login extends PageObject {
     }
 
     /**
-     * Login assuming "path" form element unavailability.<br>
-     * Paths are usually unavailable when using the "existing" Jenkins controller.<br>
-     * (Unavailable despite pre-installed form-element-path plugin.)
+     * @deprecated use {@link #doLogin(String, String)} instead. It doesn't require form-element-path.
      */
     @Deprecated
     public Login doLoginDespiteNoPaths(String user, String password){

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -1,8 +1,10 @@
 package org.jenkinsci.test.acceptance.po;
 
 import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasInvalidLoginInformation;
 import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;
@@ -32,8 +34,6 @@ public class Login extends PageObject {
         cPassword.set(password);
         // for some reason submit it just bogus...
         cLogin.clickAndWaitToBecomeStale();
-        // Wait for the redirect to happen
-        new WebDriverWait(driver, 30).until(ExpectedConditions.visibilityOfElementLocated(by.id("jenkins")));
         return this;
     }
 
@@ -58,6 +58,10 @@ public class Login extends PageObject {
 
     public Login doSuccessfulLogin(String user, String password) {
         this.doLogin(user, password);
+        waitFor().withTimeout(30, TimeUnit.SECONDS).until(() -> {
+            assertThat(this, not(hasInvalidLoginInformation())); // login hasn't failed
+            return ExpectedConditions.visibilityOfElementLocated(by.id("jenkins")); // redirect has happened
+        });
         assertThat(this, loggedInAs(user));
         return this;
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -1,11 +1,6 @@
 package org.jenkinsci.test.acceptance.po;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.time.Duration;
-
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.test.acceptance.po;
 
-import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -34,7 +33,7 @@ public class Login extends PageObject {
         // for some reason submit it just bogus...
         cLogin.clickAndWaitToBecomeStale();
         // Wait for the redirect to happen
-        new WebDriverWait(driver, 30).until(ExpectedConditions.visibilityOfElementLocated(By.id("jenkins")));
+        new WebDriverWait(driver, 30).until(ExpectedConditions.visibilityOfElementLocated(by.id("jenkins")));
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -39,8 +39,7 @@ public class Login extends PageObject {
         // for some reason submit it just bogus...
         cLogin.clickAndWaitToBecomeStale();
         // Wait for the redirect to happen
-        WebDriverWait wait = new WebDriverWait(driver, 30); // seconds
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("jenkins")));
+        new WebDriverWait(driver, 30).until(ExpectedConditions.visibilityOfElementLocated(By.id("jenkins")));
         return this;
     }
 
@@ -49,14 +48,9 @@ public class Login extends PageObject {
      * Paths are usually unavailable when using the "existing" Jenkins controller.<br>
      * (Unavailable despite pre-installed form-element-path plugin.)
      */
+    @Deprecated
     public Login doLoginDespiteNoPaths(String user, String password){
-        driver.findElement(by.name("j_username")).sendKeys(user);
-        driver.findElement(by.name("j_password")).sendKeys(password);
-        WebElement we = driver.findElement(by.name("Submit"));
-        // for some reason submit() is bogus
-        we.click();
-        cUser.waitFor(we).withTimeout(Duration.ofSeconds(30)).until(CapybaraPortingLayerImpl::isStale);
-        return this;
+        return doLogin(user, password);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -1,12 +1,14 @@
 package org.jenkinsci.test.acceptance.po;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
 import org.openqa.selenium.WebElement;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasInvalidLoginInformation;
 import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Page object for login page.
@@ -33,6 +35,12 @@ public class Login extends PageObject {
         cPassword.set(password);
         // for some reason submit it just bogus...
         cLogin.clickAndWaitToBecomeStale();
+        // Wait for the redirect to root page.
+        waitFor().withTimeout(30, TimeUnit.SECONDS).ignoring(AssertionError.class).until(() -> {
+            assertEquals(getJenkins().url.toExternalForm(), driver.getCurrentUrl());
+            return true;
+        });
+
         return this;
     }
 
@@ -64,7 +72,7 @@ public class Login extends PageObject {
 
     public Login doSuccessfulLogin(String user, String password) {
         this.doLogin(user, password);
-        Assert.assertThat(this, loggedInAs(user));
+        assertThat(this, loggedInAs(user));
         return this;
     }
 
@@ -78,7 +86,7 @@ public class Login extends PageObject {
 
     public Login doFailedLogin(String user, String password) {
         this.doLogin(user, password);
-        Assert.assertThat(this, hasInvalidLoginInformation());
+        assertThat(this, hasInvalidLoginInformation());
         return this;
     }
 

--- a/src/test/java/plugins/ActiveDirectoryTest.java
+++ b/src/test/java/plugins/ActiveDirectoryTest.java
@@ -88,11 +88,11 @@ public class ActiveDirectoryTest extends AbstractJUnitTest {
         String userWannabe = ENV.getUser() + "-wannabe";
         GlobalSecurityConfig security = saveSecurityConfig(userWannabe);
         jenkins.logout();
-        jenkins.login().doLoginDespiteNoPaths(userWannabe,
+        jenkins.login().doLogin(userWannabe,
                 ENV.getPassword());
         security.configure();
         assertThat(getElement(by.name("_.domain")), is(nullValue()));
-        jenkins.login().doLoginDespiteNoPaths(ENV.getUser(),
+        jenkins.login().doLogin(ENV.getUser(),
                 ENV.getPassword());
     }
 
@@ -103,7 +103,7 @@ public class ActiveDirectoryTest extends AbstractJUnitTest {
 
     private void userCanLoginToJenkinsAsAdmin(String userOrGroupToAddAsAdmin) {
         GlobalSecurityConfig security = saveSecurityConfig(userOrGroupToAddAsAdmin);
-        jenkins.login().doLoginDespiteNoPaths(ENV.getUser(),
+        jenkins.login().doLogin(ENV.getUser(),
                 ENV.getPassword());
         security.configure();
         WebElement domain = getElement(by.name("_.domain"));


### PR DESCRIPTION
I'm seeing regularly flakiness in my ATH such as

```
Expected: has logged in user tmpuser
     but: tmpuser is not logged in.
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:964)
	at org.junit.Assert.assertThat(Assert.java:930)
	at org.jenkinsci.test.acceptance.po.Login.doSuccessfulLogin(Login.java:67)
	at org.jenkinsci.test.acceptance.po.Login.doSuccessfulLogin(Login.java:72)
```

I think in some cases the current check is not enough and the navigation happens before the login is really completed.

While working on this area, I notices `doLoginDespiteNoPaths` was useless since `doLogin` has been changed to not use path since https://github.com/jenkinsci/acceptance-test-harness/commit/ebdd746c9a9b57877e4035ee5674f0344b32818e. So I deprecated it and removed calls I could find in this ATH.