### PR TITLE
chore: remove `@Library` annotation in infra pipeline

### DIFF
--- a/Jenkinsfile.infra.ci.jenkins.io
+++ b/Jenkinsfile.infra.ci.jenkins.io
@@ -1,5 +1,3 @@
-@Library('pipeline-library@pull/459/head') _
-
 // This pipeline runs on infra.ci.jenkins.io (private) to build, test and deploy the Docker image
 buildDockerAndPublishImage('ath', [
   automaticSemanticVersioning: false,


### PR DESCRIPTION
Follow-up of https://github.com/jenkinsci/acceptance-test-harness/pull/905, [the corresponding pipeline library pull request](https://github.com/jenkins-infra/pipeline-library/pull/459) has been merged, no need to keep this annotation.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
