### PR TITLE
Use older 108 version of firefox in ath-container

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 # No Snaps please https://www.omgubuntu.co.uk/2022/04/how-to-install-firefox-deb-apt-ubuntu-22-04
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN add-apt-repository ppa:mozillateam/ppa && \
-  printf 'Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001' | tee /etc/apt/preferences.d/mozilla-firefox
+  printf 'Package: firefox*\nPin: version 102.8.0*\nPin-Priority: 1001' | tee /etc/apt/preferences.d/mozilla-firefox
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
@@ -27,7 +27,7 @@ RUN apt-get update && \
         git \
         imagemagick \
         iptables \
-        firefox \
+        firefox-esr \
         unzip \
         tightvncserver \
         openjdk-11-jdk \
@@ -36,7 +36,7 @@ RUN apt-get update && \
     apt-get clean all && rm -rf /var/cache/apt
 
 # Selenium needs a geckodriver in order to work properly
-ENV GECKODRIVER_VERSION 0.32.0
+ENV GECKODRIVER_VERSION 0.32.2
 # gross due to https://github.com/mozilla/geckodriver/issues/1956
 RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
   if [ "$arch" = "arm64" ] ; \
@@ -94,6 +94,7 @@ COPY run.sh /usr/bin/
 
 RUN chmod u+s "$(which update-alternatives)"
 RUN dbus-uuidgen > /etc/machine-id
+RUN ln -s /lib/firefox-esr/firefox.sh /usr/bin/firefox
 
 USER ath-user
 

--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -12,10 +12,7 @@ RUN apt-get update && \
     && \
   apt-get clean all && rm -rf /var/cache/apt
 
-# No Snaps please https://www.omgubuntu.co.uk/2022/04/how-to-install-firefox-deb-apt-ubuntu-22-04
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN add-apt-repository ppa:mozillateam/ppa && \
-  printf 'Package: firefox*\nPin: version 102.8.0*\nPin-Priority: 1001' | tee /etc/apt/preferences.d/mozilla-firefox
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
@@ -27,13 +24,23 @@ RUN apt-get update && \
         git \
         imagemagick \
         iptables \
-        firefox-esr \
         unzip \
         tightvncserver \
         openjdk-11-jdk \
         xfonts-base \
         && \
     apt-get clean all && rm -rf /var/cache/apt
+
+# Install a fixed firefox version that is known to work with the current selenium version, copied from https://hub.docker.com/r/selenium/node-firefox/dockerfile
+ARG FIREFOX_VERSION=108.0.2
+RUN apt-get -y install libgtk-3-0 libasound2 libdbus-glib-1-2 libx11-xcb-dev libpci-dev libgl1-mesa-glx wget bzip2 \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+  && wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && rm -rf /opt/firefox \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
+  && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
 
 # Selenium needs a geckodriver in order to work properly
 ENV GECKODRIVER_VERSION 0.32.2
@@ -94,7 +101,6 @@ COPY run.sh /usr/bin/
 
 RUN chmod u+s "$(which update-alternatives)"
 RUN dbus-uuidgen > /etc/machine-id
-RUN ln -s /lib/firefox-esr/firefox.sh /usr/bin/firefox
 
 USER ath-user
 

--- a/src/main/resources/ath-container/run.sh
+++ b/src/main/resources/ath-container/run.sh
@@ -26,7 +26,7 @@ fi
 
 function download() {
     echo "Fetching $1 to $2"
-    status=$(curl -sSL --write-out "%{http_code}" --retry 3 --retry-delay 0 --retry-max-time 60 -o $2 $1)
+    status=$(curl --http1.1 -sSL --write-out "%{http_code}" --retry 3 --retry-delay 0 --retry-max-time 60 -o $2 $1)
     if [ "$status" -ne 200 ]; then
         echo >&2 "Failed to fetch the $1 ($status) to $2"
         return 1

--- a/src/test/java/plugins/OwnershipPluginTest.java
+++ b/src/test/java/plugins/OwnershipPluginTest.java
@@ -13,6 +13,7 @@ import org.hamcrest.Description;
 import org.jenkinsci.test.acceptance.Matcher;
 import org.jenkinsci.test.acceptance.Matchers;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.junit.Ignore;
 import org.jvnet.hudson.test.Issue;
 import org.jenkinsci.test.acceptance.junit.Since;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
@@ -80,6 +81,7 @@ public class OwnershipPluginTest extends AbstractJUnitTest {
 
     @Test
     @Since("1.509") @Issue("JENKINS-24370")
+    @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/1044")
     public void correct_redirect_after_save() throws Exception {
         JenkinsConfig cp = jenkins.getConfigPage();
         cp.configure();


### PR DESCRIPTION
110 (current one available in ppa) seems to have some issues with Selenium making the existing code not work anymore

~So to validate is the firefox version I am using here firefox esr 108, if that solves problems I will rewrite to use the standard firefox instead, sadly 108 version is not on the ppa repository anymore, that is why for this tests I am using esr~

The last known good version was 108.0.2, which is now installed, and fixed,  in the docker image. Basically I copied and adapted the installation procedure from the selenium docker images.


<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
