### PR TITLE
ByPass the FileDetector for things that are not files

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_slaves/SshSlaveLauncher.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_slaves/SshSlaveLauncher.java
@@ -10,7 +10,7 @@ import org.jenkinsci.test.acceptance.po.ComputerLauncher;
 import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.PageObject;
-
+import org.jenkinsci.test.acceptance.selenium.UselessFileDetectorReplacement;
 import static org.junit.Assert.*;
 
 /**
@@ -24,7 +24,7 @@ public class SshSlaveLauncher extends ComputerLauncher {
     public final Control suffixCmd = control("suffixStartSlaveCmd");
     public final Control timeout = control("launchTimeoutSeconds");
     public final Control retries = control("maxNumRetries");
-    public final Control javaPath = control("javaPath");
+    private final Control javaPath = control("javaPath");
     public final Control jvmOptions = control("jvmOptions");
     public final Control hostKeyVerificationStrategy = control("/");
 
@@ -44,6 +44,11 @@ public class SshSlaveLauncher extends ComputerLauncher {
         return new SshCredentialDialog(getPage(), "/credentials");
     }
 
+    public void setJavaPath(String jvmPath) {
+        try (UselessFileDetectorReplacement ufd = new UselessFileDetectorReplacement(driver)) {
+            javaPath.set(jvmPath);
+        }
+    }
     public SshSlaveLauncher port(int port) {
         ensureAdvancedOpen();
         control("port").set(port);

--- a/src/main/java/org/jenkinsci/test/acceptance/selenium/UselessFileDetectorReplacement.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/selenium/UselessFileDetectorReplacement.java
@@ -22,7 +22,6 @@ public class UselessFileDetectorReplacement implements AutoCloseable {
      *   control.setText(someTextThatIsAlsoALocalFileName);
      * }
      * </code>
-     * @param driver
      */
     public UselessFileDetectorReplacement(WebDriver driver) {
         if (driver instanceof RemoteWebDriver) {

--- a/src/main/java/org/jenkinsci/test/acceptance/selenium/UselessFileDetectorReplacement.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/selenium/UselessFileDetectorReplacement.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.test.acceptance.selenium;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.FileDetector;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.UselessFileDetector;
+
+/**
+ * Replaces the current {@link FileDetector} with the useless one that does nothing. This is handy when you are using a
+ * String that is a file that is on a remote system as well as the local one and you do not want Selenium to transfer it
+ * across.
+ */
+public class UselessFileDetectorReplacement implements AutoCloseable {
+
+    private final FileDetector previous;
+    private final RemoteWebDriver remoteDriver;
+
+    /** 
+     * Create a new instance suitable for use in a try-with-resources block.
+     * Example usage is:<code>
+     * try (UselessFileDetectorReplacement ufd = new UselessFileDetectorReplacement(driver)) {
+     *   control.setText(someTextThatIsAlsoALocalFileName);
+     * }
+     * </code>
+     * @param driver
+     */
+    public UselessFileDetectorReplacement(WebDriver driver) {
+        if (driver instanceof RemoteWebDriver) {
+            remoteDriver = (RemoteWebDriver) driver;
+            previous = remoteDriver.getFileDetector();
+            remoteDriver.setFileDetector(new UselessFileDetector());
+        } else {
+            remoteDriver = null;
+            previous = null;
+        }
+    }
+
+    @Override
+    public void close() {
+        if (remoteDriver != null) {
+            remoteDriver.setFileDetector(previous);
+        }
+    }
+}

--- a/src/test/java/plugins/SshSlavesPluginTest.java
+++ b/src/test/java/plugins/SshSlavesPluginTest.java
@@ -215,7 +215,7 @@ public class SshSlavesPluginTest extends AbstractJUnitTest {
         if (System.getProperty("os.arch").equals("aarch64")) {
             javaPath = "/usr/lib/jvm/java-11-openjdk-arm64/bin/java";
         }
-        launcher.javaPath.set(javaPath);
+        launcher.setJavaPath(javaPath);
         slave.save();
     
         verify();


### PR DESCRIPTION
The FileDetector replaces any string that is also a local file by a
temp string and uploads that file to the remote system (at the location specified in the temp string).

This is generally a good thing, but sometimes the string that is also a file path is really a string and not something local or that needs replaces.

This is always the case for the JVM path when used in an external system.


Amends #780   detected when trying to bump this as a dependency in a closed source test suite.

```
[08/09/22 12:54:32] [SSH] Starting agent process: cd "/home/test" && /tmp/7fd87797-fc61-4f70-9b2d-079c37ac4a49/upload1745090074472040540file/java  -jar remoting.jar -workDir /home/test -jar-cache /home/test/remoting/jarCache
sh: 1: /tmp/7fd87797-fc61-4f70-9b2d-079c37ac4a49/upload1745090074472040540file/java: not found
Agent JVM has terminated. Exit code=127
[08/09/22 12:54:32] Launch failed - cleaning up connection
[08/09/22 12:54:32] [SSH] Connection closed.
```

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
