### PR TITLE
Remove deprecated `withTimeout(long duration, TimeUnit unit)` in favor of `withTimeout(Duration timeout)`

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
@@ -205,14 +205,6 @@ public class Wait<Subject> extends FluentWait<Subject> {
 
     // Return subclass
 
-    /**
-     * @deprecated Use withTimeout(Duration) instead.
-     */
-    @Deprecated
-    public Wait<Subject> withTimeout(long duration, TimeUnit unit) {
-        return (Wait<Subject>) super.withTimeout(Duration.of(duration, unit.toChronoUnit()));
-    }
-
     @Override
     public Wait<Subject> withTimeout(Duration timeout) {
         return (Wait<Subject>) super.withTimeout(timeout);

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -154,7 +154,7 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
      */
     @Override @Deprecated
     public <T> T waitForCond(Callable<T> block, int timeoutSec) {
-        return waitFor(this).withTimeout(timeoutSec, TimeUnit.SECONDS).until(block);
+        return waitFor(this).withTimeout(Duration.ofSeconds(timeoutSec)).until(block);
     }
 
     @Override @Deprecated
@@ -181,7 +181,7 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     @Override
     public WebElement find(final By selector) {
         try {
-            return waitFor().withTimeout(time.seconds(1), TimeUnit.MILLISECONDS).until(new Callable<WebElement>() {
+            return waitFor().withTimeout(Duration.ofSeconds(time.seconds(1))).until(new Callable<WebElement>() {
                 @Override public WebElement call() {
                     for (WebElement element : driver.findElements(selector)) {
                         if (isDisplayed(element)) return element;

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -7,7 +7,6 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -181,7 +180,7 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     @Override
     public WebElement find(final By selector) {
         try {
-            return waitFor().withTimeout(Duration.ofSeconds(time.seconds(1))).until(new Callable<WebElement>() {
+            return waitFor().withTimeout(Duration.ofMillis(time.seconds(1))).until(new Callable<WebElement>() {
                 @Override public WebElement call() {
                     for (WebElement element : driver.findElements(selector)) {
                         if (isDisplayed(element)) return element;


### PR DESCRIPTION
This PR completes the cleanup from https://github.com/jenkinsci/acceptance-test-harness/pull/1119 by removing the deprecated method. 
All occurrences on our end have been updated.