### PR TITLE
Use a numeric cron value

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ properties([disableConcurrentBuilds(abortPrevious: true)])
 if (env.BRANCH_IS_PRIMARY) {
   properties([
           buildDiscarder(logRotator(numToKeepStr: '50')),
-          pipelineTriggers([cron('0 18 * * TUE')]),
+          pipelineTriggers([cron('0 18 * * 2')]),
   ])
 }
 


### PR DESCRIPTION
Apparently TUE is unsupported
```
java.lang.IllegalArgumentException: Could not instantiate {spec=0 18 * * TUE} for hudson.triggers.TimerTrigger: java.lang.reflect.InvocationTargetException
```
Let's use a numeric entry.