### PR TITLE
Add the ability to connect to a remote chrome session with `BROWSER=remote-webdriver-chrome`

### DIFF
--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -16,6 +16,11 @@ The following values are available:
           for example `http://0.0.0.0:32779/wd/hub`
           when using something like
           [selenium/standalone-firefox-debug](https://hub.docker.com/r/selenium/standalone-firefox-debug/))_
+ * `remote-webdriver-chrome`
+        _(Requires `REMOTE_WEBDRIVER_URL` to be set to the url of the remote,
+          for example `http://0.0.0.0:32779/wd/hub`
+          when using something like
+          [selenium/standalone-chrome-debug](https://hub.docker.com/r/selenium/standalone-chrome-debug/))_
  * `firefox-container` and `chrome-container`
         Running the browser inside selenium provided per-test container.
 

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -183,6 +183,15 @@ public class FallbackConfig extends AbstractModule {
                     new URL(u), //http://192.168.99.100:4444/wd/hub
                     DesiredCapabilities.firefox()
             );
+        case "remote-webdriver-chrome":
+            u = System.getenv("REMOTE_WEBDRIVER_URL");
+            if (StringUtils.isBlank(u)) {
+                throw new Error("remote-webdriver-chrome requires REMOTE_WEBDRIVER_URL to be set");
+            }
+            return new RemoteWebDriver(
+                    new URL(u), //http://192.168.99.100:4444/wd/hub
+                    DesiredCapabilities.chrome()
+            );
         default:
             throw new Error("Unrecognized browser type: "+browser);
         }


### PR DESCRIPTION
Adds support for `BROWSER=remote-webdriver-chrome` to run the tests in a remote chrome browser.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
