### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     ignore:
       # Selenium requires co-ordinated changes in consuming projects also due to the use of containers for webdriver
       - dependency-name: "org.seleniumhq.selenium:*"
+  - package-ecosystem: "docker"
+    directory: "src/main/resources/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Enable dependabot for docker containers.

Not sure if this works, Have heard mentions that for `docker` dependabot needs the specific path and will not search sub directories but I have found no mention of that.

Anyway w have a few containers here that could benifit from updates to check that Jenkins interoperates with the latest version of X (e.g [Artifactory ](https://github.com/jenkinsci/acceptance-test-harness/tree/83f372479c7d765be8a52900fe0f8677627aabe5/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/ArtifactoryContainer) / Jabber (is this still a thing!) 

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
