### PR TITLE
getAvailableVersionForPlugin now properly waits for plugin list to refresh, and becomes public

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -313,7 +313,7 @@ public class PluginManager extends ContainerPageObject {
         }
     }
 
-    private VersionNumber getAvailableVersionForPlugin(String pluginName) {
+    public VersionNumber getAvailableVersionForPlugin(String pluginName) {
         // assuming we are on 'available' or 'updates' page
         WebElement filterBox = find(By.id("filter-box"));
         filterBox.clear();

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -318,9 +318,8 @@ public class PluginManager extends ContainerPageObject {
         WebElement filterBox = find(By.id("filter-box"));
         filterBox.clear();
         filterBox.sendKeys(pluginName);
-        String v = find(by.xpath("//input[starts-with(@name,'plugin.%s.')]/ancestor::tr/td[2]//span[contains(@class, 'jenkins-label')] | " +
-                "//input[starts-with(@name,'plugin.%s.')]/ancestor::tr/td[3]", pluginName, pluginName)).getText();
-        return new VersionNumber(v);
+        String version = find(by.xpath("//input[starts-with(@name,'plugin.%s.')]/ancestor::tr", pluginName)).getAttribute("data-plugin-version");
+        return new VersionNumber(version);
     }
 
     /**


### PR DESCRIPTION
Hello :wave:

For some internal tests we are writting at CloudBees relying on the ATH, we would like to use `getAvailableVersionForPlugin` which is private. 

This Pull Request is to make it public, but also to use a simplified XPath (and probably an easier way to retrieve
plugins' versions), and finally, to protect the test from flakiness by properly waiting for the plugins' list to be
loaded before searching for the version after using the filterbox.

Let me know if you'd like any changes to the proposed code.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
