### PR TITLE
Exchange Jenkins http mirror in favor of https

### DIFF
--- a/grab-latest-rc.sh
+++ b/grab-latest-rc.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -xe
 
-curl -L "http://mirrors.jenkins-ci.org/war-rc/latest/jenkins.war" > jenkins.war
+curl -L "https://get.jenkins.io/war-rc/latest/jenkins.war" > jenkins.war

--- a/src/main/resources/ath-container/run.sh
+++ b/src/main/resources/ath-container/run.sh
@@ -41,7 +41,7 @@ fi
 browser=$1
 war=$2
 if [ ! -f $war ]; then
-    mirrors=http://mirrors.jenkins-ci.org
+    mirrors=https://get.jenkins.io
     case "$war" in
         "latest")
             war=jenkins-latest.war


### PR DESCRIPTION
Let's recommend the https mirror in favor over the plain old http one.