### PR TITLE
Test against the LTS as well as the weekly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ for (int i = 0; i < splits.size(); i++) {
       for (String v in ["lts", "latest"]) {
           int javaVersion = j
           String jenkinsUnderTest = v
-          def name = "java-${javaVersion}-jenkins-${jenkinsUnderTest}split${index}"
+          def name = "java-${javaVersion}-jenkins-${jenkinsUnderTest}-split${index}"
           branches[name] = {
               stage(name) {
                   node('docker-highmem') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,8 @@ for (int i = 0; i < splits.size(); i++) {
                                   set-java.sh $javaVersion
                                   eval \$(vnc.sh)
                                   java -version
-
+                              """ + (jenkinsUnderTest == "lts" ? " export FORM_ELEMENT_PATH_VERSION=1.11" : "") + 
+                              """
                                   run.sh firefox ${jenkinsUnderTest} -Dmaven.test.failure.ignore=true -DforkCount=1 -B
                               """
                           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ for (int i = 0; i < splits.size(); i++) {
                                   eval \$(vnc.sh)
                                   java -version
 
-                                  run.sh firefox jenkinsUnderTest -Dmaven.test.failure.ignore=true -DforkCount=1 -B
+                                  run.sh firefox ${jenkinsUnderTest} -Dmaven.test.failure.ignore=true -DforkCount=1 -B
                               """
                           }
                       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,37 +27,40 @@ if (needSplittingFromWorkspace) {
 for (int i = 0; i < splits.size(); i++) {
     int index = i
     for (int j in [11]) {
-        int javaVersion = j
-        def name = "java-${javaVersion}-split${index}"
-        branches[name] = {
-            stage(name) {
-                node('docker-highmem') {
-                    checkout scm
-                    def image = docker.build('jenkins/ath', '--build-arg uid="$(id -u)" --build-arg gid="$(id -g)" ./src/main/resources/ath-container/')
-                    image.inside('-v /var/run/docker.sock:/var/run/docker.sock --shm-size 2g') {
-                        def exclusions = splits.get(index).join("\n")
-                        writeFile file: 'excludes.txt', text: exclusions
-                        realtimeJUnit(
-                                testResults: 'target/surefire-reports/TEST-*.xml',
-                                testDataPublishers: [[$class: 'AttachmentPublisher']],
-                                // Slow test(s) removal can causes a split to get empty which otherwise fails the build.
-                                // The build failure prevents parallel tests executor to realize the tests are gone so same
-                                // split is run to execute and report zero tests - which fails the build. Permit the test
-                                // results to be empty to break the circle: build after removal executes one empty split
-                                // but not letting the build to fail will cause next build not to try those tests again.
-                                allowEmptyResults: true
-                        ) {
-                            sh """
-                                set-java.sh $javaVersion
-                                eval \$(vnc.sh)
-                                java -version
+      for (String v in ["lts", "latest"]) {
+          int javaVersion = j
+          String jenkinsUnderTest = v
+          def name = "java-${javaVersion}-jenkins-${jenkinsUnderTest}split${index}"
+          branches[name] = {
+              stage(name) {
+                  node('docker-highmem') {
+                      checkout scm
+                      def image = docker.build('jenkins/ath', '--build-arg uid="$(id -u)" --build-arg gid="$(id -g)" ./src/main/resources/ath-container/')
+                      image.inside('-v /var/run/docker.sock:/var/run/docker.sock --shm-size 2g') {
+                          def exclusions = splits.get(index).join("\n")
+                          writeFile file: 'excludes.txt', text: exclusions
+                          realtimeJUnit(
+                                  testResults: 'target/surefire-reports/TEST-*.xml',
+                                  testDataPublishers: [[$class: 'AttachmentPublisher']],
+                                  // Slow test(s) removal can causes a split to get empty which otherwise fails the build.
+                                  // The build failure prevents parallel tests executor to realize the tests are gone so same
+                                  // split is run to execute and report zero tests - which fails the build. Permit the test
+                                  // results to be empty to break the circle: build after removal executes one empty split
+                                  // but not letting the build to fail will cause next build not to try those tests again.
+                                  allowEmptyResults: true
+                          ) {
+                              sh """
+                                  set-java.sh $javaVersion
+                                  eval \$(vnc.sh)
+                                  java -version
 
-                                run.sh firefox latest -Dmaven.test.failure.ignore=true -DforkCount=1 -B
-                            """
-                        }
-                    }
-                }
-            }
+                                  run.sh firefox jenkinsUnderTest -Dmaven.test.failure.ignore=true -DforkCount=1 -B
+                              """
+                          }
+                      }
+                  }
+              }
+          }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,8 +53,6 @@ for (int i = 0; i < splits.size(); i++) {
                                   set-java.sh $javaVersion
                                   eval \$(vnc.sh)
                                   java -version
-                              """ + (jenkinsUnderTest == "lts" ? " export FORM_ELEMENT_PATH_VERSION=1.11" : "") + 
-                              """
                                   run.sh firefox ${jenkinsUnderTest} -Dmaven.test.failure.ignore=true -DforkCount=1 -B
                               """
                           }


### PR DESCRIPTION
As we need to run the ATH against LTS version when they are released we
should ensure that the ATH itself has no regressions when run against
it.

This allows us to actually identify issues in the LTS as opposed to the
ATH no longer being compatible with it.
This requires that the ATH be compatible with the weekly and the LTS
line, which should have been mostly done but was never tested in the PR
builder.

As we have recently removed the Java8 test this should not add any extra load onto ci.jenkins.io that was not present a few weeks ago but adding Mark for this as I know the ATH is relatively intensive for CI resources.

There is possible going to be some test failures here that need to be fixed too (so WIP until at least I have a report on failures)
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
