### PR TITLE
Drop Java 8 on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ if (needSplittingFromWorkspace) {
 }
 for (int i = 0; i < splits.size(); i++) {
     int index = i
-    for (int j in [8, 11]) {
+    for (int j in [11]) {
         int javaVersion = j
         def name = "java-${javaVersion}-split${index}"
         branches[name] = {


### PR DESCRIPTION
Seems unneeded to run on both? Running just Java 11 should save a lot of CI time

related to https://github.com/jenkinsci/jenkins/pull/6092 and https://github.com/jenkinsci/jenkins/pull/6083