### PR TITLE
Support bundle should not fail when crumb issuer is disabled

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
@@ -242,7 +242,9 @@ public class Jenkins extends Node implements Container {
                     .setParameter("json", supportBundleRequest.getJsonParameter())
                     .build());
             Crumb crumb = getCrumb(client);
-            httpPost.setHeader(crumb.getCrumbRequestField(), crumb.getCrumb());
+            if (crumb != null) {
+                httpPost.setHeader(crumb.getCrumbRequestField(), crumb.getCrumb());
+            }
             try (CloseableHttpResponse response = client.execute(httpPost, buildHttpClientContext())) {
                 int statusCode = response.getStatusLine().getStatusCode();
                 if (statusCode == 200) {
@@ -267,6 +269,9 @@ public class Jenkins extends Node implements Container {
         int statusCode = getResponse.getStatusLine().getStatusCode();
         if (statusCode == 200) {
             return new ObjectMapper().readValue(getResponse.getEntity().getContent(), Crumb.class);
+        } else if (statusCode == 404) {
+            // Crumb issuer is disabled
+            return null;
         } else {
             throw new IOException("Got status code " + statusCode + " while getting a crumb: " + EntityUtils.toString(getResponse.getEntity()));
         }


### PR DESCRIPTION
When crumb issuer is disabled (using `-Dhudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION=true`), the support bundle collection fails because it doesn't handle this case.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
