### PR TITLE
enable `GitRepo` to work on windows

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
@@ -9,8 +9,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -19,8 +20,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
-
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.zeroturnaround.zip.ZipUtil;
 
 import com.jcraft.jsch.ChannelExec;
@@ -34,7 +35,6 @@ import org.jenkinsci.test.acceptance.docker.fixtures.GitContainer;
 
 import static java.lang.ProcessBuilder.Redirect.*;
 import static java.nio.file.attribute.PosixFilePermission.*;
-import static java.util.Collections.*;
 import static org.jenkinsci.test.acceptance.docker.fixtures.GitContainer.*;
 
 /**
@@ -94,16 +94,22 @@ public class GitRepo implements Closeable {
     private File initDir() {
         try {
             // FIXME: perhaps this logic that makes it use a separate key should be moved elsewhere?
-            privateKey = File.createTempFile("ssh", "key");
+            privateKey = Files.createTempFile("ssh", "key").toFile();
+
             FileUtils.copyURLToFile(GitContainer.class.getResource("GitContainer/unsafe"), privateKey);
-            Files.setPosixFilePermissions(privateKey.toPath(), singleton(OWNER_READ));
 
-            ssh = File.createTempFile("jenkins", "ssh");
-            FileUtils.writeStringToFile(ssh,
-                    "#!/bin/sh\n" +
-                            "exec ssh -o StrictHostKeyChecking=no -i " + privateKey.getAbsolutePath() + " \"$@\"" , StandardCharsets.UTF_8);
-            Files.setPosixFilePermissions(ssh.toPath(), new HashSet<>(Arrays.asList(OWNER_READ, OWNER_EXECUTE)));
-
+            if (SystemUtils.IS_OS_WINDOWS) {
+                ssh = Files.createTempFile("jenkins", "ssh.cmd").toFile();
+                // this works if ssh is on the path, for example
+                // https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse
+                Files.writeString(ssh.toPath(), "ssh.exe -o StrictHostKeyChecking=no -i " + privateKey.getAbsolutePath() + " %*", Charset.defaultCharset());
+            } else {
+                ssh = Files.createTempFile("jenkins", "ssh").toFile();
+                FileUtils.writeStringToFile(ssh,
+                        "#!/bin/sh\n" +
+                                "exec ssh -o StrictHostKeyChecking=no -i " + privateKey.getAbsolutePath() + " \"$@\"", Charset.defaultCharset());
+                Files.setPosixFilePermissions(ssh.toPath(), new HashSet<>(Arrays.asList(OWNER_READ, OWNER_EXECUTE)));
+            }
             return createTempDir("git");
         } catch (IOException e) {
             throw new AssertionError("Can't initialize git directory", e);
@@ -198,7 +204,7 @@ public class GitRepo implements Closeable {
 
     public void touch(final String fileName) {
         try {
-            FileUtils.writeStringToFile(file(fileName), "", StandardCharsets.UTF_8);
+            FileUtils.writeStringToFile(file(fileName), "", Charset.defaultCharset());
         } catch (IOException e) {
             throw new AssertionError("Can't change file " + fileName, e);
         }
@@ -291,18 +297,21 @@ public class GitRepo implements Closeable {
             ChannelSftp channel = (ChannelSftp) session.openChannel("sftp");
             channel.connect();
             channel.cd("/home/git");
-            channel.put(Files.newInputStream(zippedRepo.toPath()), zippedFilename);
+            try (InputStream fis = Files.newInputStream(zippedRepo.toPath())) {
+                channel.put(fis, zippedFilename);
+            }
 
             ChannelExec channelExec = (ChannelExec) session.openChannel("exec");
             InputStream in = channelExec.getInputStream();
             channelExec.setCommand("unzip " + zippedFilename + " -d " + REPO_NAME);
             channelExec.connect();
 
-            BufferedReader reader = new BufferedReader(new InputStreamReader(in));
-            String line;
-            int index = 0;
-            while ((line = reader.readLine()) != null) {
-                System.out.println(++index + " : " + line);
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+                String line;
+                int index = 0;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(++index + " : " + line);
+                }
             }
 
             channelExec.disconnect();


### PR DESCRIPTION
fixes: #745

tested with `mvn test -Dtest=plugins.WorkflowPluginTest#hello_world_from_git` locally (windows)  ([source](https://github.com/jtnord/acceptance-test-harness/blob/0f5270fd68e2d278188cf6ebd911a13de418d514/src/test/java/plugins/WorkflowPluginTest.java#L99-L119))

There will be some environments where this does not work (no ssh.exe is available - and then if your git global config is set to use `plink` (an option when installing) then whilst gitRepo works, tests will eventual fail due to the git-client plugin not supporting this, and also https://issues.jenkins.io/browse/JENKINS-71122 is ssh.exe is on the path but not in a "well known" location (workaround is to set GIT_SSH to the path of the ssh executable).

these issues are either environmental or bugs in a plugin not the ATH.  this works in more cases that it did before so considering this "good engough"

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
