### PR TITLE
Observed in build 378 milestone takes 20+ minutes to complete

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,11 @@
 // For ci.jenkins.io
 // https://github.com/jenkins-infra/documentation/blob/master/ci.adoc
 
-milestone label: 'build it', ordinal: BUILD_NUMBER
+def buildNumber = BUILD_NUMBER as int
+if (buildNumber > 1) {
+    milestone ordinal: (buildNumber - 1)
+}
+milestone ordinal: buildNumber
 
 def branches = [:]
 def splits


### PR DESCRIPTION
https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/378/console
The milestone step was taking over 20 minutes to complete as it ran
through 300 milestones (presumably looping over all builds 300+
times...)

We only need a single milestone whose ordinal is greater than the
previous ordinals in order to abort older builds which we may or may not
actually want to do (but that is for another day).

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
