### PR TITLE
Remove GMaven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,31 +496,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
-        <configuration>
-          <providerSelection>2.0</providerSelection>
-          <source />
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>generateStubs</goal>
-              <goal>compile</goal>
-              <goal>generateTestStubs</goal>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M1</version>
         <configuration>


### PR DESCRIPTION
Noticed after writing [jenkinsci/pom#42  (comment)](https://github.com/jenkinsci/pom/pull/42#issuecomment-992757629). As far as I can tell, all code in `src/{main,test}/groovy` was deleted sometime around 2016 in #209, so this plugin simply doesn't need to be included in the build anymore.