### PR TITLE
Remove redundant `maven.test.redirectTestOutputToFile` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -691,7 +691,6 @@
         </property>
       </activation>
       <properties>
-        <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
         <surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>
       </properties>
     </profile>


### PR DESCRIPTION
This has been in the parent POM since https://github.com/jenkinsci/pom/pull/273 which was released in 1.79.