### PR TITLE
Adding ability to specify a JAVA_HOME path to the constructor of WinstoneController

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
@@ -66,6 +66,8 @@ public abstract class LocalController extends JenkinsController implements LogLi
 
     private final File logFile;
 
+    private File javaHome;
+
     @Inject @Named("form-element-path.hpi")
     private File formElementPathPlugin;
 
@@ -96,6 +98,10 @@ public abstract class LocalController extends JenkinsController implements LogLi
         this.logFile = new File(this.jenkinsHome.getParentFile(), this.jenkinsHome.getName()+".log");
     }
 
+    protected LocalController(Injector i, File javaHome) {
+        this(i);
+        this.javaHome = javaHome;
+    }
     @Override
     public void postConstruct(Injector injector) {
         super.postConstruct(injector);
@@ -197,6 +203,9 @@ public abstract class LocalController extends JenkinsController implements LogLi
     }
 
     public File getJavaHome() {
+        if (javaHome != null && javaHome.isDirectory()) {
+            return javaHome;
+        }
         String javaHome = getenv("JENKINS_JAVA_HOME");
         File home = StringUtils.isBlank(javaHome) ? null : new File(javaHome);
         if (home != null && home.isDirectory()) {

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
@@ -51,6 +51,12 @@ public class WinstoneController extends LocalController {
         httpPort = IOUtil.randomTcpPort();
     }
 
+    @Inject
+    public WinstoneController(Injector i, File javaHome) {
+        super(i, javaHome);
+        httpPort = IOUtil.randomTcpPort();
+    }
+
     @Override
     public ProcessInputStream startProcess() throws IOException{
         File javaHome = getJavaHome();

--- a/src/test/java/org/jenkinsci/test/acceptance/controller/WinstoneControllerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/controller/WinstoneControllerTest.java
@@ -1,0 +1,46 @@
+package org.jenkinsci.test.acceptance.controller;
+
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.name.Names;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.File;
+import java.io.IOException;
+
+public class WinstoneControllerTest {
+    private Injector i;
+    private File tempFile;
+
+    @Before
+    public void setUp() {
+        i = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                try {
+                    tempFile = File.createTempFile("junit", "test");
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                bind(String.class).annotatedWith(Names.named("WORKSPACE")).toInstance("/tmp/");
+                bind(String.class).annotatedWith(Names.named("quite")).toInstance("");
+                bind(File.class).annotatedWith(Names.named("form-element-path.hpi")).toInstance(tempFile);
+                bind(File.class).annotatedWith(Names.named("jenkins.war")).toInstance(tempFile);
+            }
+        });
+    }
+
+    @Test
+    public void constructWithJavaHome() {
+        File javaHome = new File("/tmp/path/to/java_home");
+        javaHome.mkdirs();
+        WinstoneController winstoneController = new WinstoneController(i, javaHome);
+        Assert.assertSame("Expected java home directory given to constructor", javaHome, winstoneController.getJavaHome());
+    }
+}


### PR DESCRIPTION
This is to allow testing multiple Java versions simultaneously during an acceptance test.
In particular it will allow for testing of communications between Controllers that are operating in different Java environments.

Added a File javaHome to LocalController, Added new constructor for LocalController that sets the javaHome File. Updated getJavaHome() method to check if javaHome has been set and return it if it has. Added constructor to WinstoneController that will call the super constructor with a javaHome File. 

Added a unit test for the WinstoneController constructor that accepts a javaHome. Did not test the constructor without the javaHome because the returned JAVA_HOME path will vary based on where it is run.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
