### PR TITLE
Use "No verification" ssh host key verification strategy

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git_client/ssh_host_key_verification/AcceptFirstConnectionStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git_client/ssh_host_key_verification/AcceptFirstConnectionStrategy.java
@@ -1,0 +1,11 @@
+package org.jenkinsci.test.acceptance.plugins.git_client.ssh_host_key_verification;
+
+import org.jenkinsci.test.acceptance.po.Describable;
+
+@Describable("org.jenkinsci.plugins.gitclient.verifier.AcceptFirstConnectionStrategy")
+public class AcceptFirstConnectionStrategy extends SshHostKeyVerificationStrategy {
+    @Override
+    public String id() {
+        return "0";
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git_client/ssh_host_key_verification/KnownHostsFileStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git_client/ssh_host_key_verification/KnownHostsFileStrategy.java
@@ -1,0 +1,11 @@
+package org.jenkinsci.test.acceptance.plugins.git_client.ssh_host_key_verification;
+
+import org.jenkinsci.test.acceptance.po.Describable;
+
+@Describable("org.jenkinsci.plugins.gitclient.verifier.KnownHostsFileVerificationStrategy")
+public class KnownHostsFileStrategy extends SshHostKeyVerificationStrategy {
+    @Override
+    public String id() {
+        return "1";
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git_client/ssh_host_key_verification/ManuallyProvidedKeysStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git_client/ssh_host_key_verification/ManuallyProvidedKeysStrategy.java
@@ -1,0 +1,11 @@
+package org.jenkinsci.test.acceptance.plugins.git_client.ssh_host_key_verification;
+
+import org.jenkinsci.test.acceptance.po.Describable;
+
+@Describable("org.jenkinsci.plugins.gitclient.verifier.ManuallyProvidedKeyVerificationStrategy")
+public class ManuallyProvidedKeysStrategy extends SshHostKeyVerificationStrategy {
+    @Override
+    public String id() {
+        return "2";
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git_client/ssh_host_key_verification/NoVerificationStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git_client/ssh_host_key_verification/NoVerificationStrategy.java
@@ -1,0 +1,11 @@
+package org.jenkinsci.test.acceptance.plugins.git_client.ssh_host_key_verification;
+
+import org.jenkinsci.test.acceptance.po.Describable;
+
+@Describable("org.jenkinsci.plugins.gitclient.verifier.NoHostKeyVerificationStrategy")
+public class NoVerificationStrategy extends SshHostKeyVerificationStrategy {
+    @Override
+    public String id() {
+        return "3";
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git_client/ssh_host_key_verification/SshHostKeyVerificationStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git_client/ssh_host_key_verification/SshHostKeyVerificationStrategy.java
@@ -1,0 +1,6 @@
+package org.jenkinsci.test.acceptance.plugins.git_client.ssh_host_key_verification;
+
+public abstract class SshHostKeyVerificationStrategy {
+
+    public abstract String id();
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
@@ -23,10 +23,11 @@
  */
 package org.jenkinsci.test.acceptance.po;
 
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 
 import org.jenkinsci.test.acceptance.plugins.authorize_project.BuildAccessControl;
-import org.openqa.selenium.By;
+import org.jenkinsci.test.acceptance.plugins.git_client.ssh_host_key_verification.SshHostKeyVerificationStrategy;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
@@ -58,6 +59,20 @@ public class GlobalSecurityConfig extends ContainerPageObject {
     public <T extends AuthorizationStrategy> T useAuthorizationStrategy(Class<T> type) {
         maybeCheckUseSecurity();
         return selectFromDropdownOrRadioGroup(type, "authorizationStrategy");
+    }
+
+    public <T extends SshHostKeyVerificationStrategy> void useSshHostKeyVerificationStrategy(final Class<T> type) {
+        Control gitHostKeyVerificationConfiguration = control("/org-jenkinsci-plugins-gitclient-GitHostKeyVerificationConfiguration/");
+        if (gitHostKeyVerificationConfiguration.exists()) {
+            T instance;
+            try {
+                instance = type.getDeclaredConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                     NoSuchMethodException e) {
+                throw new IllegalArgumentException("Can't initiate a new instance of " + type.getName() + " .", e);
+            }
+            gitHostKeyVerificationConfiguration.select(instance.id());
+        }
     }
 
     private void maybeCheckUseSecurity() {

--- a/src/test/java/plugins/GitPluginTest.java
+++ b/src/test/java/plugins/GitPluginTest.java
@@ -29,7 +29,9 @@ import org.jenkinsci.test.acceptance.docker.fixtures.GitContainer;
 import org.jenkinsci.test.acceptance.junit.*;
 import org.jenkinsci.test.acceptance.plugins.git.GitRepo;
 import org.jenkinsci.test.acceptance.plugins.git.GitScm;
+import org.jenkinsci.test.acceptance.plugins.git_client.ssh_host_key_verification.NoVerificationStrategy;
 import org.jenkinsci.test.acceptance.po.Build;
+import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -70,8 +72,18 @@ public class GitPluginTest extends AbstractJUnitTest {
         repoUrl = container.getRepoUrl();
         host = container.host();
         port = container.port();
+
+        useNoVerificationSshHostKeyStrategy();
+
         job = jenkins.jobs.create();
         job.configure();
+    }
+
+    private void useNoVerificationSshHostKeyStrategy() {
+        GlobalSecurityConfig sc = new GlobalSecurityConfig(jenkins);
+        sc.open();
+        sc.useSshHostKeyVerificationStrategy(NoVerificationStrategy.class);
+        sc.save();
     }
 
     @Test

--- a/src/test/java/plugins/WorkflowPluginTest.java
+++ b/src/test/java/plugins/WorkflowPluginTest.java
@@ -45,6 +45,7 @@ import org.jenkinsci.test.acceptance.junit.WithDocker;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.git.GitRepo;
 import org.jenkinsci.test.acceptance.plugins.git_client.JGitInstallation;
+import org.jenkinsci.test.acceptance.plugins.git_client.ssh_host_key_verification.NoVerificationStrategy;
 import org.jenkinsci.test.acceptance.plugins.maven.MavenInstallation;
 import org.jenkinsci.test.acceptance.plugins.ssh_slaves.SshSlaveLauncher;
 import org.jenkinsci.test.acceptance.plugins.workflow_multibranch.GithubBranchSource;
@@ -53,10 +54,12 @@ import org.jenkinsci.test.acceptance.plugins.workflow_shared_library.WorkflowSha
 import org.jenkinsci.test.acceptance.po.Artifact;
 import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.DumbSlave;
+import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
 import org.jenkinsci.test.acceptance.slave.SlaveController;
 import org.jenkinsci.utils.process.CommandBuilder;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Issue;
@@ -80,6 +83,14 @@ public class WorkflowPluginTest extends AbstractJUnitTest {
     @Inject DockerContainerHolder<SvnContainer> svn;
     @Inject DockerContainerHolder<DockerAgentContainer> agent;
     @Inject JenkinsController controller;
+
+    @Before
+    public void useNoVerificationSshHostKeyStrategy() {
+        GlobalSecurityConfig sc = new GlobalSecurityConfig(jenkins);
+        sc.open();
+        sc.useSshHostKeyVerificationStrategy(NoVerificationStrategy.class);
+        sc.save();
+    }
 
     @Category(DockerTest.class)
     @WithDocker


### PR DESCRIPTION
Proposed solution for https://github.com/jenkinsci/acceptance-test-harness/issues/877

Git-client 3.11.2 and later uses ‘Known hosts file’ as default strategy (instead of git-client 3.11.1 used ‘Accept first connection'), so tests will continue to fail, I suggest to use ’No verification’ strategy for now (but please confirm that ATH only connects to local Git servers and we do not care about MitM attacks), but once #878 will be merged better to switch to ‘Accept first connection’.

Fixes https://github.com/jenkinsci/acceptance-test-harness/issues/877