### PR TITLE
Update remoting to 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>remoting</artifactId>
-      <version>3.2</version>
+      <version>4.13.3</version>
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>


### PR DESCRIPTION
Apparently we do use remoting here, in a handful amount of classes, therefore it makes sense to use an up to date version.