### PR TITLE
update WorkflowGithubSharedLibrary for JENKINS-62813

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/workflow_shared_library/WorkflowGithubSharedLibrary.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/workflow_shared_library/WorkflowGithubSharedLibrary.java
@@ -9,8 +9,8 @@ import org.jenkinsci.test.acceptance.po.PageAreaImpl;
  */
 public class WorkflowGithubSharedLibrary extends WorkflowSharedLibrary {
 
-    public final Control modernScm = control("retriever[0]");
-    public final Control githubSourceCodeManagement = control("retriever[0]/scm[1]");
+    public final Control modernScm = control("/");
+    public final Control githubSourceCodeManagement = control("/retriever");
 
     public WorkflowGithubSharedLibrary(WorkflowSharedLibraryGlobalConfig config, String path) {
         super(config, path);
@@ -18,11 +18,10 @@ public class WorkflowGithubSharedLibrary extends WorkflowSharedLibrary {
 
     @Override
     public GithubBranchSource selectSCM() {
-        this.modernScm.click();
-        this.githubSourceCodeManagement.waitFor();
-        this.githubSourceCodeManagement.click();
+        modernScm.select("0");
+        githubSourceCodeManagement.select("1");
 
-        return new GithubBranchSource(this, this.getPath() + "/retriever[0]/scm[1]");
+        return new GithubBranchSource(this, this.getPath() + "/retriever/scm");
     }
 
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The change from radio button to dropdown list made in https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/106 breaks `WorkflowGithubSharedLibrary`. 

CC @jtnord @MRamonLeon @Vlatombe 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
