### PR TITLE
allow git local checkout for single test

### DIFF
--- a/src/test/java/plugins/JiraPluginTest.java
+++ b/src/test/java/plugins/JiraPluginTest.java
@@ -44,12 +44,15 @@ public class JiraPluginTest extends AbstractJUnitTest {
     @Before
     public void setUp() throws Exception {
         git = new GitRepo();
+        jenkins.runScript("hudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT = true");
     }
 
     @After
     public void tearDown() throws Exception {
         if (git!=null)
             git.close();
+
+        jenkins.runScript("hudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT = false");
     }
 
     @Test


### PR DESCRIPTION
After security hardening for git plugin local folder checkout for git are not allowed anymore (see [git-plugin changes](https://github.com/jenkinsci/git-plugin/commit/b295606e0b865c298fde27bea14f9b7535a976e6#diff-62e1a9b9fcde378a5c5da0b5d4f1187cc0d941635d88da23986298f91e8ef893R1281)). The fix uses escape hatch to allow local checkout and disallow it after execution.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
