### PR TITLE
Remove broken symlink

### DIFF
--- a/unsafe.key
+++ b/unsafe.key
@@ -1,1 +1,0 @@
-src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer/unsafe


### PR DESCRIPTION
The target file was removed in commit bd7fe3ffbff68c8df84f5f5dd1fe1f9eb2223993 in 2017 in #252 and replaced by the "docker-fixtures" dependency.