### PR TITLE
build: Remove old httpclient version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,11 +266,6 @@
       <version>1.4</version>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1-jenkins-3</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>


### PR DESCRIPTION
Follow up to https://github.com/jenkinsci/acceptance-test-harness/pull/850

The artifact seems to be covered by our now updated versions of httpcore and -client and is now obsolete.