### PR TITLE
tests: Address #assertThat deprecations

### DIFF
--- a/src/test/java/core/CreateItemTest.java
+++ b/src/test/java/core/CreateItemTest.java
@@ -7,10 +7,10 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
 
 public class CreateItemTest extends AbstractJUnitTest {
 

--- a/src/test/java/core/InstallWizardTest.java
+++ b/src/test/java/core/InstallWizardTest.java
@@ -23,6 +23,7 @@
  */
 package core;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;
 
 import java.io.IOException;
@@ -36,7 +37,6 @@ import org.jenkinsci.test.acceptance.po.Login;
 import org.jenkinsci.test.acceptance.po.WizardCreateAdminUser;
 import org.jenkinsci.test.acceptance.po.WizardCustomizeJenkins;
 import org.jenkinsci.test.acceptance.po.WizardLogin;
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.inject.Inject;
@@ -79,7 +79,7 @@ public class InstallWizardTest extends AbstractJUnitTest {
 
         // Check that the new user is logged in
         Login login = new Login(jenkins);
-        Assert.assertThat(login, loggedInAs("adminuser"));
+        assertThat(login, loggedInAs("adminuser"));
     }
 
     @Since("2.0")
@@ -114,6 +114,6 @@ public class InstallWizardTest extends AbstractJUnitTest {
 
         // Check that the new user is logged in
         Login login = new Login(jenkins);
-        Assert.assertThat(login, loggedInAs("adminuser"));
+        assertThat(login, loggedInAs("adminuser"));
     }
 }

--- a/src/test/java/core/JenkinsDatabaseSecurityRealmTest.java
+++ b/src/test/java/core/JenkinsDatabaseSecurityRealmTest.java
@@ -25,21 +25,16 @@ package core;
 
 import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
-import org.jenkinsci.test.acceptance.junit.SmokeTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
 import org.jenkinsci.test.acceptance.po.JenkinsDatabaseSecurityRealm;
 import org.jenkinsci.test.acceptance.po.User;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
-import static org.hamcrest.Matchers.any;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
 
 @WithPlugins("mailer")
 public class JenkinsDatabaseSecurityRealmTest extends AbstractJUnitTest {

--- a/src/test/java/org/jenkinsci/test/acceptance/recorder/TestRecorderRuleTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/recorder/TestRecorderRuleTest.java
@@ -7,10 +7,10 @@ import org.junit.runner.Description;
 
 import java.io.File;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.jenkinsci.test.acceptance.Matchers.existingFile;
-import static org.junit.Assert.assertThat;
 
 public class TestRecorderRuleTest {
 

--- a/src/test/java/plugins/AntisamyMarkupFormatterTest.java
+++ b/src/test/java/plugins/AntisamyMarkupFormatterTest.java
@@ -7,7 +7,7 @@ import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
 import org.junit.Test;
 import org.openqa.selenium.NoSuchElementException;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 

--- a/src/test/java/plugins/AuthorizeProjectTest.java
+++ b/src/test/java/plugins/AuthorizeProjectTest.java
@@ -8,10 +8,10 @@ import org.jenkinsci.test.acceptance.plugins.mock_security_realm.MockSecurityRea
 import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
@@ -47,16 +47,16 @@ public class AuthorizeProjectTest extends AbstractJUnitTest {
         Build b = job.startBuild().shouldSucceed();
 
         String consoleOutput = b.getConsole();
-        Assert.assertThat(consoleOutput, containsString(STARTED_BY_USER2));
-        Assert.assertThat(consoleOutput, not(containsString(RUNNING_ANONYMOUS)));
+        assertThat(consoleOutput, containsString(STARTED_BY_USER2));
+        assertThat(consoleOutput, not(containsString(RUNNING_ANONYMOUS)));
 
         this.authorizeUserToLaunchProject(USER1);
 
         b = job.startBuild().shouldSucceed();
         consoleOutput = b.getConsole();
-        Assert.assertThat(consoleOutput, containsString(STARTED_BY_USER2));
+        assertThat(consoleOutput, containsString(STARTED_BY_USER2));
         // Running as anonymous is displayed due to permissions but the plugin performs its job
-        Assert.assertThat(consoleOutput, containsString(RUNNING_ANONYMOUS));
+        assertThat(consoleOutput, containsString(RUNNING_ANONYMOUS));
     }
 
     private void setupUsers(final GlobalSecurityConfig security, final String... users) {

--- a/src/test/java/plugins/ConfigFileProviderTest.java
+++ b/src/test/java/plugins/ConfigFileProviderTest.java
@@ -14,8 +14,8 @@ import org.jenkinsci.test.acceptance.po.WorkflowJob;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests config-file-provider plugin inside a Pipeline.

--- a/src/test/java/plugins/CredentialsBindingTest.java
+++ b/src/test/java/plugins/CredentialsBindingTest.java
@@ -1,6 +1,5 @@
 package plugins;
 
-import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.credentials.CredentialsPage;
@@ -14,7 +13,7 @@ import org.jenkinsci.test.acceptance.po.ShellBuildStep;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @WithPlugins ({"plain-credentials", "credentials-binding", "credentials@2.0"})
 public class CredentialsBindingTest extends AbstractJUnitTest {

--- a/src/test/java/plugins/MSBuildPluginTest.java
+++ b/src/test/java/plugins/MSBuildPluginTest.java
@@ -1,6 +1,6 @@
 package plugins;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 


### PR DESCRIPTION
JUnit's Assert#assertThat is deprecated in favor of hamcrest, which already is used in a plenty of occasions.