### PR TITLE
Disable concurrent builds on the main branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ if (env.BRANCH_IS_PRIMARY) {
   properties([
           buildDiscarder(logRotator(numToKeepStr: '50')),
           pipelineTriggers([cron('0 18 * * 2')]),
+          disableConcurrentBuilds(abortPrevious: true),
   ])
 }
 


### PR DESCRIPTION
ATH builds are quite resource heavy. When doing dependabot updates or merging multiple PRs in a row, every merge is build independently.
To keep the amount of occupied resources surveyable, I'd like to prevent concurrent builds, similar to core and other major repositories.