### PR TITLE
fix: Workaround (possible) javadoc 11 issue with `@see` and generics

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
@@ -103,7 +103,8 @@ public class Wait<Subject> extends FluentWait<Subject> {
      * Create wait with configurable timer.
      * <p>
      * This is useful for timeout waiting wall-clock time to pass.
-     * @see Wait#Wait(Subject, ElasticTime)
+     *
+     * @see Wait#Wait(Object, ElasticTime)
      */
     public Wait(Subject input) {
         super(input);


### PR DESCRIPTION
See https://github.com/jenkinsci/acceptance-test-harness/pull/890#issuecomment-1213431409 for context

Javadocs are pretty nasty...

(Head branch, please delete after merge.)