### PR TITLE
[JENKINS-65587] fix FreestyleJobTest#should_visit_build_with_permalink  in latest cores

### DIFF
--- a/src/test/java/core/FreestyleJobTest.java
+++ b/src/test/java/core/FreestyleJobTest.java
@@ -2,6 +2,7 @@ package core;
 
 import hudson.util.VersionNumber;
 import org.apache.commons.io.IOUtils;
+import org.hamcrest.CoreMatchers;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.SmokeTest;
 import org.jenkinsci.test.acceptance.junit.Wait;
@@ -33,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -94,13 +96,14 @@ public class FreestyleJobTest extends AbstractJUnitTest {
         Build build = job.scheduleBuild().shouldSucceed();
         job.open();
         WebElement link = job.find(By.partialLinkText("Last build (#1)"));
-        link.click();
-
-        assertThat(driver, hasContent("Build #1"));
-        assertThat(driver, hasContent("No changes"));
-
-        WebElement successIcon = build.find(By.xpath("//h1/img"));
-        assertThat(successIcon.getAttribute("tooltip"), is("Success"));
+        String expectedUrl = link.getAttribute("href");
+        
+        Build b = new Build(job, "lastBuild");
+        b.open();
+        assertThat("Permalink link is current URL", driver.getCurrentUrl(), is(expectedUrl));
+        assertThat("Build number is correct", b.getNumber(), is(1));
+        assertThat("Build has no changes", driver, hasContent("No changes"));
+        assertThat("Build is success", b.getResult(), is(Build.Result.SUCCESS.name()));
     }
 
     @Test @Issue("JENKINS-38928")


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-65587

Test failed in latest cores as the build status icon was no longer an image but an SVG.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
