### PR TITLE
ath-container: Bum maven version for plugins based on parent-pom:4.20

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -fsSLO https://github.com/mozilla/geckodriver/releases/download/v0.26.0
     tar -xvzf geckodriver-v0.26.0-linux64.tar.gz -C /usr/local/bin
 
 # Maven in repo is not new enough for ATH
-ENV MAVEN_VERSION 3.6.3
+ENV MAVEN_VERSION 3.8.2
 RUN curl -ffSLO https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz && \
     tar -xvzf apache-maven-$MAVEN_VERSION-bin.tar.gz -C /opt/ && \
     mv /opt/apache-maven-* /opt/maven


### PR DESCRIPTION
Otherwise, the build fails with:

```
[2021-10-04T07:33:36.275Z] [WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
[2021-10-04T07:33:36.275Z] 3.8.1 required to no longer download dependencies via HTTP (use HTTPS instead).
```

Ref.: https://github.com/jenkinsci/plugin-pom/commit/826a0f18a91fe1bf3ca2c0e0f2ebd69af1224ebb

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue
