### PR TITLE
Use `<<-` here document redirection operator where applicable

### DIFF
--- a/src/main/resources/ath-container/run.sh
+++ b/src/main/resources/ath-container/run.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 
 if [[ $# -lt 2 ]]; then
-	cat <<USAGE
-Usage: $0 BROWSER JENKINS [ARGS]
+	cat <<-USAGE
+		Usage: $0 BROWSER JENKINS [ARGS]
 
-It can use jenkins.war from local maven repository or download it when missing.
+		It can use jenkins.war from local maven repository or download it when missing.
 
-BROWSER: Value for BROWSER variable
-JENKINS: Path to the jenkins.war, Jenkins version of one of "latest", "latest-rc", "lts" and "lts-rc"
+		BROWSER: Value for BROWSER variable
+		JENKINS: Path to the jenkins.war, Jenkins version of one of "latest", "latest-rc", "lts" and "lts-rc"
 
-Examples:
+		Examples:
 
-# Run full suite in FF against ./jenkins.war.
-$ ./run firefox ./jenkins.war
+		# Run full suite in FF against ./jenkins.war.
+		$ ./run firefox ./jenkins.war
 
-# Run Ant plugin test in chrome against Jenkins 1.512.
-$ ./run chrome 1.512 -Dtest=AntPluginTest
+		# Run Ant plugin test in chrome against Jenkins 1.512.
+		$ ./run chrome 1.512 -Dtest=AntPluginTest
 
-# Run full suite in FF against LTS release candidate
-$ ./run firefox lts-rc
-USAGE
+		# Run full suite in FF against LTS release candidate
+		$ ./run firefox lts-rc
+	USAGE
 	exit 2
 fi
 


### PR DESCRIPTION
Per the [Bash documentation](https://www.gnu.org/software/bash/manual/bash.html#Here-Documents):

> If the redirection operator is `<<-`, then all leading tab characters are stripped from input lines and the line containing _delimiter._ This allows here-documents within shell scripts to be indented in a natural fashion.

Note that only tab character are stripped. Spaces are not stripped. For this reason, it is _objectively_ better to use tabs rather than spaces for indentation in `bash(1)` scripts.

Now that #1086 has been merged and `run.sh` is `shfmt(1)`-clean, tabs are being used consistently for indentation in that file. As the above documentation states, "this allows here-documents within shell scripts to be indented in a natural fashion." This is an improvement over the status quo because the status quo is indented in an unnatural fashion: with no indentation at all, even though it is inside an `if` block where indentation would be expected.

This PR is (still) `shfmt(1)`-clean, and I verified that the usage was still displayed correctly when no arguments were provided.