### PR TITLE
Should use https

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/utils/aether/ArtifactResolverUtil.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/aether/ArtifactResolverUtil.java
@@ -74,7 +74,7 @@ public class ArtifactResolverUtil {
     public ArtifactResult resolve(DefaultArtifact artifact) {
         Builder repoBuilder = new RemoteRepository.Builder(
                 "repo.jenkins-ci.org", "default",
-                "http://repo.jenkins-ci.org/public/");
+                "https://repo.jenkins-ci.org/public/");
 
         DefaultSettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
 

--- a/src/main/resources/ath-container/run.sh
+++ b/src/main/resources/ath-container/run.sh
@@ -82,7 +82,7 @@ if [ ! -f $war ]; then
     if [ ! -f $war ]; then
 
         mvn -B org.apache.maven.plugins:maven-dependency-plugin:2.7:get\
-            -DremoteRepositories=repo.jenkins-ci.org::::http://repo.jenkins-ci.org/public/\
+            -DremoteRepositories=repo.jenkins-ci.org::::https://repo.jenkins-ci.org/public/\
             -Dartifact=org.jenkins-ci.main:jenkins-war:$2:war
     fi
 


### PR DESCRIPTION
Fixes
```
Downloading: http://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/form-element-path/1.10/form-element-path-1.10.hpi
org.eclipse.aether.transfer.ArtifactTransferException: Could not transfer artifact org.jenkins-ci.plugins:form-element-path:hpi:1.10 from/to repo.jenkins-ci.org (http://repo.jenkins-ci.org/public/): Permanent Redirect (308)
	at org.eclipse.aether.connector.basic.ArtifactTransportListener.transferFailed(ArtifactTransportListener.java:43)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:355)
```

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
