### PR TITLE
Remove unused imports and do linebreaks properly

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/ByFactory.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/ByFactory.java
@@ -1,22 +1,15 @@
 package org.jenkinsci.test.acceptance;
 
-import javax.xml.namespace.QName;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-import javax.xml.xpath.XPathVariableResolver;
 
 import org.jenkinsci.test.acceptance.po.PageObject;
 import org.openqa.selenium.By;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.By.ByPartialLinkText;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
 
 /**
  * More factories for {@link By} objects.
@@ -95,7 +88,7 @@ public class ByFactory {
 
     /**
      * Returns the "path" selector that finds an element by following the form-element-path plugin.
-     *
+     * <p>
      * <a href="https://plugins.jenkins.io/form-element-path/">form-element-path-plugin</a>
      */
     public By path(String path, Object... args) {

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -463,7 +463,7 @@ public class FallbackConfig extends AbstractModule {
 
     /**
      * Get the file with Jenkins to run.
-     *
+     * <p>
      * The file will exist on machine where tests run.
      */
     @Provides @Named("jenkins.war")

--- a/src/main/java/org/jenkinsci/test/acceptance/SshKeyPair.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/SshKeyPair.java
@@ -20,7 +20,7 @@ import java.security.Security;
 
 /**
  * Configuration injected from outside that holds the SSH key pair that can be used for tests.
- *
+ * <p>
  * This is used for example for test harness to remotely logging in to EC2 instances, or for
  * masters to login to slaves.
  *

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/JenkinsControllerFactory.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/JenkinsControllerFactory.java
@@ -11,7 +11,7 @@ import com.cloudbees.sdk.extensibility.ExtensionPoint;
 public interface JenkinsControllerFactory {
     /**
      * Unique short name that distinguishes this controller from others.
-     *
+     * <p>
      * User can select the factory by specifying its ID to the "TYPE" environment variable.
      */
     String getId();

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/LocalController.java
@@ -368,7 +368,7 @@ public abstract class LocalController extends JenkinsController implements LogLi
 
     /**
      * Hostname to use when accessing Jenkins.
-     *
+     * <p>
      * Useful to override with public hostname/IP when external clients needs to talk back to Jenkins.
      *
      * @return "127.0.0.1" unless overridden via JENKINS_LOCAL_HOSTNAME env var.

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneDockerController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneDockerController.java
@@ -17,7 +17,7 @@ import com.google.inject.Injector;
 
 /**
  * Runs jenkins.war inside docker so that it gets a different IP address even though it's run on the same host.
- *
+ * <p>
  * For efficiency, the docker container gets the entire host file system bind-mounted on it,
  * and we ssh into that box and start jenkins.
  *

--- a/src/main/java/org/jenkinsci/test/acceptance/guice/AdditionalBinderDsl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/guice/AdditionalBinderDsl.java
@@ -25,7 +25,7 @@ public abstract class AdditionalBinderDsl extends BinderClosureScript {
 
     /**
      * Creates another injector and bind them using the given closure.
-     *
+     * <p>
      * The newly created injector will be returned.
      */
     public SubWorld subworld(final Closure config) {

--- a/src/main/java/org/jenkinsci/test/acceptance/guice/AutoCleaned.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/guice/AutoCleaned.java
@@ -5,7 +5,7 @@ import java.io.Closeable;
 /**
  * Marks instances that want to run some shutdown action
  * at the end of their scope.
- *
+ * <p>
  * When a test scope exits, all the existing instances that implement this interface
  * gets its {@link #close()} method invoked.
  *

--- a/src/main/java/org/jenkinsci/test/acceptance/guice/Cleaner.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/guice/Cleaner.java
@@ -11,7 +11,7 @@ import java.util.logging.Logger;
 
 /**
  * Performs clean-up tasks at the end of scope.
- *
+ * <p>
  * Tests and their decorators can add stuff to this cleaner to ensure some cleanup operation
  * happens at the end of each test.
  *

--- a/src/main/java/org/jenkinsci/test/acceptance/guice/TestCleaner.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/guice/TestCleaner.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 
 /**
  * {@link Cleaner} at the end of each {@link TestScope}.
- *
+ * <p>
  * Oftentimes marking your class with {@link AutoCleaned} gets the job done.
  *
  * @author Kohsuke Kawaguchi

--- a/src/main/java/org/jenkinsci/test/acceptance/guice/TestLifecycle.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/guice/TestLifecycle.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public class TestLifecycle implements Scope {
     /**
      * Records components that are scoped to tests.
-     *
+     * <p>
      * Inherited, so that threads created from within a test can correctly identify its scope.
      */
     private final ThreadLocal<Map> testScopeObjects = new InheritableThreadLocal<>();

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/AbstractJUnitTest.java
@@ -10,10 +10,8 @@ import org.openqa.selenium.WebDriver;
 
 import javax.inject.Inject;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.Collections;
 import java.util.logging.Logger;
 
 /**

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/FailureDiagnostics.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/FailureDiagnostics.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
 
 /**
  * Attach diagnostic file related to a test failure.
- *
+ * <p>
  * The harness can attach any number of diagnostic files to be stored in /target/diagnostics/$TEST_NAME/.
  * The same 'kind' of diagnostic information is expected to use the same file/subdir name.
  *

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/GlobalRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/GlobalRule.java
@@ -12,7 +12,7 @@ import org.jvnet.hudson.annotation_indexer.Indexed;
 
 /**
  * {@link TestRule} to be applied on all tests globally.
- *
+ * <p>
  * Annotate {@link TestRule} to have it run for every test.
  * See {@link RuleAnnotation} optional rule registration.
  *

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
@@ -5,7 +5,6 @@ import com.google.inject.Injector;
 
 import org.jenkinsci.test.acceptance.controller.JenkinsController;
 import org.jenkinsci.test.acceptance.guice.World;
-import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
 import org.junit.AssumptionViolatedException;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
@@ -13,7 +12,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.annotation_indexer.Index;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 
 import java.io.IOException;

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/RuleAnnotation.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/RuleAnnotation.java
@@ -23,7 +23,7 @@ import static java.lang.annotation.RetentionPolicy.*;
 public @interface RuleAnnotation {
     /**
      * The rule class that defines the setup/shutdown behaviour.
-     *
+     * <p>
      * The instance is obtained through Guice.
      */
     Class<? extends TestRule> value();

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/Since.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/Since.java
@@ -21,7 +21,7 @@ import static java.lang.annotation.RetentionPolicy.*;
 
 /**
  * Minimal Jenkins version required to run the test.
- *
+ * <p>
  * Declares that running the test with older version is pointless, typically because of missing feature.
  *
  * @author Oliver Gondza

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/TestActivation.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/TestActivation.java
@@ -38,11 +38,11 @@ import org.junit.runners.model.Statement;
 
 /**
  * Declare there is a property that needs to be provided to run the test.
- *
+ * <p>
  * This is often used when credentials than can not be in git are needed
  * to run the test. Another use-case is test interacting with pre-deployed
  * service.
- *
+ * <p>
  * Failing the activation criteria will skip the test but unlike JUnit assumptions
  * it will happen before Jenkins boots up.
  *

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
@@ -91,7 +91,7 @@ public class Wait<Subject> extends FluentWait<Subject> {
 
     /**
      * Create wait with configurable timer.
-     *
+     * <p>
      * This is useful for timeout waiting for tasks to complete that might be dependent on test environment.
      */
     public Wait(Subject input, ElasticTime time) {
@@ -196,7 +196,7 @@ public class Wait<Subject> extends FluentWait<Subject> {
 
         /**
          * Create additional text description on the failure.
-         *
+         * <p>
          * Both lastException and message will be reported separately.
          */
         public abstract String diagnose(Throwable lastException, String message);

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/WithDocker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/WithDocker.java
@@ -21,7 +21,7 @@ import static java.lang.annotation.RetentionPolicy.*;
 
 /**
  * Indicates the docker is necessary to run the test.
- *
+ * <p>
  * Otherwise the test is skipped.
  */
 @Retention(RUNTIME)

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/WithInstallWizard.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/WithInstallWizard.java
@@ -21,7 +21,7 @@ import com.google.inject.Inject;
 /**
  * Enables the install wizard to run the test. This is only possible for LocalControllers. Otherwise the test is
  * skipped.
- *
+ * <p>
  * Note the Jenkins will not have form-element-path installed automatically preventing {@link org.jenkinsci.test.acceptance.po.Control}
  * and {@link org.jenkinsci.test.acceptance.po.PageArea} to use "path" based navigation.
  */

--- a/src/main/java/org/jenkinsci/test/acceptance/log/LogListenable.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/log/LogListenable.java
@@ -4,7 +4,7 @@ import org.jenkinsci.test.acceptance.controller.JenkinsController;
 
 /**
  * Produces line-by-line log.
- *
+ * <p>
  * Among other things, optionally implemented by {@link JenkinsController} that provides access
  * to the console output.
  *

--- a/src/main/java/org/jenkinsci/test/acceptance/log/LogWatcher.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/log/LogWatcher.java
@@ -31,7 +31,7 @@ public class LogWatcher implements LogListener {
 
     /**
      * Starts watching an expression in the output.
-     *
+     * <p>
      * Returned future will signal when the expression is found.
      */
     public Future<Matcher> watch(Pattern regexp) {

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/audit_trail/AuditTrailLogger.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/audit_trail/AuditTrailLogger.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/config_file_provider/ProvidedFile.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/config_file_provider/ProvidedFile.java
@@ -23,10 +23,8 @@
  */
 package org.jenkinsci.test.acceptance.plugins.config_file_provider;
 
-import hudson.util.VersionNumber;
 import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.PageObject;
-import org.openqa.selenium.WebElement;
 
 /**
  * Abstract class for files provided by {@link ConfigFileProvider}.

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/ManagedCredentialsBinding.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentialsbinding/ManagedCredentialsBinding.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.test.acceptance.plugins.credentialsbinding;
 
 import org.jenkinsci.test.acceptance.po.ContainerPageObject;
-import org.openqa.selenium.WebElement;
 
 public class ManagedCredentialsBinding extends ContainerPageObject {
 

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/dashboard_view/read/BuildExecutorStatus.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/dashboard_view/read/BuildExecutorStatus.java
@@ -47,7 +47,7 @@ public class BuildExecutorStatus extends PageAreaImpl {
 
     /**
      * Get the Headers (names of all nodes) in the table.
-     *
+     * <p>
      * If only one node header would be shown, it is not. And therefore also not in this list.
      *
      * @return the names of all displayed nodes/agents.

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
@@ -3,7 +3,6 @@ package org.jenkinsci.test.acceptance.plugins.git;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitScm.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitScm.java
@@ -28,10 +28,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.support.ui.Select;
 
-import javax.swing.text.html.HTMLDocument;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-
 @Describable("Git")
 public class GitScm extends Scm {
 

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/job_dsl/JobDslBuildStep.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/job_dsl/JobDslBuildStep.java
@@ -2,8 +2,6 @@ package org.jenkinsci.test.acceptance.plugins.job_dsl;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.test.acceptance.po.*;
-import org.jenkinsci.test.acceptance.selenium.Scroller;
-import org.openqa.selenium.By;
 
 /**
  * Encapsulates the PageArea of the Job DSL plugin.

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/logparser/LogParserOutputPage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/logparser/LogParserOutputPage.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
 
 /**
  * The logparser plugin uses two frames.
- *
+ * <p>
  * To check the content of the frames the selenium driver must be switched to the frames.
  *
  * @author Michael Engel.

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/mailer/MailerGlobalConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/mailer/MailerGlobalConfig.java
@@ -2,7 +2,6 @@ package org.jenkinsci.test.acceptance.plugins.mailer;
 
 import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 
-import org.jenkinsci.test.acceptance.docker.fixtures.MailhogContainer;
 import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.po.PageAreaImpl;

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/maven/MavenModuleSet.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/maven/MavenModuleSet.java
@@ -28,14 +28,12 @@ import java.util.function.Consumer;
 
 import org.jenkinsci.test.acceptance.po.BatchCommandBuildStep;
 import org.jenkinsci.test.acceptance.po.BuildStep;
-import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
 import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.PostBuildStep;
 import org.jenkinsci.test.acceptance.po.ShellBuildStep;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.google.inject.Injector;

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/parameterized_trigger/ParameterizedTrigger.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/parameterized_trigger/ParameterizedTrigger.java
@@ -4,9 +4,6 @@ import org.jenkinsci.test.acceptance.po.AbstractStep;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.PostBuildStep;
-import org.openqa.selenium.WebElement;
-
-import java.util.List;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -24,7 +21,7 @@ public class ParameterizedTrigger extends AbstractStep implements PostBuildStep 
 
     /**
      * Adds a new trigger setting.
-     *
+     * <p>
      * Note that newly added trigger has one entry in there by default.
      */
     public TriggerConfig addTriggerConfig() {

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/parameterized_trigger/TriggerCallBuildStep.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/parameterized_trigger/TriggerCallBuildStep.java
@@ -22,7 +22,7 @@ public class TriggerCallBuildStep extends AbstractStep implements BuildStep {
 
     /**
      * Adds a new trigger setting.
-     *
+     * <p>
      * Note that newly added trigger has one entry in there by default.
      */
     public BuildTriggerConfig addTriggerConfig() {

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/priority_sorter/PriorityConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/priority_sorter/PriorityConfig.java
@@ -24,7 +24,6 @@
 package org.jenkinsci.test.acceptance.plugins.priority_sorter;
 
 import org.jenkinsci.test.acceptance.po.*;
-import org.openqa.selenium.NoSuchElementException;
 
 @ActionPageObject("advanced-build-queue")
 public class PriorityConfig extends Action {

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/textfinder/TextFinderPublisher.java
@@ -7,9 +7,9 @@ import org.openqa.selenium.WebElement;
 /**
  * This class provides the ability to add a Jenkins Text Finder post build step
  * to the job.
- *
+ * <p>
  * It provides access to the particular web elements to configure the post build step.
- *
+ * <p>
  * This post build step requires installation of the text-finder plugin.
  *
  * @author Martin Ende

--- a/src/main/java/org/jenkinsci/test/acceptance/po/ArtifactManagement.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ArtifactManagement.java
@@ -28,7 +28,7 @@ import org.openqa.selenium.StaleElementReferenceException;
 
 /**
  * Global page area to configure Artifact management.
- *
+ * <p>
  * Note this feature is available since 1.532.
  *
  * @author ogondza

--- a/src/main/java/org/jenkinsci/test/acceptance/po/AuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/AuthorizationStrategy.java
@@ -2,7 +2,7 @@ package org.jenkinsci.test.acceptance.po;
 
 /**
  * Base type for {@link PageArea} for Authorization Strategy.
- *
+ * <p>
  * Use {@link Describable} annotation to register an implementation.
  *
  * @see GlobalSecurityConfig#useAuthorizationStrategy(Class)

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Build.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Build.java
@@ -12,7 +12,6 @@ import org.jenkinsci.test.acceptance.Matcher;
 import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.test.acceptance.junit.Wait;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayer.java
@@ -7,8 +7,6 @@ import org.jenkinsci.test.acceptance.junit.Wait;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 /**
  * Interface for assisting porting from Capybara.
  *

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -16,7 +16,6 @@ import org.jenkinsci.test.acceptance.junit.Wait;
 import org.jenkinsci.test.acceptance.utils.ElasticTime;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
-import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.ElementNotInteractableException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;

--- a/src/main/java/org/jenkinsci/test/acceptance/po/ComputerConnector.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ComputerConnector.java
@@ -2,7 +2,7 @@ package org.jenkinsci.test.acceptance.po;
 
 /**
  * Configuration fragment for computer launcher.
- *
+ * <p>
  * Use {@link Describable} annotation to register an implementation.
  *
  * @author Kohsuke Kawaguchi

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
@@ -6,7 +6,6 @@ import java.util.concurrent.TimeUnit;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
-import org.jenkinsci.test.acceptance.selenium.Scroller;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.JavascriptExecutor;
@@ -141,10 +140,10 @@ public class Control extends CapybaraPortingLayerImpl {
      * method has shortcomings regarding large strings because it utilizes
      * the sendKeys mechanism to enter the string which takes a significant amount
      * of time, i.e. the browser may consider the script to be unresponsive.
-     *
+     * <p>
      * This method method shall provide a high throughput mechanism which
      * puts the whole string at once into the text field instead of char by char.
-     *
+     * <p>
      * This is a solution / workaround published for Selenium Issue 4496:
      * <a href="https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/4469">#4496</a>
      *
@@ -168,7 +167,7 @@ public class Control extends CapybaraPortingLayerImpl {
 
     /**
      * Sets the value of the input field to the specified text.
-     *
+     * <p>
      * Any existing value gets cleared.
      */
     public void set(@Nullable String text) {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Describable.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Describable.java
@@ -27,7 +27,7 @@ import org.jvnet.hudson.annotation_indexer.Indexed;
 public @interface Describable {
     /**
      * Descriptions.
-     *
+     * <p>
      * The annotation accepts several values as possible alternatives. First that exists will be used.
      */
     String[] value();

--- a/src/main/java/org/jenkinsci/test/acceptance/po/DumbSlave.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/DumbSlave.java
@@ -11,7 +11,7 @@ import org.openqa.selenium.NoSuchElementException;
 
 /**
  * Built-in standard slave type.
- *
+ * <p>
  * To create a new slave into a test, use {@link SlaveController}.
  *
  * @author Kohsuke Kawaguchi

--- a/src/main/java/org/jenkinsci/test/acceptance/po/GlobalPluginConfiguration.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/GlobalPluginConfiguration.java
@@ -8,7 +8,7 @@ import org.openqa.selenium.WebElement;
  *
  * <p>
  * These page areas do not get fixed path name, so we need to figure that out from the hidden "name" field.
- *
+ * <p>
  * TODO: improve core to make this more robust
  *
  * @author Kohsuke Kawaguchi

--- a/src/main/java/org/jenkinsci/test/acceptance/po/GlobalToolConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/GlobalToolConfig.java
@@ -28,7 +28,7 @@ import java.net.URL;
 
 /**
  * Global tools configuration UI.
- *
+ * <p>
  * Introduced in Jenkins 2.0.
  */
 public class GlobalToolConfig extends ContainerPageObject {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
@@ -39,7 +39,7 @@ import java.util.logging.Level;
 
 /**
  * Top-level object that acts as an entry point to various systems.
- *
+ * <p>
  * This is also the only page object that can be injected since there's always one that points to THE Jenkins instance
  * under test.
  *

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -3,7 +3,6 @@ package org.jenkinsci.test.acceptance.po;
 import javax.inject.Inject;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -266,7 +265,7 @@ public class Job extends TopLevelItem {
 
     /**
      * "Copy" any file from the System into the Workspace using a zipFIle.
-     *
+     * <p>
      * Differentiates when the file is being run on Windows or Unix based machines.
      */
     public void copyFile(File file) {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/LdapSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/LdapSecurityRealm.java
@@ -3,7 +3,6 @@ package org.jenkinsci.test.acceptance.po;
 import org.jenkinsci.test.acceptance.plugins.ldap.LdapDetails;
 import org.jenkinsci.test.acceptance.plugins.ldap.LdapEnvironmentVariable;
 import org.jenkinsci.test.acceptance.plugins.ldap.LdapGroupMembershipStrategy;
-import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Node.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Node.java
@@ -27,7 +27,6 @@ import com.google.inject.Injector;
 import org.openqa.selenium.NoSuchElementException;
 
 import java.net.URL;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Common base for Jenkins and Slave.

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PageObject.java
@@ -7,7 +7,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -122,13 +121,13 @@ public abstract class PageObject extends CapybaraPortingLayerImpl {
 
     /**
      * Capture path attribute of newly created form chunk upon invoking action.
-     *
+     * <p>
      * Consider "Add" button in page area with path "/foo" that is supposed to create new page area with path "/foo/bar"
      * or "/foo/bar[n]". There are several problems with the straightforward approach:
      *  - Created area may or may not be the first one of its kind so figuring the "path" is nontrivial.
      *  - The area may can take a while to render so waiting is needed.
      *  - Even after the markup appears, it can take a while for "path" attribute is added.
-     *
+     * <p>
      * This method properly wait until the new path is known. To be used as:
      *
      * <pre>

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -3,23 +3,19 @@ package org.jenkinsci.test.acceptance.po;
 import javax.inject.Named;
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.time.temporal.ChronoUnit;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.jar.JarFile;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.methods.HttpGet;
 import org.jenkinsci.test.acceptance.FallbackConfig;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.update_center.PluginMetadata;
@@ -35,16 +31,7 @@ import org.openqa.selenium.WebElement;
 import com.google.inject.Inject;
 
 import hudson.util.VersionNumber;
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPost;
 
-import static java.util.logging.Level.WARNING;
-import static org.apache.http.entity.ContentType.APPLICATION_OCTET_STREAM;
-import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.jenkinsci.test.acceptance.update_center.MockUpdateCenter;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Slave.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Slave.java
@@ -8,11 +8,10 @@ import org.jenkinsci.test.acceptance.junit.Wait;
 import org.jenkinsci.test.acceptance.slave.SlaveController;
 
 import com.google.common.base.Joiner;
-import org.openqa.selenium.NoSuchElementException;
 
 /**
  * An agent page object.
- *
+ * <p>
  * To create a new agent into a test, use {@link SlaveController}.
  *
  * @author Kohsuke Kawaguchi

--- a/src/main/java/org/jenkinsci/test/acceptance/po/ToolInstallation.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ToolInstallation.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import hudson.util.VersionNumber;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.SystemUtils;
-import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.utils.process.CommandBuilder;
 import org.openqa.selenium.NoSuchElementException;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/ToolInstallationPageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ToolInstallationPageObject.java
@@ -41,7 +41,7 @@ public @interface ToolInstallationPageObject {
 
     /**
      * Pattern to be logged once updates arrive.
-     *
+     * <p>
      * Clients should not interact with this ToolInstalltion before updates was loaded.
      */
     String installer();

--- a/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/TopLevelItem.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import hudson.util.VersionNumber;
-import org.jenkinsci.test.acceptance.junit.Since;
 import org.openqa.selenium.WebElement;
 
 import com.google.inject.Injector;

--- a/src/main/java/org/jenkinsci/test/acceptance/po/UpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/UpdateCenter.java
@@ -10,7 +10,6 @@ import org.jenkinsci.test.acceptance.update_center.PluginSpec;
 
 import static java.util.Arrays.*;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -63,7 +62,7 @@ public class UpdateCenter extends ContainerPageObject {
 
     /**
      * Wait for the plugin installation is done.
-     *
+     * <p>
      * Wait for all UC jobs are completed. If some of them fail or require restart, Jenkins is restarted.
      * If some of the plugins is not installed after that or the version is older than expected, the waiting is considered failed.
      *

--- a/src/main/java/org/jenkinsci/test/acceptance/po/User.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/User.java
@@ -26,8 +26,6 @@ package org.jenkinsci.test.acceptance.po;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.openqa.selenium.NoSuchElementException;
 
-import java.util.Objects;
-
 public class User extends ContainerPageObject {
 
     private String id;

--- a/src/main/java/org/jenkinsci/test/acceptance/po/ViewsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ViewsMixIn.java
@@ -3,7 +3,6 @@ package org.jenkinsci.test.acceptance.po;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/src/main/java/org/jenkinsci/test/acceptance/po/WorkflowMultiBranchJob.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WorkflowMultiBranchJob.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Workspace.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Workspace.java
@@ -24,7 +24,6 @@
 package org.jenkinsci.test.acceptance.po;
 
 import org.jenkinsci.test.acceptance.Matcher;
-import org.openqa.selenium.Alert;
 
 public class Workspace extends PageObject {
 

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/LocalOverrideUpdateCenterMetadataDecoratorImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/LocalOverrideUpdateCenterMetadataDecoratorImpl.java
@@ -10,12 +10,11 @@ import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
  * Allow local plugins specified via environment variables to override plugin metadata from update center.
- *
+ * <p>
  * This is to support testing of locally built plugin
  *
  * @author Kohsuke Kawaguchi

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginSpec.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/PluginSpec.java
@@ -28,13 +28,13 @@ import hudson.util.VersionNumber;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
+
 import java.util.Iterator;
 import java.util.Objects;
 
 /**
  * Reference to a plugin, optionally with the version.
- *
+ * <p>
  * The string syntax of this is shortName[@version].
  */
 public class PluginSpec {

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/UpdateCenterMetadata.java
@@ -70,9 +70,9 @@ public class UpdateCenterMetadata {
 
     /**
      * Find all the transitive dependency plugins of the given plugins, in the order of installation.
-     * 
+     * <p>
      * Resolved plugins set should satisfy required versions including Jenkins version.
-     * 
+     * <p>
      * Transitive dependencies will not be included if there is an already valid version of the plugin installed.
      *
      * @throws UnableToResolveDependencies When there requested plugin version can not be installed.

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/ElasticTime.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/ElasticTime.java
@@ -58,7 +58,7 @@ public class ElasticTime {
 
     /**
      * Relative performance difference compared to reference environment (Upstream CI).
-     *
+     * <p>
      * Default is 1.0 (no difference). Use >1 in case of slower environment, <1 in case of faster one.
      */
     private final double factor = Double.parseDouble(System.getProperty("ElasticTime.factor", "1.0"));

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/SauceLabsConnection.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/SauceLabsConnection.java
@@ -5,7 +5,6 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/aether/AetherModule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/aether/AetherModule.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 /**
  * Hook up Aether resolver.
- *
+ * <p>
  * To resolve components, inject {@link RepositorySystem} and {@link RepositorySystemSession}.
  *
  * @author Kohsuke Kawaguchi

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/aether/ConsoleTransferListener.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/aether/ConsoleTransferListener.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * <p>
  * Contributors:
  *    Sonatype, Inc. - initial API and implementation
  *******************************************************************************/

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/pluginreporter/TextFileExercisedPluginReporter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/pluginreporter/TextFileExercisedPluginReporter.java
@@ -37,9 +37,9 @@ import org.apache.commons.io.FileUtils;
 /**
  * Exercised Plugin Reporter that logs to text file
  * The contents are java properties.
- *
+ * <p>
  * Properties will be stored as follows:
- *
+ * <p>
  * {@literal <testName>::<pluginName> = <pluginVersion>}
  *
  * @author scott.hebert@ericsson.com

--- a/src/test/java/core/FreestyleJobTest.java
+++ b/src/test/java/core/FreestyleJobTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/core/ScriptTest.java
+++ b/src/test/java/core/ScriptTest.java
@@ -2,11 +2,9 @@ package core;
 
 import com.google.inject.Inject;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
-import org.jenkinsci.test.acceptance.junit.SmokeTest;
 import org.jenkinsci.test.acceptance.po.Slave;
 import org.jenkinsci.test.acceptance.slave.SlaveController;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/plugins/AntPluginTest.java
+++ b/src/test/java/plugins/AntPluginTest.java
@@ -11,7 +11,6 @@ import org.jenkinsci.test.acceptance.po.ToolInstallation;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
 @SuppressWarnings("CdiInjectionPointsInspection")

--- a/src/test/java/plugins/FolderPluginTest.java
+++ b/src/test/java/plugins/FolderPluginTest.java
@@ -24,7 +24,6 @@
 
 package plugins;
 
-import org.hamcrest.MatcherAssert;
 import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;

--- a/src/test/java/plugins/GerritTriggerTest.java
+++ b/src/test/java/plugins/GerritTriggerTest.java
@@ -39,7 +39,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/src/test/java/plugins/JobDslPluginTest.java
+++ b/src/test/java/plugins/JobDslPluginTest.java
@@ -28,9 +28,7 @@ import org.jenkinsci.test.acceptance.po.ListView;
 import org.jenkinsci.test.acceptance.po.PluginManager;
 import org.jenkinsci.test.acceptance.po.View;
 import org.jenkinsci.test.acceptance.update_center.PluginSpec;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 

--- a/src/test/java/plugins/MSBuildPluginTest.java
+++ b/src/test/java/plugins/MSBuildPluginTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * This test is designed to be run on a Windows machine with MSBuild installed and in the PATH
- * 
+ * <p>
  * Tests will be skipped if:
  *      - MSBUild.exe is not in the path. This implies that machine running Jenkins is windows.
  *      - The test and Jenkins are being run on different machines

--- a/src/test/java/plugins/MatrixAuthPluginTest.java
+++ b/src/test/java/plugins/MatrixAuthPluginTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertFalse;
 public class MatrixAuthPluginTest extends AbstractJUnitTest {
     /**
      * Test scenario:
-     *
+     * <p>
      * - we create admin user "alice" and regular limited user "bob"
      * - alice creates a new project
      * - bob shouldn't be able to see it


### PR DESCRIPTION
The former one is for SpotBugs, the latter one ensures linebreaks are treated as those. An empty line doesn't do a linebreak for javadoc.