### PR TITLE
Restore compatibility with the older Jenkins versions

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -89,7 +89,12 @@ public class PluginManager extends ContainerPageObject {
         // The check now button is a form submit (POST) with a redirect to the same page only if the check is successful.
         // We use the button itself to detect when the page has changed, which happens after the refresh has been done
         // And we check for the presence of the button again
-        WebElement checkButton = find(by.css("#button-refresh, .jenkins-button[href='checkUpdatesServer']"));
+        WebElement checkButton;
+        try {
+            checkButton = find(by.css("#button-refresh, .jenkins-button[href='checkUpdatesServer']"));
+        } catch (NoSuchElementException e) {
+            checkButton = find(by.link("Check now"));
+        }
         checkButton.click();
         // The wait criteria is: we have left the current page and returned to the same one
         waitFor(checkButton).withTimeout(java.time.Duration.of(time.seconds(30), ChronoUnit.MILLIS)).until(webElement -> {
@@ -306,7 +311,7 @@ public class PluginManager extends ContainerPageObject {
         WebElement filterBox = find(By.id("filter-box"));
         filterBox.clear();
         filterBox.sendKeys(pluginName);
-        
+
         // DEV MEMO: There is a {@code data-plugin-version} attribute on the {@code tr} tag holding the plugin line entry in the
         // plugin manager. By selecting the line, we can then retrieve the version directly without having to parse the line's content.
         final String xpathToPluginLine = "//input[starts-with(@name,'plugin.%s.')]/ancestor::tr";
@@ -322,7 +327,7 @@ public class PluginManager extends ContainerPageObject {
             }
             return true;
         });
-        
+
         String version = find(by.xpath(xpathToPluginLine, pluginName)).getAttribute("data-plugin-version");
         return new VersionNumber(version);
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR adds a fallback selector for the `Check now` button that was used in the older Jenkins versions. See: https://github.com/jenkinsci/acceptance-test-harness/pull/1080

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
