### PR TITLE
fix: specifies UID and GID from the user running pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ for (int i = 0; i < splits.size(); i++) {
             stage(name) {
                 node('docker && highmem') {
                     checkout scm
-                    def image = docker.build('jenkins/ath', "src/main/resources/ath-container")
+                    def image = docker.build('jenkins/ath', '--build-arg uid="$(id -u)" --build-arg gid="$(id -g)" ./src/main/resources/ath-container/')
                     image.inside('-v /var/run/docker.sock:/var/run/docker.sock --shm-size 2g') {
                         def exclusions = splits.get(index).join("\n")
                         writeFile file: 'excludes.txt', text: exclusions

--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -33,9 +33,9 @@ ENV PATH="$PATH:/opt/maven/bin"
 ENV SHARED_DOCKER_SERVICE true
 
 # Allow injecting uid and git to match directory ownership
-ARG uid=1000
+ARG uid=1001
 ENV uid $uid
-ARG gid=1000
+ARG gid=1001
 ENV gid $gid
 
 EXPOSE 5942


### PR DESCRIPTION
Fixes https://issues.jenkins.io/browse/INFRA-3006 until the
docker.inside is removed.

Root cause was https://github.com/jenkins-infra/packer-images/pull/57
which changed the default UID if the agent's `jenkins` user.

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
