### PR TITLE
ATH should not be Java11 only (yet)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,8 @@
     <mockito.version>1.10.19</mockito.version>
     <slf4j.version>1.7.36</slf4j.version>
     <!-- TODO remove these when we can finally switch to Java 11 requirements -->
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-    <maven.compiler.testSource>8</maven.compiler.testSource>
-    <maven.compiler.testTarget>8</maven.compiler.testTarget>
-    <maven.compiler.release/>
-    <maven.compiler.testRelease/>
+    <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.testRelease>8</maven.compiler.testRelease>
   </properties>
 
   <repositories>
@@ -574,14 +570,6 @@
                   <version>[3.8.1,)</version>
                   <message>3.8.1 required to no longer download dependencies via HTTP (use HTTPS instead).</message>
                 </requireMavenVersion>
-                <!-- TODO failing during incrementals deploy: MENFORCER-281
-                <requirePluginVersions>
-                  <banSnapshots>false</banSnapshots>
-                </requirePluginVersions>
-                -->
-                <requireJavaVersion>
-                  <version>[1.8.0,]</version>
-                </requireJavaVersion>
                 <enforceBytecodeVersion>
                   <maxJdkVersion>1.8</maxJdkVersion>
                 </enforceBytecodeVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -564,12 +564,8 @@
               <goal>enforce</goal>
             </goals>
             <phase>validate</phase>
-            <configuration >
+            <configuration>
               <rules>
-                <requireMavenVersion>
-                  <version>[3.8.1,)</version>
-                  <message>3.8.1 required to no longer download dependencies via HTTP (use HTTPS instead).</message>
-                </requireMavenVersion>
                 <enforceBytecodeVersion>
                   <maxJdkVersion>1.8</maxJdkVersion>
                 </enforceBytecodeVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,13 @@
     <monte.version>0.7.7.0</monte.version>
     <mockito.version>1.10.19</mockito.version>
     <slf4j.version>1.7.36</slf4j.version>
+    <!-- TODO remove these when we can finally switch to Java 11 requirements -->
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.testSource>8</maven.compiler.testSource>
+    <maven.compiler.testTarget>8</maven.compiler.testTarget>
+    <maven.compiler.release/>
+    <maven.compiler.testRelease/>
   </properties>
 
   <repositories>
@@ -540,6 +547,46 @@
             <goals>
               <goal>run</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- overwite parent config so we do not require java 11 prematurely -->
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.5.1</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>display-info</id>
+            <goals>
+              <goal>display-info</goal>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration >
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.8.1,)</version>
+                  <message>3.8.1 required to no longer download dependencies via HTTP (use HTTPS instead).</message>
+                </requireMavenVersion>
+                <!-- TODO failing during incrementals deploy: MENFORCER-281
+                <requirePluginVersions>
+                  <banSnapshots>false</banSnapshots>
+                </requirePluginVersions>
+                -->
+                <requireJavaVersion>
+                  <version>[1.8.0,]</version>
+                </requireJavaVersion>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.8</maxJdkVersion>
+                </enforceBytecodeVersion>
+              </rules>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
The parent was updated to produce java11 bytecode in https://github.com/jenkinsci/acceptance-test-harness/pull/851#issuecomment-1192377049.
We should not yet be requiring Java11, indeed even when Jenkins is Java11 there is no rush to move to Java11 until we want to take advantage of a java11 library or use java11 features.


<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
