### PR TITLE
Wait for ConfigurablePageObject elements even if we don't need to navigate

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
@@ -102,10 +102,9 @@ public abstract class ConfigurablePageObject extends PageObject {
      * @see #getConfigUrl()
      */
     public void configure() {
-        if (driver.getCurrentUrl().equals(getConfigUrl().toExternalForm())) {
-            return;
+        if (!driver.getCurrentUrl().equals(getConfigUrl().toExternalForm())) {
+            visit(getConfigUrl());
         }
-        visit(getConfigUrl());
         waitFor(By.xpath("//form[contains(@name, '" + getFormName() + "')]"), 10);
         waitFor(By.xpath("//span[contains(@class, 'submit-button')]//button[contains(text(), '" + getSubmitButtonText() + "')]"), 5);
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
In some cases it was causing `StaleElementReferenceException` when saving too early.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
