### PR TITLE
Update LdapContainer image to no longer use the ubuntu precise repo

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer/Dockerfile
@@ -6,7 +6,7 @@
 #
 # VERSION=2
 #
-FROM phusion/baseimage:0.9.8
+FROM phusion/baseimage:focal-1.0.0
 
 ENV HOME /root
 
@@ -16,10 +16,8 @@ RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]
 
-# Configure apt
-RUN echo 'deb http://us.archive.ubuntu.com/ubuntu/ precise universe' >> /etc/apt/sources.list
 # Install slapd
-RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get -y update && apt-get install -y slapd
+RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get -y update && apt-get install -y slapd && apt-get clean
 
 # Default configuration: can be overridden at the docker command line
 ENV LDAP_ROOTPASS jenkins
@@ -33,5 +31,3 @@ RUN mkdir /etc/service/slapd /etc/slapd-config
 
 ADD config /etc/slapd-config
 RUN cp /etc/slapd-config/slapd.sh /etc/service/slapd/run && chmod 755 /etc/service/slapd/run && chown root:root /etc/service/slapd/run
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Ubuntu Precise is no longer supported and the container can not be
built.  Switch to Focal as the most recent ubuntu LTS

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
