### PR TITLE
Add a timeout value parameter to PluginManager.checkForUpdates. 

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -86,15 +86,10 @@ public class PluginManager extends ContainerPageObject {
         this.jenkins = jenkins;
     }
 
-    public void checkForUpdates() {
-        checkForUpdates(30L);
-    }
-
     /**
      * Force update the plugin update center metadata.
-     * @param timeOutSeconds seconds to wait before timeout.
      */
-    public void checkForUpdates(long timeOutSeconds) {
+    public void checkForUpdates() {
         mockUpdateCenter.ensureRunning(jenkins);
         visit("index");
         final String current = getCurrentUrl();
@@ -104,7 +99,7 @@ public class PluginManager extends ContainerPageObject {
         WebElement checkButton = find(by.link("Check now"));
         checkButton.click();
         // The wait criteria is: we have left the current page and returned to the same one
-        waitFor(checkButton).withTimeout(java.time.Duration.of(time.seconds(timeOutSeconds), ChronoUnit.MILLIS)).until(webElement -> {
+        waitFor(checkButton).withTimeout(java.time.Duration.of(time.seconds(30), ChronoUnit.MILLIS)).until(webElement -> {
             try {
                 // We interact with the element just to detect if it is stale
                 webElement.findElement(by.id("it does not matter"));

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -86,10 +86,15 @@ public class PluginManager extends ContainerPageObject {
         this.jenkins = jenkins;
     }
 
+    public void checkForUpdates() {
+        checkForUpdates(30L);
+    }
+
     /**
      * Force update the plugin update center metadata.
+     * @param timeOutSeconds seconds to wait before timeout.
      */
-    public void checkForUpdates() {
+    public void checkForUpdates(long timeOutSeconds) {
         mockUpdateCenter.ensureRunning(jenkins);
         visit("index");
         final String current = getCurrentUrl();
@@ -99,7 +104,7 @@ public class PluginManager extends ContainerPageObject {
         WebElement checkButton = find(by.link("Check now"));
         checkButton.click();
         // The wait criteria is: we have left the current page and returned to the same one
-        waitFor(checkButton).withTimeout(java.time.Duration.of(time.seconds(30), ChronoUnit.MILLIS)).until(webElement -> {
+        waitFor(checkButton).withTimeout(java.time.Duration.of(time.seconds(timeOutSeconds), ChronoUnit.MILLIS)).until(webElement -> {
             try {
                 // We interact with the element just to detect if it is stale
                 webElement.findElement(by.id("it does not matter"));


### PR DESCRIPTION
New parameter to allow for adjusting of timeout duration during testing. Overload parameterless checkForUpdates to use the 30 second timeout as before. 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
