### PR TITLE
Upgrade parent POM from 1.97 to 1.98

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.97</version>
+    <version>1.98</version>
   </parent>
 
   <artifactId>acceptance-test-harness</artifactId>


### PR DESCRIPTION
Routine parent POM upgrade. Can this please be released? This adds `Implementation-Build` to `META-INF/MANIFEST.MF`, which I need in order to start making progress on the Launchable prototype.