### PR TITLE
Update hamcrest to non-deprecated package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,12 +212,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>2.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
+      <artifactId>hamcrest</artifactId>
       <version>2.2</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
hancrest -core and -library are deprecated in favor of `hamcrest`.