### PR TITLE
Fix GroovyPluginTest.run_groovy

### DIFF
--- a/src/main/tool_installers/updates/hudson.plugins.groovy.GroovyInstaller
+++ b/src/main/tool_installers/updates/hudson.plugins.groovy.GroovyInstaller
@@ -1,307 +1,502 @@
 {"list": [
     {
-    "id": "2.2.1",
-    "name": "Groovy 2.2.1",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.2.1.zip"
+    "id": "3.0.8",
+    "name": "Groovy 3.0.8",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.8.zip"
   },
     {
-    "id": "2.2.0",
-    "name": "Groovy 2.2.0",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.2.0.zip"
+    "id": "3.0.7",
+    "name": "Groovy 3.0.7",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.7.zip"
   },
     {
-    "id": "2.1.9",
-    "name": "Groovy 2.1.9",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.9.zip"
+    "id": "3.0.6",
+    "name": "Groovy 3.0.6",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.6.zip"
   },
     {
-    "id": "2.1.8",
-    "name": "Groovy 2.1.8",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.8.zip"
+    "id": "3.0.5",
+    "name": "Groovy 3.0.5",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.5.zip"
   },
     {
-    "id": "2.1.7",
-    "name": "Groovy 2.1.7",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.7.zip"
+    "id": "3.0.4",
+    "name": "Groovy 3.0.4",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.4.zip"
   },
     {
-    "id": "2.1.6",
-    "name": "Groovy 2.1.6",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.6.zip"
+    "id": "3.0.3",
+    "name": "Groovy 3.0.3",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.3.zip"
   },
     {
-    "id": "2.1.5",
-    "name": "Groovy 2.1.5",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.5.zip"
+    "id": "3.0.2",
+    "name": "Groovy 3.0.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.2.zip"
   },
     {
-    "id": "2.1.4",
-    "name": "Groovy 2.1.4",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.4.zip"
+    "id": "3.0.1",
+    "name": "Groovy 3.0.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.1.zip"
   },
     {
-    "id": "2.1.3",
-    "name": "Groovy 2.1.3",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.3.zip"
+    "id": "3.0.0",
+    "name": "Groovy 3.0.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.0.zip"
   },
     {
-    "id": "2.1.2",
-    "name": "Groovy 2.1.2",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.2.zip"
+    "id": "2.5.9",
+    "name": "Groovy 2.5.9",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.5.9.zip"
   },
     {
-    "id": "2.1.1",
-    "name": "Groovy 2.1.1",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.1.zip"
+    "id": "2.5.8",
+    "name": "Groovy 2.5.8",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.5.8.zip"
   },
     {
-    "id": "2.1.0",
-    "name": "Groovy 2.1.0",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.0.zip"
+    "id": "2.5.7",
+    "name": "Groovy 2.5.7",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.5.7.zip"
   },
     {
-    "id": "2.0.8",
-    "name": "Groovy 2.0.8",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.0.8.zip"
+    "id": "2.5.6",
+    "name": "Groovy 2.5.6",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.5.6.zip"
   },
     {
-    "id": "2.0.7",
-    "name": "Groovy 2.0.7",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.0.7.zip"
+    "id": "2.5.5",
+    "name": "Groovy 2.5.5",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.5.5.zip"
   },
     {
-    "id": "2.0.6",
-    "name": "Groovy 2.0.6",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.0.6.zip"
+    "id": "2.5.4",
+    "name": "Groovy 2.5.4",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.5.4.zip"
   },
     {
-    "id": "2.0.5",
-    "name": "Groovy 2.0.5",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.0.5.zip"
+    "id": "2.5.3",
+    "name": "Groovy 2.5.3",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.5.3.zip"
   },
     {
-    "id": "2.0.4",
-    "name": "Groovy 2.0.4",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.0.4.zip"
+    "id": "2.5.2",
+    "name": "Groovy 2.5.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.5.2.zip"
   },
     {
-    "id": "2.0.3",
-    "name": "Groovy 2.0.3",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.0.3.zip"
+    "id": "2.5.1",
+    "name": "Groovy 2.5.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.5.1.zip"
   },
     {
-    "id": "2.0.2",
-    "name": "Groovy 2.0.2",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.0.2.zip"
+    "id": "2.5.0",
+    "name": "Groovy 2.5.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.5.0.zip"
   },
     {
-    "id": "2.0.1",
-    "name": "Groovy 2.0.1",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.0.1.zip"
+    "id": "2.4.9",
+    "name": "Groovy 2.4.9",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.4.9.zip"
   },
     {
-    "id": "2.0.0",
-    "name": "Groovy 2.0.0",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-2.0.0.zip"
+    "id": "2.4.8",
+    "name": "Groovy 2.4.8",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.4.8.zip"
   },
     {
-    "id": "1.8.9",
-    "name": "Groovy 1.8.9",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.8.9.zip"
+    "id": "2.4.7",
+    "name": "Groovy 2.4.7",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.4.7.zip"
   },
     {
-    "id": "1.8.8",
-    "name": "Groovy 1.8.8",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.8.8.zip"
+    "id": "2.4.6",
+    "name": "Groovy 2.4.6",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.4.6.zip"
   },
     {
-    "id": "1.8.7",
-    "name": "Groovy 1.8.7",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.8.7.zip"
-  },
-    {
-    "id": "1.8.6",
-    "name": "Groovy 1.8.6",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.8.6.zip"
-  },
-    {
-    "id": "1.8.5",
-    "name": "Groovy 1.8.5",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.8.5.zip"
-  },
-    {
-    "id": "1.8.4",
-    "name": "Groovy 1.8.4",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.8.4.zip"
-  },
-    {
-    "id": "1.8.3",
-    "name": "Groovy 1.8.3",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.8.3.zip"
-  },
-    {
-    "id": "1.8.2",
-    "name": "Groovy 1.8.2",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.8.2.zip"
-  },
-    {
-    "id": "1.8.1",
-    "name": "Groovy 1.8.1",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.8.1.zip"
-  },
-    {
-    "id": "1.8.0",
-    "name": "Groovy 1.8.0",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.8.0.zip"
-  },
-    {
-    "id": "1.7.9",
-    "name": "Groovy 1.7.9",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.7.9.zip"
-  },
-    {
-    "id": "1.7.8",
-    "name": "Groovy 1.7.8",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.7.8.zip"
-  },
-    {
-    "id": "1.7.7",
-    "name": "Groovy 1.7.7",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.7.7.zip"
-  },
-    {
-    "id": "1.7.6",
-    "name": "Groovy 1.7.6",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.7.6.zip"
-  },
-    {
-    "id": "1.7.5",
-    "name": "Groovy 1.7.5",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.7.5.zip"
-  },
-    {
-    "id": "1.7.4",
-    "name": "Groovy 1.7.4",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.7.4.zip"
-  },
-    {
-    "id": "1.7.3",
-    "name": "Groovy 1.7.3",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.7.3.zip"
-  },
-    {
-    "id": "1.7.2",
-    "name": "Groovy 1.7.2",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.7.2.zip"
-  },
-    {
-    "id": "1.7.1",
-    "name": "Groovy 1.7.1",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.7.1.zip"
-  },
-    {
-    "id": "1.7.0",
-    "name": "Groovy 1.7.0",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.7.0.zip"
-  },
-    {
-    "id": "1.6.9",
-    "name": "Groovy 1.6.9",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.6.9.zip"
-  },
-    {
-    "id": "1.6.8",
-    "name": "Groovy 1.6.8",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.6.8.zip"
-  },
-    {
-    "id": "1.6.7",
-    "name": "Groovy 1.6.7",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.6.7.zip"
-  },
-    {
-    "id": "1.6.6",
-    "name": "Groovy 1.6.6",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.6.6.zip"
-  },
-    {
-    "id": "1.6.5",
-    "name": "Groovy 1.6.5",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.6.5.zip"
-  },
-    {
-    "id": "1.6.4",
-    "name": "Groovy 1.6.4",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.6.4.zip"
-  },
-    {
-    "id": "1.6.3",
-    "name": "Groovy 1.6.3",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.6.3.zip"
-  },
-    {
-    "id": "1.6.2",
-    "name": "Groovy 1.6.2",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.6.2.zip"
-  },
-    {
-    "id": "1.6.1",
-    "name": "Groovy 1.6.1",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.6.1.zip"
-  },
-    {
-    "id": "1.6.0",
-    "name": "Groovy 1.6.0",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.6.0.zip"
-  },
-    {
-    "id": "1.5.8",
-    "name": "Groovy 1.5.8",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.5.8.zip"
-  },
-    {
-    "id": "1.5.7",
-    "name": "Groovy 1.5.7",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.5.7.zip"
-  },
-    {
-    "id": "1.5.6",
-    "name": "Groovy 1.5.6",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.5.6.zip"
-  },
-    {
-    "id": "1.5.5",
-    "name": "Groovy 1.5.5",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.5.5.zip"
-  },
-    {
-    "id": "1.5.4",
-    "name": "Groovy 1.5.4",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.5.4.zip"
-  },
-    {
-    "id": "1.5.3",
-    "name": "Groovy 1.5.3",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.5.3.zip"
-  },
-    {
-    "id": "1.5.2",
-    "name": "Groovy 1.5.2",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.5.2.zip"
-  },
-    {
-    "id": "1.5.1",
-    "name": "Groovy 1.5.1",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.5.1.zip"
-  },
-    {
-    "id": "1.5.0",
-    "name": "Groovy 1.5.0",
-    "url": "https://dl.bintray.com/groovy/maven/groovy-binary-1.5.0.zip"
+    "id": "2.4.5",
+    "name": "Groovy 2.4.5",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.4.5.zip"
   },
     {
     "id": "2.4.4",
     "name": "Groovy 2.4.4",
-    "url": "https://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.4.zip"
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.4.4.zip"
+  },
+    {
+    "id": "2.4.3",
+    "name": "Groovy 2.4.3",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.4.3.zip"
+  },
+    {
+    "id": "2.4.2",
+    "name": "Groovy 2.4.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.4.2.zip"
+  },
+    {
+    "id": "2.4.1",
+    "name": "Groovy 2.4.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.4.1.zip"
+  },
+    {
+    "id": "2.4.0",
+    "name": "Groovy 2.4.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.4.0.zip"
+  },
+    {
+    "id": "2.3.9",
+    "name": "Groovy 2.3.9",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.3.9.zip"
+  },
+    {
+    "id": "2.3.8",
+    "name": "Groovy 2.3.8",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.3.8.zip"
+  },
+    {
+    "id": "2.3.7",
+    "name": "Groovy 2.3.7",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.3.7.zip"
+  },
+    {
+    "id": "2.3.6",
+    "name": "Groovy 2.3.6",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.3.6.zip"
+  },
+    {
+    "id": "2.3.5",
+    "name": "Groovy 2.3.5",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.3.5.zip"
+  },
+    {
+    "id": "2.3.4",
+    "name": "Groovy 2.3.4",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.3.4.zip"
+  },
+    {
+    "id": "2.3.3",
+    "name": "Groovy 2.3.3",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.3.3.zip"
+  },
+    {
+    "id": "2.3.2",
+    "name": "Groovy 2.3.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.3.2.zip"
+  },
+    {
+    "id": "2.3.1",
+    "name": "Groovy 2.3.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.3.1.zip"
+  },
+    {
+    "id": "2.3.0",
+    "name": "Groovy 2.3.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.3.0.zip"
+  },
+    {
+    "id": "2.2.2",
+    "name": "Groovy 2.2.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.2.2.zip"
+  },
+    {
+    "id": "2.2.1",
+    "name": "Groovy 2.2.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.2.1.zip"
+  },
+    {
+    "id": "2.2.0",
+    "name": "Groovy 2.2.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.2.0.zip"
+  },
+    {
+    "id": "2.1.9",
+    "name": "Groovy 2.1.9",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.1.9.zip"
+  },
+    {
+    "id": "2.1.8",
+    "name": "Groovy 2.1.8",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.1.8.zip"
+  },
+    {
+    "id": "2.1.7",
+    "name": "Groovy 2.1.7",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.1.7.zip"
+  },
+    {
+    "id": "2.1.6",
+    "name": "Groovy 2.1.6",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.1.6.zip"
+  },
+    {
+    "id": "2.1.5",
+    "name": "Groovy 2.1.5",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.1.5.zip"
+  },
+    {
+    "id": "2.1.4",
+    "name": "Groovy 2.1.4",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.1.4.zip"
+  },
+    {
+    "id": "2.1.3",
+    "name": "Groovy 2.1.3",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.1.3.zip"
+  },
+    {
+    "id": "2.1.2",
+    "name": "Groovy 2.1.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.1.2.zip"
+  },
+    {
+    "id": "2.1.1",
+    "name": "Groovy 2.1.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.1.1.zip"
+  },
+    {
+    "id": "2.1.0",
+    "name": "Groovy 2.1.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.1.0.zip"
+  },
+    {
+    "id": "2.0.8",
+    "name": "Groovy 2.0.8",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.0.8.zip"
+  },
+    {
+    "id": "2.0.7",
+    "name": "Groovy 2.0.7",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.0.7.zip"
+  },
+    {
+    "id": "2.0.6",
+    "name": "Groovy 2.0.6",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.0.6.zip"
+  },
+    {
+    "id": "2.0.5",
+    "name": "Groovy 2.0.5",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.0.5.zip"
+  },
+    {
+    "id": "2.0.4",
+    "name": "Groovy 2.0.4",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.0.4.zip"
+  },
+    {
+    "id": "2.0.3",
+    "name": "Groovy 2.0.3",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.0.3.zip"
+  },
+    {
+    "id": "2.0.2",
+    "name": "Groovy 2.0.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.0.2.zip"
+  },
+    {
+    "id": "2.0.1",
+    "name": "Groovy 2.0.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.0.1.zip"
+  },
+    {
+    "id": "2.0.0",
+    "name": "Groovy 2.0.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.0.0.zip"
+  },
+    {
+    "id": "1.8.9",
+    "name": "Groovy 1.8.9",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.8.9.zip"
+  },
+    {
+    "id": "1.8.8",
+    "name": "Groovy 1.8.8",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.8.8.zip"
+  },
+    {
+    "id": "1.8.7",
+    "name": "Groovy 1.8.7",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.8.7.zip"
+  },
+    {
+    "id": "1.8.6",
+    "name": "Groovy 1.8.6",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.8.6.zip"
+  },
+    {
+    "id": "1.8.5",
+    "name": "Groovy 1.8.5",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.8.5.zip"
+  },
+    {
+    "id": "1.8.4",
+    "name": "Groovy 1.8.4",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.8.4.zip"
+  },
+    {
+    "id": "1.8.3",
+    "name": "Groovy 1.8.3",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.8.3.zip"
+  },
+    {
+    "id": "1.8.2",
+    "name": "Groovy 1.8.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.8.2.zip"
+  },
+    {
+    "id": "1.8.1",
+    "name": "Groovy 1.8.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.8.1.zip"
+  },
+    {
+    "id": "1.8.0",
+    "name": "Groovy 1.8.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.8.0.zip"
+  },
+    {
+    "id": "1.7.9",
+    "name": "Groovy 1.7.9",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.7.9.zip"
+  },
+    {
+    "id": "1.7.8",
+    "name": "Groovy 1.7.8",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.7.8.zip"
+  },
+    {
+    "id": "1.7.7",
+    "name": "Groovy 1.7.7",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.7.7.zip"
+  },
+    {
+    "id": "1.7.6",
+    "name": "Groovy 1.7.6",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.7.6.zip"
+  },
+    {
+    "id": "1.7.5",
+    "name": "Groovy 1.7.5",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.7.5.zip"
+  },
+    {
+    "id": "1.7.4",
+    "name": "Groovy 1.7.4",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.7.4.zip"
+  },
+    {
+    "id": "1.7.3",
+    "name": "Groovy 1.7.3",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.7.3.zip"
+  },
+    {
+    "id": "1.7.2",
+    "name": "Groovy 1.7.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.7.2.zip"
+  },
+    {
+    "id": "1.7.1",
+    "name": "Groovy 1.7.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.7.1.zip"
+  },
+    {
+    "id": "1.7.0",
+    "name": "Groovy 1.7.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.7.0.zip"
+  },
+    {
+    "id": "1.6.9",
+    "name": "Groovy 1.6.9",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.6.9.zip"
+  },
+    {
+    "id": "1.6.8",
+    "name": "Groovy 1.6.8",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.6.8.zip"
+  },
+    {
+    "id": "1.6.7",
+    "name": "Groovy 1.6.7",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.6.7.zip"
+  },
+    {
+    "id": "1.6.6",
+    "name": "Groovy 1.6.6",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.6.6.zip"
+  },
+    {
+    "id": "1.6.5",
+    "name": "Groovy 1.6.5",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.6.5.zip"
+  },
+    {
+    "id": "1.6.4",
+    "name": "Groovy 1.6.4",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.6.4.zip"
+  },
+    {
+    "id": "1.6.3",
+    "name": "Groovy 1.6.3",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.6.3.zip"
+  },
+    {
+    "id": "1.6.2",
+    "name": "Groovy 1.6.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.6.2.zip"
+  },
+    {
+    "id": "1.6.1",
+    "name": "Groovy 1.6.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.6.1.zip"
+  },
+    {
+    "id": "1.6.0",
+    "name": "Groovy 1.6.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.6.0.zip"
+  },
+    {
+    "id": "1.5.8",
+    "name": "Groovy 1.5.8",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.5.8.zip"
+  },
+    {
+    "id": "1.5.7",
+    "name": "Groovy 1.5.7",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.5.7.zip"
+  },
+    {
+    "id": "1.5.6",
+    "name": "Groovy 1.5.6",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.5.6.zip"
+  },
+    {
+    "id": "1.5.5",
+    "name": "Groovy 1.5.5",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.5.5.zip"
+  },
+    {
+    "id": "1.5.4",
+    "name": "Groovy 1.5.4",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.5.4.zip"
+  },
+    {
+    "id": "1.5.3",
+    "name": "Groovy 1.5.3",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.5.3.zip"
+  },
+    {
+    "id": "1.5.2",
+    "name": "Groovy 1.5.2",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.5.2.zip"
+  },
+    {
+    "id": "1.5.1",
+    "name": "Groovy 1.5.1",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.5.1.zip"
+  },
+    {
+    "id": "1.5.0",
+    "name": "Groovy 1.5.0",
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-1.5.0.zip"
   }
 ]}


### PR DESCRIPTION
Bintray is no more, so get the groovy artifacts from
https://groovy.jfrog.io/ui/packages which is the same place as a real
jenkins would get them from.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
