### PR TITLE
Click label instead of input for checkbox

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/ByFactory.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/ByFactory.java
@@ -138,7 +138,7 @@ public class ByFactory {
      * Finds checkbox.
      *
      * @param locator
-     *      Text, id, title.
+     *      Text
      */
     public By checkbox(String locator) {
         return xpath(String.format(".//label[contains(normalize-space(.), '%1$s')]", locator));

--- a/src/main/java/org/jenkinsci/test/acceptance/ByFactory.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/ByFactory.java
@@ -141,7 +141,7 @@ public class ByFactory {
      *      Text, id, title.
      */
     public By checkbox(String locator) {
-        return xpath(fieldXPath("input[@type='checkbox']",locator));
+        return xpath(String.format(".//label[contains(normalize-space(.), '%1$s')]", locator));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/maven/MavenModuleSet.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/maven/MavenModuleSet.java
@@ -34,9 +34,12 @@ import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.PostBuildStep;
 import org.jenkinsci.test.acceptance.po.ShellBuildStep;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.google.inject.Injector;
+
+import static java.util.Objects.requireNonNull;
 
 @Describable("hudson.maven.MavenModuleSet")
 public class MavenModuleSet extends Job {
@@ -103,7 +106,13 @@ public class MavenModuleSet extends Job {
             }
         });
         checkbox.click();
-        T bs = newInstance(type, this, checkbox.getAttribute("path"));
+
+        WebElement input = checkbox;
+        if (checkbox.getTagName().equals("label")) {
+            input = checkbox.findElement(By.xpath("../input"));
+        }
+
+        T bs = newInstance(type, this, requireNonNull(input.getAttribute("path")));
 
         publishers.add(bs);
         return bs;

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/priority_sorter/PriorityConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/priority_sorter/PriorityConfig.java
@@ -66,7 +66,11 @@ public class PriorityConfig extends Action {
             control("").select("Jobs included in a View");
             control("jobGroupStrategy/viewName").select("All");
             control("jobGroupStrategy/jobFilter").check();
-            control("jobGroupStrategy/jobPattern").set(pattern);
+            try {
+                control("jobGroupStrategy/jobFilter/jobPattern").set(pattern);
+            } catch (NoSuchElementException e) {
+                control("jobGroupStrategy/jobPattern").set(pattern);
+            }
         }
 
         public void byView(String name) {

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/priority_sorter/PriorityConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/priority_sorter/PriorityConfig.java
@@ -66,11 +66,7 @@ public class PriorityConfig extends Action {
             control("").select("Jobs included in a View");
             control("jobGroupStrategy/viewName").select("All");
             control("jobGroupStrategy/jobFilter").check();
-            try {
-                control("jobGroupStrategy/jobFilter/jobPattern").set(pattern);
-            } catch (NoSuchElementException e) {
-                control("jobGroupStrategy/jobPattern").set(pattern);
-            }
+            control("jobGroupStrategy/jobFilter/jobPattern", "jobGroupStrategy/jobPattern").set(pattern);
         }
 
         public void byView(String name) {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -268,11 +268,6 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
                 executeScript("arguments[0].click();", e);
             }
         }
-        // It seems like Selenium sometimes has issues when trying to click elements that are out of view.
-        // We use the following javascript as a workaround if the previous click failed.
-        if (e.isSelected() != state) {
-            executeScript("arguments[0].click();", e);
-        }
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -397,7 +397,7 @@ public class Job extends TopLevelItem {
     }
 
     public void disable() {
-        check("disable");
+        check("Disable this project");
     }
 
     public int getNextBuildNumber() {

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/ArtifactoryContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/ArtifactoryContainer/Dockerfile
@@ -1,14 +1,1 @@
-FROM codingtony/java
-
-MAINTAINER tony.bussieres@ticksmith.com
-
-RUN apt-get update && apt-get install -y unzip
-RUN wget --content-disposition http://dl.bintray.com/jfrog/artifactory/artifactory-3.4.0.zip
-RUN cd /opt && unzip ~/artifactory-3.4.0.zip
-RUN mv /opt/artifactory-3.4.0 /opt/artifactory
-RUN rm ~/artifactory-3.4.0.zip
-RUN mkdir /opt/artifactory/data
-
-EXPOSE 8081
-
-CMD [ "/opt/artifactory/bin/artifactory.sh" ]
+FROM docker.bintray.io/jfrog/artifactory-oss:7.29.7

--- a/src/test/java/core/FreestyleJobTest.java
+++ b/src/test/java/core/FreestyleJobTest.java
@@ -2,7 +2,6 @@ package core;
 
 import hudson.util.VersionNumber;
 import org.apache.commons.io.IOUtils;
-import org.hamcrest.CoreMatchers;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.SmokeTest;
 import org.jenkinsci.test.acceptance.junit.Wait;


### PR DESCRIPTION
Required for https://github.com/jenkinsci/jenkins/pull/5923
Already applied for radio buttons in
https://github.com/jenkinsci/acceptance-test-harness/pull/704

Browser can't click on the new checkboxes if you ask them to click the input, the label must be clicked instead.