### PR TITLE
Forward compat for plugin manager modernise

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -93,7 +93,7 @@ public class PluginManager extends ContainerPageObject {
      */
     public void checkForUpdates() {
         mockUpdateCenter.ensureRunning(jenkins);
-        visit("advanced");
+        visit("index");
         final String current = getCurrentUrl();
         // The check now button is a form submit (POST) with a redirect to the same page only if the check is successful.
         // We use the button itself to detect when the page has changed, which happens after the refresh has been done

--- a/src/test/java/core/PluginManagerTest.java
+++ b/src/test/java/core/PluginManagerTest.java
@@ -28,11 +28,12 @@ import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.po.PluginManager;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
 
 public class PluginManagerTest extends AbstractJUnitTest {
@@ -52,9 +53,9 @@ public class PluginManagerTest extends AbstractJUnitTest {
         check(find(by.url("plugin/gerrit-trigger")), false);
         WebElement form = find(by.action("plugin/gerrit-trigger/uninstall"));
         form.submit();
+        clickButton("Yes");
         jenkins.restart();
         jenkins.getPluginManager().visit("installed");
-        WebElement trigger = find(by.url("plugin/gerrit-trigger"));
-        assertFalse(trigger.isSelected());
+        assertThrows(NoSuchElementException.class, () -> find(by.url("plugin/gerrit-trigger")));
     }
 }

--- a/src/test/java/core/PluginManagerTest.java
+++ b/src/test/java/core/PluginManagerTest.java
@@ -50,7 +50,6 @@ public class PluginManagerTest extends AbstractJUnitTest {
     public void uninstall_plugin() throws InterruptedException, ExecutionException {
         assumeTrue("This test requires a restartable Jenkins", jenkins.canRestart());
         jenkins.getPluginManager().visit("installed");
-        check(find(by.url("plugin/gerrit-trigger")), false);
         WebElement form = find(by.action("plugin/gerrit-trigger/uninstall"));
         form.submit();
         clickButton("Yes");


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/5916 removes the check now button from the advanced page is it looks out of place there and doesn't really have any purpose being on that page as nothing you check will influence that page.