### PR TITLE
Revamp build/CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,13 +355,6 @@
       <artifactId>zt-zip</artifactId>
       <version>1.15</version>
     </dependency>
-    <!-- Keep in sync with mockito-core's version -->
-    <dependency>
-      <groupId>net.bytebuddy</groupId>
-      <artifactId>byte-buddy</artifactId>
-      <version>1.12.14</version>
-      <scope>test</scope>
-    </dependency>
     <!--
       This is just for dependency updates.
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <trimStackTrace>false</trimStackTrace> <!-- surefire -->
     <spotbugs.skip>true</spotbugs.skip>
 
+    <jenkins.version>2.399</jenkins.version>
     <selenium.version>4.8.1</selenium.version>
     <guava.version>31.1-jre</guava.version> <!-- aligned with selenium -->
     <aether.version>1.1.0</aether.version>
@@ -361,6 +362,24 @@
       <artifactId>byte-buddy</artifactId>
       <version>1.12.14</version>
       <scope>test</scope>
+    </dependency>
+    <!--
+      This is just for dependency updates.
+
+      TODO: Delete this dependency and figure out how to automatically update
+      this dependency some other way.
+    -->
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-core</artifactId>
+      <version>${jenkins.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -787,6 +806,49 @@ and
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>download-war</id>
+      <activation>
+        <file>
+          <missing>${env.JENKINS_WAR}</missing>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>jenkins-war</id>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <phase>process-test-resources</phase>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.jenkins-ci.main</groupId>
+                      <artifactId>jenkins-war</artifactId>
+                      <version>${jenkins.version}</version>
+                      <type>war</type>
+                    </artifactItem>
+                  </artifactItems>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                  <stripVersion>true</stripVersion>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>lts</id>
+      <properties>
+        <jenkins.version>2.387.1</jenkins.version>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/src/main/resources/ath-container/run.sh
+++ b/src/main/resources/ath-container/run.sh
@@ -7,20 +7,28 @@ if [[ $# -lt 2 ]]; then
 		It can use jenkins.war from local maven repository or download it when missing.
 
 		BROWSER: Value for BROWSER variable
-		JENKINS: Path to the jenkins.war, Jenkins version of one of "latest", "latest-rc", "lts" and "lts-rc"
+		JENKINS: Path to the Jenkins WAR, URL to the Jenkins WAR, version of the Jenkins WAR, "latest", or "lts"
 
 		Examples:
 
-		# Run full suite in FF against ./jenkins.war.
+		# Run full suite in Firefox against a URL:
+		$ ./run firefox https://updates.jenkins.io/download/war/2.394/jenkins.war
+
+		# Run full suite in Firefox against ./jenkins.war:
 		$ ./run firefox ./jenkins.war
 
-		# Run Ant plugin test in chrome against Jenkins 1.512.
-		$ ./run chrome 1.512 -Dtest=AntPluginTest
+		# Run Ant plugin test in chrome against Jenkins 2.399:
+		$ ./run chrome 2.399 -Dtest=AntPluginTest
 
-		# Run full suite in FF against LTS release candidate
-		$ ./run firefox lts-rc
+		# Run full suite in Firefox against LTS:
+		$ ./run firefox lts
 	USAGE
 	exit 2
+fi
+
+MVN='mvn -V -e -ntp'
+if [[ -n ${MAVEN_SETTINGS-} ]]; then
+	MVN="${MVN} -s ${MAVEN_SETTINGS}"
 fi
 
 function download() {
@@ -39,50 +47,33 @@ fi
 
 browser=$1
 war=$2
+extra_args=
+
 if [[ ! -f $war ]]; then
 	case "$war" in
 	latest)
-		war=jenkins-latest.war
-		url=https://updates.jenkins.io/latest/jenkins.war
+		# Maven will download this in the process-test-resources phase
+		war=target/jenkins-war.war
 		;;
 	lts)
-		war=jenkins-lts.war
-		url=https://updates.jenkins.io/stable/latest/jenkins.war
+		# Maven will download this in the process-test-resources phase
+		war=target/jenkins-war.war
+		extra_args='-Plts'
+		;;
+	*.war)
+		download "$war" "jenkins.war" || exit 1
+		war=jenkins.war
+		;;
+	*)
+		# Maven will download this in the process-test-resources phase
+		war=target/jenkins-war.war
+		extra_args="-Djenkins.version=$2"
 		;;
 	esac
-
-	if [[ -n $url ]]; then
-		find $war -maxdepth 0 -mtime +1 -delete 2>/dev/null
-		if [[ ! -f $war ]]; then
-			download "$url" "$war" || exit 1
-		fi
-	fi
-fi
-
-if [[ ! -f $war ]] && [[ $war == *.war ]]; then
-	download "$war" "jenkins.war" || exit 1
-	war=jenkins.war
-fi
-
-if [[ ! -f $war ]]; then
-	wardir=~/.m2/repository/org/jenkins-ci/main/jenkins-war
-
-	war=$wardir/$2/jenkins-war-$2.war
-	if [[ ! -f $war ]]; then
-		mvn -B org.apache.maven.plugins:maven-dependency-plugin:2.7:get \
-			-DremoteRepositories=repo.jenkins-ci.org::::https://repo.jenkins-ci.org/public/ \
-			"-Dartifact=org.jenkins-ci.main:jenkins-war:$2:war"
-	fi
-
-	if [[ ! -f $war ]]; then
-		echo 'No such jenkins.war. Available local versions:'
-		ls $wardir/*/jenkins-war-*.war | sed -r -e 's/.*jenkins-war-(.+)\.war/\1/'
-		exit 1
-	fi
 fi
 
 shift 2
 
 set -x
 
-BROWSER=$browser JENKINS_WAR=$war mvn --show-version --no-transfer-progress test "$@"
+BROWSER=$browser JENKINS_WAR=$war $MVN test $extra_args "$@"


### PR DESCRIPTION
Fixes #736. Preparatory work for #963. See self-review for details.

High-level changes:

- Retry CI stage on agent failure, consistent with other jobs.
- Publish incrementals, just like other jobs.
- Set `maven.repo.local` inside `WORKSPACE_TMP` in CI, just like jenkinsci/bom#1842.
- Define `jenkins.version` in `pom.xml`, where user-submitted PRs may set it to an incremental build. This version will be updated by Dependabot.
- Define an LTS Maven profile with the LTS version. This will need to be updated by the release lead after shipping an LTS.
- When `latest`, `lts`, or a version number are provided, have `run.sh` delegate to Maven rather than trying to do the download itself. Continue to support usages of a URL or a filesystem path to the WAR.
- Update documentation.
- Observe `MAVEN_SETTINGS`, if set. This is preparatory work for #963.