### PR TITLE
support file upload for remote webdriver

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -6,6 +6,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
@@ -49,6 +50,7 @@ import org.jenkinsci.utils.process.CommandBuilder;
 import org.jenkinsci.utils.process.ProcessInputStream;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.Alert;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Proxy;
@@ -168,36 +170,27 @@ public class FallbackConfig extends AbstractModule {
             capabilities.setCapability(LANGUAGE_SELECTOR_PHANTOMJS, "en");
             return new PhantomJSDriver(capabilities);
         case "remote-webdriver-firefox":
-            String u = System.getenv("REMOTE_WEBDRIVER_URL");
-            if (StringUtils.isBlank(u)) {
-                throw new Error("remote-webdriver-firefox requires REMOTE_WEBDRIVER_URL to be set");
-            }
-            {
-                RemoteWebDriver driver =  new RemoteWebDriver(
-                        new URL(u), //http://192.168.99.100:4444/wd/hub
-                        buildFirefoxOptions(testName)
-                );
-                driver.setFileDetector(new LocalFileDetector());
-                return driver;
-            }
+            return buildRemoteWebDriver(buildFirefoxOptions(testName));
         case "remote-webdriver-chrome":
-            u = System.getenv("REMOTE_WEBDRIVER_URL");
-            if (StringUtils.isBlank(u)) {
-                throw new Error("remote-webdriver-chrome requires REMOTE_WEBDRIVER_URL to be set");
-            }
-            {
-                RemoteWebDriver driver = new RemoteWebDriver(
-                        new URL(u), //http://192.168.99.100:4444/wd/hub
-                        DesiredCapabilities.chrome()
-                );
-                driver.setFileDetector(new LocalFileDetector());
-                return driver;
-            }
+            return buildRemoteWebDriver(buildChromeOptions(testName));
         default:
             throw new Error("Unrecognized browser type: "+browser);
         }
     }
 
+    private RemoteWebDriver buildRemoteWebDriver(Capabilities options) throws MalformedURLException {
+        String u = System.getenv("REMOTE_WEBDRIVER_URL");
+        if (StringUtils.isBlank(u)) {
+            throw new Error("remote-webdriver type browsers require REMOTE_WEBDRIVER_URL to be set");
+        }
+        RemoteWebDriver driver =  new RemoteWebDriver(
+                new URL(u), //http://192.168.99.100:4444/wd/hub
+                options
+        );
+        driver.setFileDetector(new LocalFileDetector());
+        return driver;
+
+    }
     private String getBrowser() {
         String browser = System.getenv("BROWSER");
         if (browser==null) browser = "firefox";
@@ -219,6 +212,14 @@ public class FallbackConfig extends AbstractModule {
             firefoxOptions.setBinary(System.getenv("FIREFOX_BIN"));
         }
         return firefoxOptions;
+    }
+
+    private ChromeOptions buildChromeOptions(TestName testName) throws IOException {
+        ChromeOptions chromeOptions = new ChromeOptions();
+        if (isCaptureHarEnabled()) {
+            chromeOptions.setProxy(createSeleniumProxy(testName.get()));
+        }
+        return chromeOptions;
     }
 
     private WebDriver createContainerWebDriver(TestCleaner cleaner, String image, MutableCapabilities capabilities) throws IOException {


### PR DESCRIPTION
In order to use a file upload when using remote webdriver the [driver needs to be explicitly configure](https://www.selenium.dev/documentation/webdriver/remote_webdriver/#local-file-detector)d.

discovered in a set of proprietary tests that started failing.  tested with a snapshot build of this and the tests work as expected.

```
org.openqa.selenium.InvalidArgumentException:
File not found: C:\xxxxxx\acceptance\credentialsbinding\secretFile
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: 'xxxxS', ip: 'xx.xx.xx.xx', os.name: 'Windows 10', os.arch: 'amd64', os.version: '10.0', java.version: '1.8.0_322'
Driver info: org.openqa.selenium.remote.RemoteWebDriver
Capabilities {acceptInsecureCerts: true, browserName: firefox, browserVersion: 92.0.1, javascriptEnabled: true, moz:accessibilityChecks: false, moz:buildID: 20210922161155, moz:geckodriverVersion: 0.29.1, moz:headless: false, moz:processID: 171, moz:profile: /tmp/rust_mozprofileiQBebo, moz:shutdownTimeout: 60000, moz:useNonSpecCompliantPointerOrigin: false, moz:webdriverClick: true, pageLoadStrategy: normal, platform: LINUX, platformName: LINUX, platformVersion: 5.10.16.3-microsoft-standar..., proxy: Proxy(manual, http=xx.xx.xx.xx..., setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify, webdriver.remote.sessionid: 393a4be1-935f-48b9-9045-c1b...}
Session ID: 393a4be1-935f-48b9-9045-c1b87215b6e3
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.openqa.selenium.remote.http.W3CHttpResponseCodec.createException(W3CHttpResponseCodec.java:187)
        at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:122)
        at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:49)
        at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:158)
        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
        at org.openqa.selenium.remote.RemoteWebElement.execute(RemoteWebElement.java:285)
        at org.openqa.selenium.remote.RemoteWebElement.sendKeys(RemoteWebElement.java:106)
```

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
