### PR TITLE
Ignore Maven dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,13 @@
     ":semanticCommitsDisabled",
     "schedule:earlyMondays"
   ],
+  "ignoreDeps": [
+    "org.apache.maven:maven-resolver-provider",
+    "org.apache.maven:maven-settings-builder",
+    "org.apache.maven.resolver:maven-resolver-connector-basic",
+    "org.apache.maven.resolver:maven-resolver-transport-file",
+    "org.apache.maven.resolver:maven-resolver-transport-http"
+  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
While we could try to keep up with Maven updates, my experience maintaining various Maven plugins in the Jenkins ecosystem is that doing so is a lot of effort for very little benefit: constant small API changes and Enforcer conflicts, for example. Recently we configured all our Maven plugins to use a stable baseline of Maven 3.8.1 and turned off Dependabot updates for Maven. This PR does the same for this repository. While not an apples-to-apples comparison (because this is not a Maven plugin), I think this will make it easier to maintain this repository. Maven upgrades can be done across the Jenkins ecosystem whenever we decide to shift to a newer Maven baseline and usually require a few API adaptations and a bit of testing.