### PR TITLE
build: Update mail to 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,9 +337,9 @@
       <version>1.15</version>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
-      <version>1.4.4</version>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>jakarta.mail</artifactId>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/MailhogContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/MailhogContainer.java
@@ -29,7 +29,6 @@ import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
 import org.jenkinsci.test.acceptance.utils.IOUtil;
 
-import javax.mail.MessagingException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;

--- a/src/test/java/plugins/WorkflowMultibranchTest.java
+++ b/src/test/java/plugins/WorkflowMultibranchTest.java
@@ -13,7 +13,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import javax.mail.MessagingException;
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.containsString;


### PR DESCRIPTION
mail is discontinued and lives on as jakarta mail, alternative to https://github.com/jenkinsci/acceptance-test-harness/pull/827