### PR TITLE
fix: use specific 'docker-highmem' instead of the combination of 'docker' and 'highmem' (INFRA-3099)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ for (int i = 0; i < splits.size(); i++) {
         def name = "java-${javaVersion}-split${index}"
         branches[name] = {
             stage(name) {
-                node('docker && highmem') {
+                node('docker-highmem') {
                     checkout scm
                     def image = docker.build('jenkins/ath', '--build-arg uid="$(id -u)" --build-arg gid="$(id -g)" ./src/main/resources/ath-container/')
                     image.inside('-v /var/run/docker.sock:/var/run/docker.sock --shm-size 2g') {


### PR DESCRIPTION
So we can ensure only these pipelines with require a docker highmem machine

Second step of https://issues.jenkins.io/browse/INFRA-3099

Depends on https://github.com/jenkins-infra/jenkins-infra/pull/1934

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
