### PR TITLE
[JENKINS-49707] Retry `node` block after infrastructure outages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,7 @@ for (int i = 0; i < splits.size(); i++) {
       def name = "java-${javaVersion}-jenkins-${jenkinsUnderTest}-split${index}"
       branches[name] = {
         stage(name) {
+         retry(count: 2, conditions: [agent(), nonresumable()]) {
           node('docker-highmem') {
             checkout scm
             def image = docker.build('jenkins/ath', '--build-arg uid="$(id -u)" --build-arg gid="$(id -g)" ./src/main/resources/ath-container/')
@@ -58,6 +59,7 @@ for (int i = 0; i < splits.size(); i++) {
               }
             }
           }
+         }
         }
       }
     }


### PR DESCRIPTION
Analogous to https://github.com/jenkins-infra/pipeline-library/pull/405. Should be possible as of https://github.com/jenkins-infra/helpdesk/issues/2984#issuecomment-1176418097.
