### PR TITLE
Add Java 17 to Docker image

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
         unzip \
         tightvncserver \
         openjdk-11-jdk \
+        openjdk-17-jdk \
         xfonts-base \
         openssh-client \
         && \

--- a/src/main/resources/ath-container/set-java.sh
+++ b/src/main/resources/ath-container/set-java.sh
@@ -6,6 +6,8 @@ trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 # The selection used by update-alternatives for each java version
 if [[ $1 == '11' ]]; then
 	selection='11-openjdk'
+elif [[ $1 == '17' ]]; then
+	selection='17-openjdk'
 else
 	echo >&2 "Unsupported java version '${1}'"
 	exit 1


### PR DESCRIPTION
Adds the `openjdk-17-jdk` package to the Docker image to enable local testing on Java 17. (The test suite does not currently work on Java 17.) Note that everywhere this image is consumed, we should be calling `set-java.sh` to a well-defined Java version rather than relying on the default. All consumers in this repository look fine (including this repository's `Jenkinsfile` build, which always explicitly sets Java 11), but Jenkins core's `ath.sh` is not doing this, so it will need to be adapted when we pull in this new image there.