### PR TITLE
Fix selectors from artifactory plugin

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/artifactory/ArtifactoryGlobalConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/artifactory/ArtifactoryGlobalConfig.java
@@ -35,12 +35,12 @@ public class ArtifactoryGlobalConfig extends PageAreaImpl {
 
     public Server addServer() {
         control("repeatable-add").click();
-        return new Server(this, "artifactoryServer");
+        return new Server(this, "jfrogInstances");
     }
 
     public static class Server extends PageAreaImpl {
-        public final Control id = control("serverId");
-        public final Control url = control("artifactoryUrl");
+        public final Control id = control("instanceId");
+        public final Control url = control("platformUrl");
         public final Control username = control("deployerCredentialsConfig/username");
         public final Control password = control("deployerCredentialsConfig/password");
         public final Control testConnectionButton =  control("validate-button");

--- a/src/test/java/plugins/ArtifactoryPluginTest.java
+++ b/src/test/java/plugins/ArtifactoryPluginTest.java
@@ -35,7 +35,7 @@ import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 import static org.jenkinsci.test.acceptance.plugins.maven.MavenInstallation.installSomeMaven;
 
 /**
- * Checks the successfully integration of Artifactory plugin.
+ * Checks the successful integration of Artifactory plugin.
  */
 @WithPlugins("artifactory")
 @Category(DockerTest.class)
@@ -65,7 +65,7 @@ public class ArtifactoryPluginTest extends AbstractJUnitTest {
         waitFor(hasContent(Pattern.compile("Error occurred while requesting version information: Connection( to http://localhost:4898)* refused")));
     }
 
-    @Test @WithPlugins("maven-plugin")
+    @Test @WithPlugins("maven-plugin") @Ignore @Issue("")
     public void maven_integration() {
         installSomeMaven(jenkins);
         final ArtifactoryContainer artifactory = artifactoryContainer.get();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This fixes `ArtifactoryPluginTest#check_config_is_persisted` however there seems to be problems in the plugin itself to fix `maven_integration. Ignored it and filed [JENKINS-66791](https://issues.jenkins.io/browse/JENKINS-66791)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
