### PR TITLE
Escape maven version in Dockerfile

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -27,8 +27,8 @@ RUN curl -fsSLO https://github.com/mozilla/geckodriver/releases/download/v0.26.0
 
 # Maven in repo is not new enough for ATH
 ENV MAVEN_VERSION 3.8.6
-RUN curl -ffSLO https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz && \
-    tar -xvzf apache-maven-$MAVEN_VERSION-bin.tar.gz -C /opt/ && \
+RUN curl -ffSLO https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-"$MAVEN_VERSION"-bin.tar.gz && \
+    tar -xvzf apache-maven-"$MAVEN_VERSION"-bin.tar.gz -C /opt/ && \
     mv /opt/apache-maven-* /opt/maven
 ENV PATH="$PATH:/opt/maven/bin"
 


### PR DESCRIPTION
IntelliJ interprets `-bin` as part of the MAVEN_VERSION env. I don't see this as an issue in real test scenarios, but better be safe by escaping the version.