### PR TITLE
Upgrade Maven from 3.3.9 to 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <jenkins.version>2.402</jenkins.version>
     <selenium.version>4.9.0</selenium.version>
     <guava.version>31.1-jre</guava.version> <!-- aligned with selenium -->
-    <aether.version>1.1.0</aether.version>
-    <maven.version>3.3.9</maven.version>
+    <maven.version>3.8.1</maven.version>
+    <maven-resolver.version>1.6.2</maven-resolver.version>
     <groovy.version>3.0.17</groovy.version>
     <monte.version>0.7.7.0</monte.version>
     <slf4j.version>2.0.7</slf4j.version>
@@ -172,13 +172,28 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
+      <artifactId>maven-resolver-provider</artifactId>
       <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings-builder</artifactId>
       <version>${maven.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
+      <version>${maven-resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-file</artifactId>
+      <version>${maven-resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-http</artifactId>
+      <version>${maven-resolver.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -194,41 +209,6 @@
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-console</artifactId>
       <version>${groovy.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-basic</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-spi</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-file</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-http</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
-      <version>${aether.version}</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/aether/AetherModule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/aether/AetherModule.java
@@ -5,12 +5,22 @@ import com.cloudbees.sdk.extensibility.ExtensionModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
-import org.apache.maven.repository.internal.MavenAetherModule;
+import org.apache.maven.model.building.DefaultModelBuilderFactory;
+import org.apache.maven.model.building.ModelBuilder;
+import org.apache.maven.repository.internal.DefaultArtifactDescriptorReader;
+import org.apache.maven.repository.internal.DefaultVersionRangeResolver;
+import org.apache.maven.repository.internal.DefaultVersionResolver;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.apache.maven.repository.internal.SnapshotMetadataGeneratorFactory;
+import org.apache.maven.repository.internal.VersionsMetadataGeneratorFactory;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.impl.ArtifactDescriptorReader;
+import org.eclipse.aether.impl.MetadataGeneratorFactory;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.impl.VersionResolver;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
@@ -29,6 +39,9 @@ import java.util.Set;
  * Hook up Aether resolver.
  * <p>
  * To resolve components, inject {@link RepositorySystem} and {@link RepositorySystemSession}.
+ * <p>
+ * Here, we assemble a complete module by using {@link org.eclipse.aether.impl.guice.AetherModule} (see its Javadoc)
+ * and adding bits from Maven itself (binding those components that complete the repository system).
  *
  * @author Kohsuke Kawaguchi
  */
@@ -36,9 +49,30 @@ import java.util.Set;
 public class AetherModule extends AbstractModule implements ExtensionModule {
     @Override
     protected void configure() {
-        install(new MavenAetherModule());
-        // alternatively, use the Guice Multibindings extensions
-        bind(RepositoryConnectorFactory.class).annotatedWith(Names.named("basic")).to(BasicRepositoryConnectorFactory.class);
+        // NOTE: see org.eclipse.aether.impl.guice.AetherModule Javadoc:
+        // org.eclipse.aether.impl.guice.AetherModule alone is "ready-made" but incomplete.
+        // To have a complete resolver, we actually need to bind the missing components making the module complete.
+        install(new org.eclipse.aether.impl.guice.AetherModule());
+
+        // make module "complete" by binding things not bound by org.eclipse.aether.impl.guice.AetherModule
+        bind(ArtifactDescriptorReader.class)
+                .to(DefaultArtifactDescriptorReader.class)
+                .in(Singleton.class);
+        bind(VersionResolver.class).to(DefaultVersionResolver.class).in(Singleton.class);
+        bind(VersionRangeResolver.class).to(DefaultVersionRangeResolver.class).in(Singleton.class);
+        bind(MetadataGeneratorFactory.class)
+                .annotatedWith(Names.named("snapshot"))
+                .to(SnapshotMetadataGeneratorFactory.class)
+                .in(Singleton.class);
+
+        bind(MetadataGeneratorFactory.class)
+                .annotatedWith(Names.named("versions"))
+                .to(VersionsMetadataGeneratorFactory.class)
+                .in(Singleton.class);
+
+        bind(RepositoryConnectorFactory.class)
+                .annotatedWith(Names.named("basic"))
+                .to(BasicRepositoryConnectorFactory.class);
         bind(TransporterFactory.class).annotatedWith(Names.named("file")).to(FileTransporterFactory.class);
         bind(TransporterFactory.class).annotatedWith(Names.named("http")).to(HttpTransporterFactory.class);
     }
@@ -63,21 +97,50 @@ public class AetherModule extends AbstractModule implements ExtensionModule {
         return session;
     }
 
+    /**
+     * Repository system connectors (needed for remote transport).
+     */
     @Provides
     @Singleton
-    Set<RepositoryConnectorFactory> provideRepositoryConnectorFactories(@Named("basic") RepositoryConnectorFactory basic) {
-        Set<RepositoryConnectorFactory> factories = new HashSet<RepositoryConnectorFactory>();
+    Set<RepositoryConnectorFactory> provideRepositoryConnectorFactories(
+            @Named("basic") RepositoryConnectorFactory basic) {
+        Set<RepositoryConnectorFactory> factories = new HashSet<>();
         factories.add(basic);
         return Collections.unmodifiableSet(factories);
     }
 
+    /**
+     * Repository system transporters (needed for remote transport).
+     */
     @Provides
     @Singleton
-    Set<TransporterFactory> provideTransporterFactories(@Named("file") TransporterFactory file,
-                                                        @Named("http") TransporterFactory http) {
-        Set<TransporterFactory> factories = new HashSet<TransporterFactory>();
+    Set<TransporterFactory> provideTransporterFactories(
+            @Named("file") TransporterFactory file, @Named("http") TransporterFactory http) {
+        Set<TransporterFactory> factories = new HashSet<>();
         factories.add(file);
         factories.add(http);
         return Collections.unmodifiableSet(factories);
+    }
+
+    /**
+     * Repository metadata generators (needed for remote transport).
+     */
+    @Provides
+    @Singleton
+    Set<MetadataGeneratorFactory> provideMetadataGeneratorFactories(
+            @Named("snapshot") MetadataGeneratorFactory snapshot,
+            @Named("versions") MetadataGeneratorFactory versions) {
+        Set<MetadataGeneratorFactory> factories = new HashSet<>(2);
+        factories.add(snapshot);
+        factories.add(versions);
+        return Collections.unmodifiableSet(factories);
+    }
+
+    /**
+     * Simple instance provider for model builder factory.
+     */
+    @Provides
+    ModelBuilder provideModelBuilder() {
+        return new DefaultModelBuilderFactory().newInstance();
     }
 }


### PR DESCRIPTION
Upgrade Maven from 3.3.9 to 3.8.1 which also involves a migration from Aether to `maven-resolver`. I followed the example at https://github.com/apache/maven-resolver/blob/89dadad860dc802fd328f2c7a29e7285b599ecde/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/guice/DemoResolverModule.java when adapting to the breaking API changes.