### PR TITLE
[DO NOT MERGE] Running full ATH suite on Core PR 6485

### DIFF
--- a/src/main/resources/ath-container/run.sh
+++ b/src/main/resources/ath-container/run.sh
@@ -53,7 +53,7 @@ if [ ! -f $war ]; then
         ;;
         "lts")
             war=jenkins-lts.war
-            url=$mirrors/war-stable/latest/jenkins.war
+            url=https://ci.jenkins.io/job/Core/job/jenkins/job/PR-6485/48/artifact/org/jenkins-ci/main/jenkins-war/2.350-rc32444.a_49359dd01a_f/jenkins-war-2.350-rc32444.a_49359dd01a_f.war
         ;;
         "lts-rc")
             war=jenkins-lts-rc.war


### PR DESCRIPTION
Hello there :wave:

While checking the impacts of https://github.com/jenkinsci/jenkins/pull/6485 on some CloudBees products based on Jenkins Core, I noticed (from internal CI) that this change breaks several ATHs.

AFAICT, the "checks" running on the PR are only executing 7 ATHs (which are all green btw) which is a very small subset of all ATHs.

In order to have some meaningful feedback to share with the authors of https://github.com/jenkinsci/jenkins/pull/6485 (great job btw!), here is a temporary PR attempting to run all the ATH suite against the core modification so we can collect some logs about the tests failures.

Please do not merge that Pull Request.