### PR TITLE
Allow the firefox binary to be specified with `FIREFOX_BIN`

### DIFF
--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -5,7 +5,7 @@ The person who runs tests can select which browser to use by using the `BROWSER`
 The following values are available:
 
  * `firefox` (default)
-        _(if set the binary at `FIREFOX_BIN` will be used to launch firefox)
+        _(if set the binary at `FIREFOX_BIN` will be used to launch firefox)_
  * `ie`
  * `chrome`
  * `safari`

--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -5,6 +5,7 @@ The person who runs tests can select which browser to use by using the `BROWSER`
 The following values are available:
 
  * `firefox` (default)
+        _(if set the binary at `FIREFOX_BIN` will be used to launch firefox)
  * `ie`
  * `chrome`
  * `safari`

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -122,6 +122,9 @@ public class FallbackConfig extends AbstractModule {
                 firefoxOptions.setProxy(createSeleniumProxy(testName.get()));
             }
             setDriverPropertyIfMissing("geckodriver", GeckoDriverService.GECKO_DRIVER_EXE_PROPERTY);
+            if (System.getenv("FIREFOX_BIN") != null) {
+                firefoxOptions.setBinary(System.getenv("FIREFOX_BIN"));
+            }
 
             GeckoDriverService.Builder builder = new GeckoDriverService.Builder();
             if (display != null) {


### PR DESCRIPTION
Whilst you can use a system property (`webdriver.firefox.bin`) that is
cumbersome when running via surefire.  this exposes a system property
for advanced use to control which firefox to start.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
