### PR TITLE
Remove jcl-api because it doesn't exist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,11 +461,6 @@ and
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>jcl-api</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
       </dependency>


### PR DESCRIPTION
There's no such artifact with the pattern `org.slf4j:jcl-api` available on the [central repository](https://repo1.maven.org/maven2/org/slf4j/jcl-api).

Although, `slf4j-jcl` exists, it appears we can remove the dependency safely because it doesn't exist and the build didn't complain about it before.