### PR TITLE
Fix up firefox closing in all cases

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -344,19 +344,10 @@ public class FallbackConfig extends AbstractModule {
                         //https://bugzilla.mozilla.org/show_bug.cgi?id=1264259
                         //https://bugzilla.mozilla.org/show_bug.cgi?id=1434872
                         d.navigate().to("about:mozilla");
-
-                        String oldWindow = d.getWindowHandle();
-                        Wait<EventFiringWebDriver> wait = new Wait<>(d, time)
-                                .pollingEvery(500, TimeUnit.MILLISECONDS)
-                                .withTimeout(10, TimeUnit.SECONDS);
-                        Alert alert = wait.until(ExpectedConditions.alertIsPresent());
+                        Alert alert = ExpectedConditions.alertIsPresent().apply(d);
                         if (alert != null) {
-                            try {
-                                alert.accept();
-                                d.navigate().refresh();
-                            } finally {
-                                d.switchTo().window(oldWindow);
-                            }
+                            alert.accept();
+                            d.navigate().refresh();
                         }
                 }
                 d.quit();


### PR DESCRIPTION
Follows up on #680 and #684

This fixes handling of open alerts when closing firefox in all scenarios (was covered only for local firefox)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
