### PR TITLE
improve security some more by not exposing ports to the world!

### DIFF
--- a/vars.cmd
+++ b/vars.cmd
@@ -4,7 +4,7 @@
 set DISPLAY=:0
 set INTERACTIVE=false
 set BROWSER=remote-webdriver-firefox
-set REMOTE_WEBDRIVER_URL=http://0.0.0.0:4444/wd/hub
+set REMOTE_WEBDRIVER_URL=http://127.0.0.1:4444/wd/hub
 set JENKINS_JAVA_OPTS=-Xmx1280m
 
 @REM Jenkins binds to 0.0.0.0 (OMG) so we can use any network but the docker network.
@@ -18,4 +18,4 @@ set SELENIUM_PROXY_HOSTNAME=%IP%
 set JENKINS_LOCAL_HOSTNAME=%IP%
 @echo.
 @echo To start the remote firefox container run the following command:
-@echo docker run --shm-size=256m -d -p 4444:4444 -p 5900:5900 -e no_proxy=localhost -e SCREEN_WIDTH=1680 -e SCREEN_HEIGHT=1090 selenium/standalone-firefox-debug:3.141.59
+@echo docker run --shm-size=256m -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e no_proxy=localhost -e SCREEN_WIDTH=1680 -e SCREEN_HEIGHT=1090 selenium/standalone-firefox-debug:3.141.59


### PR DESCRIPTION
we only need the webdriver and vnc ports exposed on localhost not to the
world, so limit them a bit more.

Realized this when working that the docker ports where over exposed for what we need.  
Do not rely on any firewall rules (which at least[ on Linux are bypassed](https://docs.docker.com/engine/reference/commandline/run/#publish-or-expose-port--p---expose)!)

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
