### PR TITLE
Track geckodriver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,6 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 20
-    ignore:
-      # Kept in sync with the version mockito-core uses
-      - dependency-name: "net.bytebuddy:byte-buddy"
   - package-ecosystem: "docker"
     directory: "src/main/resources/ath-container"
     schedule:
@@ -89,7 +81,3 @@ updates:
     ignore:
       - dependency-name: "ubuntu"
         versions: [">=22.04"]
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":semanticCommitsDisabled",
+    "schedule:earlyMondays"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["src/main/resources/ath-container/Dockerfile"],
+      "matchStrings": ["ENV GECKODRIVER_VERSION=(?<currentValue>.*?)\n"],
+      "depNameTemplate": "geckodriver/releases",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["src/main/resources/ath-container/Dockerfile"],
+      "matchStrings": ["ENV MAVEN_VERSION=(?<currentValue>.*?)\n"],
+      "depNameTemplate": "org.apache.maven:maven-core",
+      "datasourceTemplate": "maven"
+    },
+    {
+      "fileMatch": ["src/main/resources/ath-container/Dockerfile"],
+      "matchStrings": ["DOCKER_VERSION=(?<currentValue>.*?)\n"],
+      "depNameTemplate": "docker",
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "rebaseWhen": "conflicted"
+}

--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get -y --no-install-recommends install libgtk-3-0 libasound2 libdbus-gli
   && ln -fs /opt/firefox-${FIREFOX_VERSION}/firefox /usr/bin/firefox
 
 # Selenium needs a geckodriver in order to work properly
-ENV GECKODRIVER_VERSION 0.32.2
+ENV GECKODRIVER_VERSION=0.32.2
 # gross due to https://github.com/mozilla/geckodriver/issues/1956
 RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
   if [ "$arch" = "arm64" ] ; \
@@ -63,7 +63,7 @@ RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
   fi
 
 # Maven in repo is not new enough for ATH
-ENV MAVEN_VERSION 3.9.1
+ENV MAVEN_VERSION=3.9.1
 RUN curl -ffSLO https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-"$MAVEN_VERSION"-bin.tar.gz && \
     tar -xvzf apache-maven-"$MAVEN_VERSION"-bin.tar.gz -C /opt/ && \
     mv /opt/apache-maven-* /opt/maven


### PR DESCRIPTION
ref https://github.com/jenkinsci/acceptance-test-harness/pull/1141#pullrequestreview-1406969616

I left the existing Dockerfile configurations of dependabot in place, given they all use ubuntu 22 and don't require frequent updates.