### PR TITLE
Don't display an ugly stacktrace if the JENKINS_HOME doesn't exist when cleaning up

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.test.acceptance.controller;
 
+import java.util.logging.Level;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -283,15 +284,19 @@ public abstract class LocalController extends JenkinsController implements LogLi
     @Override
     public void tearDown(){
         try {
-            FileUtils.forceDelete(jenkinsHome);
+            if (jenkinsHome.exists()) {
+                FileUtils.forceDelete(jenkinsHome);
+            }
         } catch (IOException e) {
-            System.out.println("Cleaning up temporary JENKINS_HOME failed, retrying in 5 sec.");
+            LOGGER.log(Level.WARNING, "Cleaning up temporary JENKINS_HOME failed, retrying in 5 sec.", e);
             //maybe process is shutting down, wait for a sec then try again
             try {
                 Thread.sleep(5000);
-                FileUtils.forceDelete(jenkinsHome);
+                if (jenkinsHome.exists()) {
+                    FileUtils.forceDelete(jenkinsHome);
+                }
             } catch (InterruptedException | IOException e1) {
-                System.out.println("Cleaning up temporary JENKINS_HOME failed again, giving up.");
+                LOGGER.log(Level.WARNING, "Cleaning up temporary JENKINS_HOME failed again, giving up.");
                 throw new RuntimeException(e);
             }
         }


### PR DESCRIPTION
```
java.lang.RuntimeException: java.io.FileNotFoundException: File does not exist: [redacted]
  at org.jenkinsci.test.acceptance.controller.LocalController.tearDown(LocalController.java:295)
  at org.jenkinsci.test.acceptance.controller.JenkinsController.close(JenkinsController.java:138)
  at org.jenkinsci.test.acceptance.guice.TestCleaner.performCleanUp(TestCleaner.java:23)
  at org.jenkinsci.test.acceptance.guice.World.endTestScope(World.java:66)
  at org.jenkinsci.test.acceptance.junit.JenkinsAcceptanceTestRule$1.evaluate(JenkinsAcceptanceTestRule.java:64)
  ... 30 more
Caused by: java.io.FileNotFoundException: File does not exist: [redacted]
  at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:2275)
  at org.jenkinsci.test.acceptance.controller.LocalController.tearDown(LocalController.java:286)
  ... 35 more
```

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
