### PR TITLE
[JENKINS-44860] Fixes for credentials:2.5

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_slaves/SshSlaveLauncher.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_slaves/SshSlaveLauncher.java
@@ -107,6 +107,7 @@ public class SshSlaveLauncher extends ComputerLauncher {
         final SshCredentialDialog dia = this.addCredential();
         final SshPrivateKeyCredential cred = dia.select(SshPrivateKeyCredential.class);
         cred.username.set(username);
+        cred.description.set(username);
         if (passphrase != null) {
             cred.passphrase.set(passphrase);
         }

--- a/src/test/java/plugins/SshSlavesPluginTest.java
+++ b/src/test/java/plugins/SshSlavesPluginTest.java
@@ -108,7 +108,7 @@ public class SshSlavesPluginTest extends AbstractJUnitTest {
             }
             f.add();
 
-            l.credentialsId.select(String.format("%s (%s)", username, description));
+            l.credentialsId.select(description);
         }
         s.save();
     }
@@ -147,7 +147,7 @@ public class SshSlavesPluginTest extends AbstractJUnitTest {
         SshSlaveLauncher l = s.setLauncher(SshSlaveLauncher.class);
         l.host.set("127.0.0.1");
 
-        l.credentialsId.select(String.format("%s (%s)", username, description));
+        l.credentialsId.select(description);
     }
 
     private void verifyValueForCredential(CredentialsPage cp, Control element, String expected) {


### PR DESCRIPTION
Since https://github.com/jenkinsci/credentials-plugin/pull/205 credentials dropdown elements have changed format, they are not showing
usernames anymore, so selects need to use the description instead.

Test error is similar to:

```
org.openqa.selenium.NoSuchElementException: Unable to locate By.xpath: .//option[normalize-space(.)='user1 (Ssh key)' or @value='user1 (Ssh key)']
```

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
