### PR TITLE
Run ATH on a weekly basis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,13 @@
 
 properties([disableConcurrentBuilds(abortPrevious: true)])
 
+if (env.BRANCH_IS_PRIMARY) {
+  properties([
+          buildDiscarder(logRotator(numToKeepStr: '50')),
+          pipelineTriggers([cron('0 18 * * TUE')]),
+  ])
+}
+
 def branches = [:]
 def splits
 def needSplittingFromWorkspace = true


### PR DESCRIPTION
The change proposed runs the ATH after the weekly release, to highlight possible regressions quicker, and outside regularly core PR testing.