### PR TITLE
Workaround some problems with checking elements with tooltip

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -14,6 +14,7 @@ import org.jenkinsci.test.acceptance.junit.Wait;
 import org.jenkinsci.test.acceptance.utils.ElasticTime;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
+import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -260,7 +261,12 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     @Override
     public void check(WebElement e, boolean state) {
         if (e.isSelected() != state) {
-            e.click();
+            try {
+                e.click();
+            } catch (ElementClickInterceptedException ex) {
+                // tooltip can make an element not clickable.
+                executeScript("arguments[0].click();", e);
+            }
         }
         // It seems like Selenium sometimes has issues when trying to click elements that are out of view.
         // We use the following javascript as a workaround if the previous click failed.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Should workaround issues with recent firefox such as

```
org.openqa.selenium.ElementClickInterceptedException: 
Element <input class="  " name="[hudson.model.Hudson.Read]" type="checkbox"> is not clickable at point (244,207) because another element <div class="bd"> obscures it
```

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
