### PR TITLE
Fix SSH Agents on recent core

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Slave.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Slave.java
@@ -55,7 +55,7 @@ public class Slave extends Node {
 
     public String getLog() {
         visit("log");
-        return find(by.css("pre#out pre")).getText();
+        return find(by.css("pre#out")).getText();
     }
 
     public boolean isOffline() {

--- a/src/test/java/plugins/SshSlavesPluginTest.java
+++ b/src/test/java/plugins/SshSlavesPluginTest.java
@@ -210,12 +210,16 @@ public class SshSlavesPluginTest extends AbstractJUnitTest {
     @Test public void customJavaPath() {
         setUp();
         SshSlaveLauncher launcher = configureDefaultSSHSlaveLauncher().pwdCredentials("test", "test");
-        
-        launcher.javaPath.set("/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java");
+
+        String javaPath = "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java";
+        if (System.getProperty("os.arch").equals("aarch64")) {
+            javaPath = "/usr/lib/jvm/java-8-openjdk-arm64/jre/bin/java";
+        }
+        launcher.javaPath.set(javaPath);
         slave.save();
     
         verify();
-        verifyLog("java-8-openjdk-amd64");
+        verifyLog("java-8-openjdk");
     }
     
     @Test public void jvmOptions() {


### PR DESCRIPTION
Pre is no longer nested as pre -> pre, just pre -> div now.

Plugin manager tests worked fine because it just loads `pre`.

So adjusted to the same