### PR TITLE
Fix JobDslPluginTest#are_columns_created

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/View.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/View.java
@@ -137,7 +137,7 @@ public abstract class View extends ContainerPageObject {
     }
 
     public static Matcher<View> containsImage(String imageName) {
-        return new Matcher<View>("Contains ToolTip " + imageName) {
+        return new Matcher<View>("Contains image " + imageName) {
             @Override
             public boolean matchesSafely(View item) {
                 WebElement webElement = item.getElement(By.xpath("//img[contains(@src, '" + imageName + "')]"));

--- a/src/test/java/plugins/JobDslPluginTest.java
+++ b/src/test/java/plugins/JobDslPluginTest.java
@@ -958,7 +958,7 @@ public class JobDslPluginTest extends AbstractJUnitTest {
         assertThat(view, containsColumnHeader("Last Success"));
         assertThat(view, containsColumnHeader("Last Failure"));
         assertThat(view, containsColumnHeader("Last Duration"));
-        assertThat(view, containsImage("clock.png"));
+        assertThat(view, containsImage("clock"));
     }
 
     /**


### PR DESCRIPTION
Fixes `JobDslPluginTest#are_columns_created`

At some point after the latest LTS, icons were switched from png to svg

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
