### PR TITLE
Drop XMLUnit-legacy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,11 +339,6 @@
       <version>1.5</version>
     </dependency>
     <dependency>
-      <groupId>org.xmlunit</groupId>
-      <artifactId>xmlunit-legacy</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>jira-api</artifactId>
       <version>1.3</version>


### PR DESCRIPTION
Apparently unused, if it's not a dependency for something else.