### PR TITLE
Revert "Bump leftover docker images to ubuntu 22.04"

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/FtpdContainer/Dockerfile
@@ -2,7 +2,7 @@
 # Runs sshd and allow the 'test' user to login
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:trusty
 
 # install FTP
 RUN apt-get update && apt-get install -y vsftpd

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/Dockerfile
@@ -3,7 +3,7 @@
 # and prepares for execution of gitplugin tests.
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:xenial
 
 RUN mkdir -p /var/run/sshd
 

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JabberContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JabberContainer/Dockerfile
@@ -2,7 +2,7 @@
 # Setup Prosody IM XMPP Server with two users
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:latest
 
 # Needed for supervisord
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer/Dockerfile
@@ -3,7 +3,7 @@
 #
 #    The initial password is 'admin:admin'
 #
-FROM ubuntu:22.04
+FROM ubuntu:xenial
 
 # Pin JIRA version to make the tests more predictable and less fragile
 # In particular, pinned to 6.X because from 7.X the SOAP API is gone, and it's

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SMBContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SMBContainer/Dockerfile
@@ -2,7 +2,7 @@
 # Runs smbd and allow the 'test' user to connect
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:trusty
 
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
 RUN apt-get update && apt-get -y install samba

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/Tomcat7Container/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/Tomcat7Container/Dockerfile
@@ -4,7 +4,7 @@
 # The admin user has username 'admin' and password 'tomcat'
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:xenial
 
 # Tomcat7 is from Universe
 RUN echo "deb http://archive.ubuntu.com/ubuntu xenial universe" >> /etc/apt/sources.list


### PR DESCRIPTION
Reverts jenkinsci/acceptance-test-harness#1024