### PR TITLE
Fix plugin size mismatch when LOCAL_JARS is used

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -122,6 +122,8 @@ public class MockUpdateCenter implements AutoCleaned {
                 }
                 plugin.put("url", name + ".hpi");
                 updating(plugin, "version", version);
+                // "Avoid IOException: Inconsistent file length" from hudson.model.UpdateCenter
+                updating(plugin, "size", "-1");
                 updating(plugin, "gav", meta.gav);
                 updating(plugin, "requiredCore", meta.requiredCore().toString());
                 updating(plugin, "dependencies", new JSONArray(meta.getDependencies().stream().map(d -> {


### PR DESCRIPTION
When plugins are injected using `LOCAL_JARS`, Jenkins fails to load them because of `java.io.IOException: Inconsistent file length: expected XXXXXX but only got YYYYYY`.

While I do not understand why it was working before - all relevant code seems in place for years. The discrepancy between metadata and actual file size is undesirable.

So this erases file size from metadata, forcing Jenkins to accept whatever is being served.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
