### PR TITLE
Clean up shell scripts

### DIFF
--- a/ath-container.sh
+++ b/ath-container.sh
@@ -3,25 +3,39 @@
 set -euo pipefail
 trap 's=$?; echo "$0: Error $s on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 uid=$(id -u)
 gid=$(id -g)
-tag="jenkins/ath"
+tag='jenkins/ath'
 java_version="${java_version:-11}"
 
 # high chance of uid / group already existing in the container
 # known to happen on macOS
-if (( uid < 1000 )); then
-    uid=1001
+if ((uid < 1000)); then
+	uid=1001
 fi
 
-if (( gid < 1000 )); then
-    gid=1001
+if ((gid < 1000)); then
+	gid=1001
 fi
 
-docker build --build-arg=uid="$uid" --build-arg=gid="$gid" "$DIR/src/main/resources/ath-container" -t "$tag"
+docker build \
+	--build-arg=uid="$uid" \
+	--build-arg=gid="$gid" \
+	"$DIR/src/main/resources/ath-container" \
+	-t "$tag"
 
-run_opts="--interactive --tty --rm --publish-all --user ath-user --workdir /home/ath-user/sources --shm-size 2g"
-run_drive_mapping="-v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/home/ath-user/sources -v ${HOME}/.m2/repository:/home/ath-user/.m2/repository"
-docker run $run_opts $run_drive_mapping $tag /bin/bash -c "set-java.sh $java_version; bash"
+docker run \
+	--interactive \
+	--tty \
+	--rm \
+	--publish-all \
+	--user ath-user \
+	--workdir /home/ath-user/sources \
+	--shm-size 2g \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	-v "$(pwd):/home/ath-user/sources" \
+	-v "${HOME}/.m2/repository:/home/ath-user/.m2/repository" \
+	$tag \
+	/bin/bash -c "set-java.sh $java_version; bash"

--- a/grab-latest-rc.sh
+++ b/grab-latest-rc.sh
@@ -1,3 +1,3 @@
-#!/bin/sh -xe
-
-curl -L "https://get.jenkins.io/war-rc/latest/jenkins.war" > jenkins.war
+#!/usr/bin/env bash
+set -eux
+curl -L https://get.jenkins.io/war-rc/latest/jenkins.war >jenkins.war

--- a/jut-server.sh
+++ b/jut-server.sh
@@ -1,8 +1,7 @@
-#!/bin/bash
-DIR="$( cd "$( dirname "$0" )" && pwd )"
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
 CMD="$DIR/target/appassembler/bin/jut-server"
-if [ ! -s $CMD ]
-then
-  mvn package -DskipTests -f "$DIR/pom.xml"
+if [[ ! -s $CMD ]]; then
+	mvn package -DskipTests -f "$DIR/pom.xml"
 fi
 sh "$CMD" "$@"

--- a/src/main/resources/ath-container/set-java.sh
+++ b/src/main/resources/ath-container/set-java.sh
@@ -4,11 +4,11 @@ set -uo pipefail
 trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 # The selection used by update-alternatives for each java version
-if [ "$1" == "11" ]; then
-    selection="11-openjdk"
+if [[ $1 == '11' ]]; then
+	selection='11-openjdk'
 else
-    echo >&2 "Unsupported java version '${1}'"
-    exit 1
+	echo >&2 "Unsupported java version '${1}'"
+	exit 1
 fi
 
 # For some reason, all tools from JDK are split to 2 groups named java and javac

--- a/src/main/resources/ath-container/vnc.sh
+++ b/src/main/resources/ath-container/vnc.sh
@@ -1,24 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: `eval $(./vnc.sh)`
 
-display=":42"
-if [ ! -z "$1" ]; then
-  display=":$1"
+display=':42'
+if [[ -n $1 ]]; then
+	display=":$1"
 fi
 
 # Use setsid to detach processes that are supposed to keep running (vncserver and vncviewer) from current process group,
 # so ^C sent to any command run afterwards does not kill the vnc. Happens commonly when ATH is paused by INTERACTIVE=true
 # and then killed normally.
 
-vncserver -kill $display > /dev/null
-setsid vncserver $display -geometry 1750x1250 1>&2
+vncserver -kill "$display" >/dev/null
+setsid vncserver "$display" -geometry 1750x1250 1>&2
 if command -v vncviewer >/dev/null 2>&1; then
-  setsid vncviewer localhost$display > /dev/null &
+	setsid vncviewer "localhost$display" >/dev/null &
 fi
 
-echo export BROWSER_DISPLAY=$display
-if [ "$SHARED_DOCKER_SERVICE" == "true" ]; then
-    # No need to use separate variable when in container
-    echo export DISPLAY=$display
+echo "export BROWSER_DISPLAY=$display"
+if [[ $SHARED_DOCKER_SERVICE == "true" ]]; then
+	# No need to use separate variable when in container
+	echo "export DISPLAY=$display"
 fi


### PR DESCRIPTION
While reading these shell scripts my eyes started twitching: a variety of different conventions were in place for indentation, quoting style, conditionals, shebang lines, etc. I fixed this up using a combination of automated tools and manual editing. The result is `shfmt`-clean, (mostly) `shellcheck` clean, and a whole lot easier to read. I recommend reviewing this with the "hide whitespace changes" feature enabled.