### PR TITLE
Add ability to skip form-element-path plugin check

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/utils/FormElementPath.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/FormElementPath.java
@@ -32,6 +32,15 @@ import java.util.logging.Logger;
 public class FormElementPath {
     private static final Logger LOGGER = Logger.getLogger(FormElementPath.class.getName());
 
+    /**
+     * Set to true if plugin check should be skipped. Useful when running tests against
+     * Jenkins instance where the user doesn't have Overall/Administer access.
+     * Warning! By setting to true, you will have to ensure that form-element-path
+     * plugin is installed by other means.
+     */
+    public static boolean SKIP_PLUGIN_CHECK = Boolean.getBoolean(
+            FormElementPath.class.getName() + ".SKIP_PLUGIN_CHECK");
+
     private Credentials credentials;
 
     @Inject
@@ -42,6 +51,9 @@ public class FormElementPath {
     private AccessTokenGenerator accessToken;
 
     public void ensure(@Nonnull URL url, @CheckForNull Credentials credentials) {
+        if (SKIP_PLUGIN_CHECK) {
+            return;
+        }
         try {
             if (credentials != null) {
                 this.credentials = accessToken.generate(url, credentials);


### PR DESCRIPTION
Its not always possible to check for and install plugins when running tests against protected Jenkins instances where the test user has limited access. This PR adds the ability to instruct form-element-path check to skip check and assume it is installed.

In our case we use the acceptance test harness to run various sanity checks against our production instances. We don't want any golden service account that has admin access on all of our Jenkins instances, but rather a service user which behaves like a normal user. The check in FormElementPath prevents us in doing so, hence this PR.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
