### PR TITLE
prevent split modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,12 @@
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>htmlunit-driver</artifactId>
       <version>2.64.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.codeborne</groupId>
@@ -388,6 +394,10 @@
         <exclusion>
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/main/java/org/jenkinsci/test/acceptance/SshKeyPairGenerator.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/SshKeyPairGenerator.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.test.acceptance;
 
-import org.apache.xerces.impl.dv.util.Base64;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.jvnet.hudson.crypto.RSAPublicKeyUtil;
 
@@ -14,6 +13,7 @@ import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.EnumSet;
 
 import static java.nio.file.attribute.PosixFilePermission.*;
@@ -56,7 +56,7 @@ public class SshKeyPairGenerator implements Provider<SshKeyPair>, com.google.inj
 
         // and public key
         try (FileWriter w = new FileWriter(publicKey)) {
-            w.write("ssh-rsa "+ Base64.encode(RSAPublicKeyUtil.encode(kp.getPublic()))+" generated-used-by-jenkins");
+            w.write("ssh-rsa "+ Base64.getEncoder().encode(RSAPublicKeyUtil.encode(kp.getPublic()))+" generated-used-by-jenkins");
         }
     }
 }


### PR DESCRIPTION
java xml libraries are provided by a java standard module (java.xml)

having them in 2 different jars causes the following compilation errors (shown by the eclipse compiler)

Fixes using base64 from the stock JDK at the same time (rather than xalan) as that is likely to be yanked in a future PR. (it was yanked here - but then reverted as I figured htmlunit may actually depend on xalan directly rather then use the xml apis).

```
* The package javax.xml is accessible from more than one module: <unnamed>, java.xml
* The package javax.xml.parsers is accessible from more than one module: <unnamed>, java.xml
* The package javax.xml.xpath is accessible from more than one module: <unnamed>, java.xml
* The package javax.xml.xpath is accessible from more than one module: <unnamed>, java.xml
* The package org.w3c.dom is accessible from more than one module: <unnamed>, java.xml
```
<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
