### PR TITLE
Upgrade Extensibility API from 1.5 to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,13 +83,7 @@
     <dependency>
       <groupId>com.cloudbees</groupId>
       <artifactId>extensibility</artifactId>
-      <version>1.5</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-inject-plexus</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>1.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
The [new version](https://github.com/jenkinsci/extensibility-api/releases/tag/extensibility-1.6) supports Java 17 and has a recent Guice dependency, obviating the existing `sisu-inject-plexus` exclusion.