### PR TITLE
Remove references to `--ajp13Port`

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
@@ -99,7 +99,6 @@ public class WinstoneController extends LocalController {
             cb.add("-Dwinstone.portFileName=" + portFile.getAbsolutePath());
         }
         cb.add("-jar", war,
-                "--ajp13Port=-1",
                 "--httpPort=" + httpPort
         );
         cb.addAll(JENKINS_OPTS);

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneDockerController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneDockerController.java
@@ -69,7 +69,7 @@ public class WinstoneDockerController extends LocalController {
             cmds.add("-DJENKINS_HOME=/work");
             cmds.add("-Djenkins.formelementpath.FormElementPathPageDecorator.enabled=true");
             cmds.add("-jar", "/war/" + war.getName());
-            cmds.add("--ajp13Port=-1","--controlPort=8081","--httpPort=8080");
+            cmds.add("--controlPort=8081","--httpPort=8080");
             return container.popen(cmds);
         } catch (InterruptedException e) {
             throw (IOException)new InterruptedIOException("Failed to launch winstone").initCause(e);


### PR DESCRIPTION
AJP support was removed in Jetty 9 and Winstone 3.0 in https://github.com/jenkinsci/winstone/pull/22, never to return. As a result I ripped it out in https://github.com/jenkinsci/winstone/pull/291. But before I can release that PR, I need the ATH to drop its requirement on the existence of this option to avoid errors like

```
[2022-10-19T18:42:41.243Z] Exception in thread "main" java.lang.IllegalArgumentException: Unrecognized option: --ajp13Port=-1
[2022-10-19T18:42:41.243Z] 	at winstone.cmdline.CmdLineParser.parse(CmdLineParser.java:52)
[2022-10-19T18:42:41.243Z] 	at winstone.Launcher.getArgsFromCommandLine(Launcher.java:399)
[2022-10-19T18:42:41.243Z] 	at winstone.Launcher.main(Launcher.java:369)
[2022-10-19T18:42:41.243Z] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[2022-10-19T18:42:41.243Z] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[2022-10-19T18:42:41.243Z] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[2022-10-19T18:42:41.243Z] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[2022-10-19T18:42:41.243Z] 	at executable.Main.main(Main.java:355)
[2022-10-19T18:42:41.243Z] 
[2022-10-19T18:42:41.243Z] 	at org.jenkinsci.test.acceptance.controller.JenkinsLogWatcher.waitTillReady(JenkinsLogWatcher.java:104)
[2022-10-19T18:42:41.243Z] 	at org.jenkinsci.test.acceptance.controller.LocalController.startNow(LocalController.java:206)
[2022-10-19T18:42:41.243Z] 	... 40 more
[2022-10-19T18:42:41.243Z] Caused by: java.util.concurrent.ExecutionException: java.io.IOException: Regular termination
[2022-10-19T18:42:41.243Z] 	at org.apache.http.concurrent.BasicFuture.getResult(BasicFuture.java:71)
[2022-10-19T18:42:41.243Z] 	at org.apache.http.concurrent.BasicFuture.get(BasicFuture.java:102)
[2022-10-19T18:42:41.243Z] 	at org.jenkinsci.test.acceptance.controller.JenkinsLogWatcher.waitTillReady(JenkinsLogWatcher.java:97)
[2022-10-19T18:42:41.243Z] 	... 41 more
[2022-10-19T18:42:41.243Z] Caused by: java.io.IOException: Regular termination
[2022-10-19T18:42:41.243Z] 	at org.jenkinsci.test.acceptance.log.LogWatcher$Watcher.processClose(LogWatcher.java:63)
[2022-10-19T18:42:41.243Z] 	at org.jenkinsci.test.acceptance.log.LogSplitter.processClose(LogSplitter.java:39)
[2022-10-19T18:42:41.243Z] 	at org.jenkinsci.test.acceptance.log.LogWatcher.processClose(LogWatcher.java:29)
[2022-10-19T18:42:41.243Z] 	at org.jenkinsci.test.acceptance.log.LogSplitter.processClose(LogSplitter.java:39)
[2022-10-19T18:42:41.243Z] 	at org.jenkinsci.test.acceptance.log.LogReader.run(LogReader.java:55)
[2022-10-19T18:42:41.243Z] 	at java.base/java.lang.Thread.run(Thread.java:829)
```

For this reason, a release of this would be appreciated.