### PR TITLE
Fix compiler warnings in jenkins core master caused by test harness

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/AbstractPipelineTest.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/AbstractPipelineTest.java
@@ -58,14 +58,14 @@ public class AbstractPipelineTest extends AbstractJUnitTest {
         final String script = this.scriptForPipeline();
         PipelineTestUtils.checkScript(script);
 
-        return String.format(script, scriptParameters);
+        return String.format(script, (Object[]) scriptParameters);
     }
 
     public String scriptForPipelineFromResourceWithParameters(final String resourceName, final String... scriptParameters) throws IOException {
         final String script = PipelineTestUtils.scriptForPipelineFromResource(this.getClass(), resourceName);
         PipelineTestUtils.checkScript(script);
 
-        return String.format(script, scriptParameters);
+        return String.format(script, (Object[]) scriptParameters);
     }
 
     protected void assertJavadoc(final Job job) {

--- a/src/main/java/org/jenkinsci/test/acceptance/ByFactory.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/ByFactory.java
@@ -62,12 +62,12 @@ public class ByFactory {
         }
         // Fill the pattern with unique placeholders so we can safely identify what appears where so we do not
         // have to support various String.format specifiers.
-        String marker = String.format(format, placeholders);
+        String marker = String.format(format, (Object[]) placeholders);
         // Then replace the placeholders with quotes around them with unquoted format sequences
         String unquotedFormat = marker.replaceAll("(['\" ])placeholder(\\d+)\\1", "%$2\\$s");
 
         // Format the template with quoted arguments
-        String quotedSanitizedFormat = String.format(unquotedFormat, sanitized);
+        String quotedSanitizedFormat = String.format(unquotedFormat, (Object[]) sanitized);
 
         // Placeholders that are part of longer string literal will not be escaped
         String finalFormat = quotedSanitizedFormat.replaceAll("placeholder(\\d+)", "%$1\\$s");

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
@@ -109,10 +109,11 @@ public class WinstoneController extends LocalController {
     }
 
     private boolean supportsPortFileName() throws IOException {
-        JarFile warFile = new JarFile(war);
-        String jenkinsVersion = warFile.getManifest().getMainAttributes().getValue("Jenkins-Version");
-        VersionNumber version = new VersionNumber(jenkinsVersion);
-        return version.compareTo(v2339) >= 0;
+        try (JarFile warFile = new JarFile(war)) {
+            String jenkinsVersion = warFile.getManifest().getMainAttributes().getValue("Jenkins-Version");
+            VersionNumber version = new VersionNumber(jenkinsVersion);
+            return version.compareTo(v2339) >= 0;
+        }
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PageObject.java
@@ -40,7 +40,7 @@ public abstract class PageObject extends CapybaraPortingLayerImpl {
      * @see ContainerPageObject#url(String) Method that lets you resolve relative paths easily.
      */
     public final URL url;
-    
+
     /**
      * If the object was created with some context, preserve it so that we can
      * easily get the real Jenkins root
@@ -143,7 +143,7 @@ public abstract class PageObject extends CapybaraPortingLayerImpl {
      */
     public @NonNull String createPageArea(final String pathPrefix, Runnable action) throws TimeoutException {
         assert pathPrefix.startsWith("/"): "Path not absolute: " + pathPrefix;
-        final By by = this.by.areaPath(pathPrefix);
+        final By by = PageObject.by.areaPath(pathPrefix);
         final List<String> existing = extractPaths(all(by));
         final int existingSize = existing.size();
         action.run();

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/PipelineTestUtils.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/PipelineTestUtils.java
@@ -57,7 +57,7 @@ public class PipelineTestUtils {
         final String script = scriptForPipelineFromResource(resourceOwner, resourceName);
         checkScript(script);
 
-        return String.format(script, scriptParameters);
+        return String.format(script, (Object[]) scriptParameters);
     }
 
     public static void checkScript(final String script) {

--- a/src/test/java/plugins/AuditTrailPluginTest.java
+++ b/src/test/java/plugins/AuditTrailPluginTest.java
@@ -35,10 +35,12 @@ public class AuditTrailPluginTest extends AbstractJUnitTest {
 
         // purpose of this is to just go through the motion of creating a new slave,
         // so this one can bypass SlaveController.
-        Slave slave = new LocalSlaveController().install(jenkins).get();
+        try (LocalSlaveController slaveController = new LocalSlaveController()) {
+            Slave slave = slaveController.install(jenkins).get();
 
-        List<String> events = auditTrail.getEvents();
-        assertThat(events, hasItem("/createItem (" + freeStyleJob.name + ")"));
-        assertThat(events, hasItem("/computer/createItem (" + slave.getName() + ")"));
+            List<String> events = auditTrail.getEvents();
+            assertThat(events, hasItem("/createItem (" + freeStyleJob.name + ")"));
+            assertThat(events, hasItem("/computer/createItem (" + slave.getName() + ")"));
+        }
     }
 }

--- a/src/test/java/plugins/ConfigFileProviderTest.java
+++ b/src/test/java/plugins/ConfigFileProviderTest.java
@@ -264,7 +264,7 @@ public class ConfigFileProviderTest extends AbstractJUnitTest {
         final String script = this.scriptForPipeline();
         PipelineTestUtils.checkScript(script);
 
-        return String.format(script, scriptParameters);
+        return String.format(script, (Object[]) scriptParameters);
     }
 
 }

--- a/src/test/java/plugins/ExternalWorkspaceManagerPluginTest.java
+++ b/src/test/java/plugins/ExternalWorkspaceManagerPluginTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.openqa.selenium.By;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.apache.commons.io.FileUtils.listFiles;
@@ -148,15 +149,16 @@ public class ExternalWorkspaceManagerPluginTest extends AbstractJUnitTest {
         jenkins.save();
     }
 
-    private void setUpNode(String label, String fakeMountingPoint) throws ExecutionException, InterruptedException {
-        SlaveController controller = new LocalSlaveController();
-        Slave linuxSlave = controller.install(jenkins).get();
-        linuxSlave.configure();
-        linuxSlave.setLabels(label);
+    private void setUpNode(String label, String fakeMountingPoint) throws ExecutionException, InterruptedException, IOException {
+        try (SlaveController controller = new LocalSlaveController()) {
+            Slave linuxSlave = controller.install(jenkins).get();
+            linuxSlave.configure();
+            linuxSlave.setLabels(label);
 
-        ExternalNodeConfig nodeConfig = new ExternalNodeConfig(linuxSlave);
-        nodeConfig.setConfig(DISK_POOL_ID, DISK_ONE, DISK_TWO, fakeMountingPoint);
-        linuxSlave.save();
+            ExternalNodeConfig nodeConfig = new ExternalNodeConfig(linuxSlave);
+            nodeConfig.setConfig(DISK_POOL_ID, DISK_ONE, DISK_TWO, fakeMountingPoint);
+            linuxSlave.save();
+        }
     }
 
     private WorkflowJob createWorkflowJob(String script) {


### PR DESCRIPTION
This PR fixes the compiler warnings in the Jenkins core master build that are actually caused by the test harness code. See https://ci.jenkins.io/job/Core/job/jenkins/job/master/java
In addition it fixes resource leaks.

The aim is not to have no warnings locally (there are way more in my IDE), but rather to have zero warnings on the CI server.

This is not relevant for any changelog.

### Testing done

Just compiled locally. I'm not sure if I could really verify Selenium based tests on my Windows machine with sufficient trust.

### Submitter checklist

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
