### PR TITLE
Reduce flakiness on plugins check

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -285,7 +285,14 @@ public class PluginManager extends ContainerPageObject {
         WebElement filterBox = find(By.id("filter-box"));
         filterBox.clear();
         filterBox.sendKeys(name);
-        check(waitFor(by.xpath("//input[starts-with(@name,'plugin.%s.')]", name), 10));
+        WebElement pluginEntry = waitFor(by.xpath("//input[starts-with(@name,'plugin.%s.')]", name), 10);
+        // sometimes the web element gets stale because of the dynamic JS behaviour of the plugin manager UI
+        if (Control.isStale(pluginEntry)) {
+            // wait 1 second, re-try and give up if it fails again
+            sleep(1000);
+            pluginEntry = waitFor(by.xpath("//input[starts-with(@name,'plugin.%s.')]", name), 10);
+        }
+        check(pluginEntry);
         final VersionNumber requiredVersion = spec.getVersionNumber();
         if (requiredVersion != null) {
             final VersionNumber availableVersion = getAvailableVersionForPlugin(name);


### PR DESCRIPTION
I've observed this failing with `StaleElementReferenceException` from
time to time. I tracked it down to the plugin manager UI dynamic
behaviour (DOM elements show up and down) so the initially select
element becomes stale after a few milliseconds.

There is no way to know if the element will become stale or not, so the
only way I found to make this less flaky is by waiting 1 second and
retrying, then give up if it fails again.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
