### PR TITLE
[JENKINS-66827] enable the ability to specify the proxy server

### DIFF
--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -68,6 +68,11 @@ It can also be set to save results even on success using
 
     RECORD_BROWSER_TRAFFIC=always mvn install
 
+If the host running maven is different to the host running Selenium (e.g. `remote-webdriver-selenium`) then you may have to specify the network address to use for the proxy (by default it will bind to 127.0.0.1 which would not be reachable for the browser).
+If this is the case you can specify the address to use using:
+    `SELENIUM_PROXY_HOSTNAME=ip.address.of.host mvn install`
+**Important**: this could exposed the proxy wider beyond your machine and expose other internal services, so this should only be used on private or internal networks to prevent any information leak.
+
 ## Avoid focus steal with Xvnc on Linux
 If you select a real GUI browser, such as Firefox,
 a browser window will pop up left and right during tests,

--- a/src/main/java/org/jenkinsci/test/acceptance/recorder/HarRecorder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/recorder/HarRecorder.java
@@ -13,7 +13,7 @@ import org.junit.runner.Description;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
-
+import java.net.InetAddress;
 import static org.jenkinsci.test.acceptance.recorder.HarRecorder.State.*;
 
 /**
@@ -68,7 +68,11 @@ public class HarRecorder extends TestWatcher {
 
     private static BrowserUpProxy proxy;
 
-    public static BrowserUpProxy getProxy() {
+    /**
+     * Create a proxy to record the HAR listening on the specified address
+     * @param listenAddress the specific address to bind to, or {@code null} to bind on all addresses
+     */
+    public static BrowserUpProxy getProxy(InetAddress networkAddress) {
         if (proxy == null) {
             // start the proxy
             proxy = new BrowserUpProxyServer();
@@ -80,7 +84,7 @@ public class HarRecorder extends TestWatcher {
                     CaptureType.RESPONSE_CONTENT
             );
             proxy.setTrustAllServers(true);
-            proxy.start();
+            proxy.start(0, networkAddress);
         }
         return proxy;
     }

--- a/src/test/java/org/jenkinsci/test/acceptance/recorder/HarRecorderTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/recorder/HarRecorderTest.java
@@ -22,7 +22,7 @@ public class HarRecorderTest {
         Description desc = description();
         HarRecorder harRecorder = rule(desc);
         HarRecorder.CAPTURE_HAR = HarRecorder.State.FAILURES_ONLY;
-        BrowserUpProxy proxy = HarRecorder.getProxy();
+        BrowserUpProxy proxy = HarRecorder.getProxy(null);
         proxy.newHar("jenkins");
 
         System.out.println("Good Bye World");


### PR DESCRIPTION
 #684 specified the firefox options consitently across all firefox
      browser types, however this broke remote-webdriver-firefox as the proxy was not localhost as far as firefox was conserned (as it was by definition remote).

This change makes the NIC to use for the proxy configurable so that you
can bind to a specific NIC and pass that to firefox via selenium.

Tested on Windows with `BROWSER=remote-webdriver-firefox`, `REMOTE_WEBDRIVER_URL=http://0.0.0.0:4444/wd/hub`  `SELENIUM_PROXY_HOSTNAME=redacted` and `JENKINS_LOCAL_HOSTNAME=redacted` 

Without this change all tests fail as the server (JENKINS) is unreachable.  with this change (and no environment set the same failure occurs), with this change and `SELENIUM_PROXY_HOSTNAME` the test passes as expected.


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
