### PR TITLE
the WebDriver may be wrapped so we also need to unwrap it

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/Credential.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/Credential.java
@@ -27,10 +27,11 @@ public abstract class Credential extends PageAreaImpl {
      * Adds this credential and close the dialog.
      */
     public void add() {
+        WebElement dialog = find(by.id("credentialsDialog"));
         WebElement we = find(by.id("credentials-add-submit-button"));
         we.click();
         // wait for the form to be removed from the UI
-        waitFor(driver).until(ExpectedConditions.invisibilityOf(we));
+        waitFor(driver).until(ExpectedConditions.invisibilityOf(dialog));
     }
 
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/SlavesMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/SlavesMixIn.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.test.acceptance.po;
 
+import org.jenkinsci.test.acceptance.selenium.Scroller;
 import org.openqa.selenium.NoSuchElementException;
 
 import java.io.File;
@@ -41,6 +42,10 @@ public class SlavesMixIn extends MixIn {
         // This form submission will drop us on the configure page
 
         S s = newInstance(type, jenkins, name);
+        // Automatic disabling of sticky elements doesn't occur after a redirect
+        // so force it after the configuration page has loaded
+        new Scroller().disableStickyElements(driver);
+
 
         // reasonable starting point values
         s.setExecutors(1);

--- a/src/main/java/org/jenkinsci/test/acceptance/selenium/UselessFileDetectorReplacement.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/selenium/UselessFileDetectorReplacement.java
@@ -26,7 +26,9 @@ public class UselessFileDetectorReplacement implements AutoCloseable {
      */
     public UselessFileDetectorReplacement(WebDriver driver) {
         driver = getNonWrappedDriver(driver);
-        if (driver instanceof RemoteWebDriver) {
+        if (driver.getClass().equals(RemoteWebDriver.class)) {
+            // we test the explicit class not instanceof as the local FirefoxDriver and others 
+            // are also RemoteWebDriver but can not be configured with a FileDetector
             remoteDriver = (RemoteWebDriver) driver;
             previous = remoteDriver.getFileDetector();
             remoteDriver.setFileDetector(new UselessFileDetector());

--- a/src/main/java/org/jenkinsci/test/acceptance/selenium/UselessFileDetectorReplacement.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/selenium/UselessFileDetectorReplacement.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.test.acceptance.selenium;
 
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.remote.FileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.UselessFileDetector;
@@ -24,6 +25,7 @@ public class UselessFileDetectorReplacement implements AutoCloseable {
      * </code>
      */
     public UselessFileDetectorReplacement(WebDriver driver) {
+        driver = getNonWrappedDriver(driver);
         if (driver instanceof RemoteWebDriver) {
             remoteDriver = (RemoteWebDriver) driver;
             previous = remoteDriver.getFileDetector();
@@ -32,6 +34,18 @@ public class UselessFileDetectorReplacement implements AutoCloseable {
             remoteDriver = null;
             previous = null;
         }
+    }
+
+    /**
+     * Obtain the underlying driver if the driver is {@link WrapsDriver wrapped} otherwise returns {@code driver}. 
+     * @param driver the {@link WebDriver} to unwrap or return if it is not wrapped. 
+     */
+    private WebDriver getNonWrappedDriver(WebDriver driver) {
+        WebDriver d = driver;
+        while (d instanceof WrapsDriver) {
+            d = ((WrapsDriver)d).getWrappedDriver();
+        }
+        return d;
     }
 
     @Override


### PR DESCRIPTION
The WebDriver may be wrapped or unwrapped so we need to unwarp it to get
the underlying driver to see if that is a RemoteWebDriver to configure
the FileDetector

amends #884

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
