### PR TITLE
Don't skip doclint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
     <version>1.85</version>
+    <relativePath />
   </parent>
 
   <artifactId>acceptance-test-harness</artifactId>
@@ -485,6 +486,8 @@
         <artifactId>maven-source-plugin</artifactId>
         <executions>
           <execution>
+            <phase>compile</phase>
+            <id>generate-sources</id>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -495,15 +498,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.4.0</version>
-        <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
-        </configuration>
         <executions>
           <execution>
-            <id>attach-javadocs</id>
-            <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
-            </configuration>
+            <phase>compile</phase>
+            <id>generate-javadocs</id>
+            <goals>
+                <goal>jar</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
@@ -103,7 +103,8 @@ public class Wait<Subject> extends FluentWait<Subject> {
      * Create wait with configurable timer.
      * <p>
      * This is useful for timeout waiting wall-clock time to pass.
-     * @see Wait#Wait(Subject, ElasticTime)
+     *
+     * @see Wait#Wait(Object, ElasticTime)
      */
     public Wait(Subject input) {
         super(input);


### PR DESCRIPTION
The build as-is fails for me locally if I invoke `mvn clean verify -DskipTests`, and should fail on ci.j too, because we're lacking https://github.com/jenkinsci/acceptance-test-harness/pull/890.