### PR TITLE
Address `#pollingEvery(long duration, TimeUnit unit)` deprecation

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/Wait.java
@@ -223,12 +223,9 @@ public class Wait<Subject> extends FluentWait<Subject> {
         return (Wait<Subject>) super.withMessage(message);
     }
 
-    /**
-     * @deprecated Use pollingEvery(Duration) instead.
-     */
-    @Deprecated
-    public Wait<Subject> pollingEvery(long duration, TimeUnit unit) {
-        return (Wait<Subject>) super.pollingEvery(Duration.of(duration, unit.toChronoUnit()));
+    @Override
+    public Wait<Subject> pollingEvery(Duration timeout) {
+        return (Wait<Subject>) super.pollingEvery(timeout);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -119,7 +119,7 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     @Override
     public <T> Wait<T> waitFor(T subject) {
         return new Wait<>(subject, time)
-                .pollingEvery(500, TimeUnit.MILLISECONDS)
+                .pollingEvery(Duration.ofMillis(500))
                 .withTimeout(Duration.ofSeconds(120))
         ;
     }
@@ -407,7 +407,7 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
             runnable.run();
         }
         Wait<WebDriver> wait = new Wait<>(driver, time)
-                .pollingEvery(500, TimeUnit.MILLISECONDS)
+                .pollingEvery(Duration.ofMillis(500))
                 .withTimeout(Duration.ofSeconds(timeoutSeconds))
         ;
         Alert alert = wait.until(ExpectedConditions.alertIsPresent());

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Control.java
@@ -98,7 +98,7 @@ public class Control extends CapybaraPortingLayerImpl {
         // can take a while to update the layout \o/
         waitFor(we).
                withTimeout(Duration.ofSeconds(1)).
-               pollingEvery(100, TimeUnit.MILLISECONDS).
+               pollingEvery(Duration.ofMillis(100)).
                ignoring(ElementClickInterceptedException.class).
                until(() -> {we.click(); return true;});
     }
@@ -185,20 +185,20 @@ public class Control extends CapybaraPortingLayerImpl {
         click();
         WebElement we = findCaption(type,findDropDownMenuItem);
         // the element may not yet be visible so wait for it to become shown after the click above
-        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(Duration.ofSeconds(1)).until(we::isDisplayed);
+        waitFor(we).pollingEvery(Duration.ofMillis(100)).withTimeout(Duration.ofSeconds(1)).until(we::isDisplayed);
         we.click();
         // wait until the menu is hidden
-        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(Duration.ofSeconds(1)).until(() -> !we.isDisplayed());
+        waitFor(we).pollingEvery(Duration.ofMillis(100)).withTimeout(Duration.ofSeconds(1)).until(() -> !we.isDisplayed());
     }
 
     public void selectDropdownMenu(String displayName) {
         click();
         WebElement we = findDropDownMenuItem.find(displayName);
         // the element may not yet be visible so wait for it to become shown after the click above
-        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(Duration.ofSeconds(1)).until(we::isDisplayed);
+        waitFor(we).pollingEvery(Duration.ofMillis(100)).withTimeout(Duration.ofSeconds(1)).until(we::isDisplayed);
         we.click();
         // wait until the menu is hidden
-        waitFor(we).pollingEvery(100L, TimeUnit.MILLISECONDS).withTimeout(Duration.ofSeconds(1)).until(() -> !we.isDisplayed());
+        waitFor(we).pollingEvery(Duration.ofMillis(100)).withTimeout(Duration.ofSeconds(1)).until(() -> !we.isDisplayed());
     }
 
     /**


### PR DESCRIPTION
This PR addresses the deprecation of the PR title, by migrating to `Duration.of*` according to the javadocs.
It appears the method to use wasn't introduced when the deprecation was put in place in https://github.com/jenkinsci/acceptance-test-harness/pull/973/files#diff-addf4f5ac9e35192228ef3c7c0fa96e212baa9f6ad9c71f0c1ef42320547463bR227f
Therefore, I introduced it in this PR, while removing the deprecated method.