### PR TITLE
Use proper `@see` javadoc notation

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
@@ -103,7 +103,7 @@ public class Wait<Subject> extends FluentWait<Subject> {
      * Create wait with configurable timer.
      * <p>
      * This is useful for timeout waiting wall-clock time to pass.
-     * @see #Wait(Subject, ElasticTime)
+     * @see Wait#Wait(Subject, ElasticTime)
      */
     public Wait(Subject input) {
         super(input);

--- a/src/main/java/org/jenkinsci/test/acceptance/slave/SlaveController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/slave/SlaveController.java
@@ -59,7 +59,6 @@ public abstract class SlaveController extends CapybaraPortingLayerImpl implement
     /**
      * Stops the slave from the slave side, for those slave launch methods that support it.
      * <p>
-     * <p>
      * Most notably JNLP slaves can control their own lifecycles, and for those slaves this method lets you disconnect
      * this slave. A stopped slave can be later reconnected via {@link #start()}.
      */


### PR DESCRIPTION
Even if James' proposed changes were valid according to IJ, they didn't suffice for javadoc ☹️ 

![Screenshot 2022-08-12 at 17 02 28](https://user-images.githubusercontent.com/13383509/184383975-88790c1f-633a-48e8-87b5-8196ddbe8c97.png)

I changed your proposal to a Class#method reference to be explicit.

(On a future note, these issues should probably fail the build, because addressing them post merge isn't the best imo)