### PR TITLE
Do not assume that `forkCount` is an integer

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/utils/ElasticTime.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/ElasticTime.java
@@ -45,7 +45,16 @@ public class ElasticTime {
     /**
      * Amount of threads executing concurrently. Time is slowed down proportionally multiplying the time;
      */
-    private final int concurrency = Integer.parseInt(System.getProperty("forkCount", "1"));
+    private final int concurrency;
+    {
+        int forkCount = 1;
+        try {
+            forkCount = Integer.parseInt(System.getProperty("forkCount", "1"));
+        } catch (NumberFormatException x) {
+            // may be floating point or use C suffix, fine
+        }
+        concurrency = forkCount;
+    }
 
     /**
      * Relative performance difference compared to reference environment (Upstream CI).


### PR DESCRIPTION
`warnings-ng` failed in PCT with

```
java.lang.NumberFormatException: For input string: ".75C"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Integer.parseInt(Integer.java:638)
	at java.base/java.lang.Integer.parseInt(Integer.java:770)
	at org.jenkinsci.test.acceptance.utils.ElasticTime.<init>(ElasticTime.java:48)
	at org.jenkinsci.test.acceptance.utils.IOUtil.<clinit>(IOUtil.java:39)
	at …
```

See https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#forkCount

> When terminated with "C", the number part is multiplied with the number of CPU cores. Floating point value are only accepted together with "C".
