### PR TITLE
Remove redundant project.build.sourceEncoding property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <trimStackTrace>false</trimStackTrace> <!-- surefire -->
     <spotbugs.skip>true</spotbugs.skip>
 


### PR DESCRIPTION
This has been in the parent POM since https://github.com/jenkinsci/pom/pull/257 which was released in 1.76.