### PR TITLE
Allow WinstoneController subclasses to provide additional java/jenkins options

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
@@ -2,6 +2,7 @@ package org.jenkinsci.test.acceptance.controller;
 
 import hudson.util.VersionNumber;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.jar.JarFile;
 import javax.inject.Inject;
 import java.io.File;
@@ -98,15 +99,33 @@ public class WinstoneController extends LocalController {
             portFile.deleteOnExit();
             cb.add("-Dwinstone.portFileName=" + portFile.getAbsolutePath());
         }
+        cb.addAll(getAdditionalJavaOptions());
         cb.add("-jar", war,
                 "--ajp13Port=-1",
                 "--httpPort=" + httpPort
         );
         cb.addAll(JENKINS_OPTS);
+        cb.addAll(getAdditionalJenkinsOptions());
 
         cb.env.putAll(commonLaunchEnv());
-        LOGGER.info("Starting Jenkins: " + cb.toString());
+        LOGGER.info("Starting Jenkins: " + cb);
         return cb.popen();
+    }
+
+    /**
+     * Returns additional options to the JVM.
+     * @return additional options to the JVM.
+     */
+    protected Collection<String> getAdditionalJavaOptions() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns additional Jenkins options that subclasses can provide.
+     * @return additional Jenkins options that subclasses can provide
+     */
+    protected Collection<String> getAdditionalJenkinsOptions() {
+        return Collections.emptyList();
     }
 
     private boolean supportsPortFileName() throws IOException {


### PR DESCRIPTION
I have a subclass currently that is overriding `startProcess` for the purpose of adding a new java option. Making that a separate method to ease maintenance.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
