### PR TITLE
try to fix git plugin tests

### DIFF
--- a/src/test/java/plugins/GitPluginTest.java
+++ b/src/test/java/plugins/GitPluginTest.java
@@ -47,7 +47,7 @@ import static org.hamcrest.core.IsNot.not;
 
 @WithDocker
 @Category(DockerTest.class)
-@WithPlugins("git")
+@WithPlugins({"git", "trilead-api"})
 @WithCredentials(credentialType = WithCredentials.SSH_USERNAME_PRIVATE_KEY, values = {"gitplugin", "/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/unsafe"})
 public class GitPluginTest extends AbstractJUnitTest {
 


### PR DESCRIPTION
The git plugin gets an old version of trilead as it uses an older core
with a detached version so it gets installed from the war and not the
update center.
attempt to work around this by requesting trilead be installed in the
"with-plugins" so we get something from the update center

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
