### PR TITLE
Fix driver location support when run on windows and cygwin is in the path.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
 
 import com.browserup.bup.BrowserUpProxy;
 import com.browserup.bup.client.ClientUtil;
+import org.apache.commons.exec.OS;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -264,8 +265,9 @@ public class FallbackConfig extends AbstractModule {
 
     // TODO: add Windows support
     private String locateDriver(final String name) {
-        try {
-            return new CommandBuilder("which", name).popen().asText().trim();
+        String command = OS.isFamilyWindows() ? "where": "which";
+        try (ProcessInputStream pis = new CommandBuilder(command, name).popen()) {
+            return pis.asText().trim();
         }
         catch (IOException | InterruptedException exception) {
             return StringUtils.EMPTY;

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -263,7 +263,6 @@ public class FallbackConfig extends AbstractModule {
         }
     }
 
-    // TODO: add Windows support
     private String locateDriver(final String name) {
         String command = OS.isFamilyWindows() ? "where": "which";
         try (ProcessInputStream pis = new CommandBuilder(command, name).popen()) {
@@ -484,4 +483,3 @@ public class FallbackConfig extends AbstractModule {
          }
      }
 }
-


### PR DESCRIPTION
if Cygwin was on the path `which` would work and return a cygwin path -
and those are not executable on windows..

e.g. fix the following:

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed:
2.293 s <<< FAILURE! - in core.FormValidationTest
[ERROR] validate(core.FormValidationTest)  Time elapsed: 2.254 s  <<<
ERROR!
com.google.inject.ProvisionException:
Unable to provision, see the following errors:

1) Error in custom provider, java.lang.IllegalStateException: The driver
   executable does not exist: C:\cygdrive\c\tools\geckodriver
     at
     org.jenkinsci.test.acceptance.FallbackConfig.createWebDriver(FallbackConfig.java:293)
     (via modules: org.jenkinsci.test.acceptance.guice.World ->
     com.google.inject.util.Modules$OverrideModule ->
     com.google.inject.util.Modules$OverrideModule ->
     org.jenkinsci.test.acceptance.FallbackConfig)
       at
       org.jenkinsci.test.acceptance.FallbackConfig.createWebDriver(FallbackConfig.java:293)
       (via modules: org.jenkinsci.test.acceptance.guice.World ->
       com.google.inject.util.Modules$OverrideModule ->
       com.google.inject.util.Modules$OverrideModule ->
       org.jenkinsci.test.acceptance.FallbackConfig)
         while locating org.openqa.selenium.WebDriver
```