### PR TITLE
Update hamcrest methods

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/Matchers.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/Matchers.java
@@ -9,7 +9,6 @@ import java.util.regex.Pattern;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import org.apache.commons.io.IOUtils;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -140,7 +139,7 @@ public class Matchers {
      * @return the matcher
      */
     public static org.hamcrest.Matcher<String> containsString(final String format, final Object... args) {
-        return CoreMatchers.containsString(String.format(format, args));
+        return org.hamcrest.Matchers.containsString(String.format(format, args));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/CredentialsPage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/CredentialsPage.java
@@ -5,7 +5,7 @@ import java.net.URL;
 
 import org.jenkinsci.test.acceptance.po.*;
 
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 import org.openqa.selenium.WebDriver;

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/DomainPage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/DomainPage.java
@@ -6,7 +6,7 @@ import org.jenkinsci.test.acceptance.po.ConfigurablePageObject;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.openqa.selenium.NoSuchElementException;
 
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerServer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerServer.java
@@ -33,8 +33,8 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Artifact.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Artifact.java
@@ -7,7 +7,7 @@ import java.net.HttpURLConnection;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Build.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Build.java
@@ -15,8 +15,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
 import static org.jenkinsci.test.acceptance.Matchers.pageObjectDoesNotExist;
 import static org.jenkinsci.test.acceptance.Matchers.pageObjectExists;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ConfigurablePageObject.java
@@ -33,8 +33,8 @@ import org.jenkinsci.test.acceptance.selenium.Scroller;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.test.acceptance.Matchers.*;
 
 /**

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -33,8 +33,10 @@ import org.zeroturnaround.zip.ZipUtil;
 import com.google.inject.Injector;
 
 import static java.util.Objects.requireNonNull;
-import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.test.acceptance.Matchers.*;
 import static org.junit.Assert.assertTrue;
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Login.java
@@ -4,7 +4,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.time.Duration;
 
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasInvalidLoginInformation;
 import static org.jenkinsci.test.acceptance.Matchers.loggedInAs;

--- a/src/main/java/org/jenkinsci/test/acceptance/po/View.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/View.java
@@ -6,14 +6,13 @@ import org.hamcrest.Description;
 import org.jenkinsci.test.acceptance.Matcher;
 import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
-import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebElement;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Injector;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
 import static org.jenkinsci.test.acceptance.Matchers.*;
 
 /**

--- a/src/main/java/org/jenkinsci/test/acceptance/po/WizardCustomizeJenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WizardCustomizeJenkins.java
@@ -32,7 +32,7 @@ import org.openqa.selenium.WebElement;
 import java.time.Duration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.Matchers.not;
 import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 
 /**

--- a/src/test/java/core/ArtifactsTest.java
+++ b/src/test/java/core/ArtifactsTest.java
@@ -13,8 +13,10 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Feature: Archive artifacts

--- a/src/test/java/core/FreestyleJobTest.java
+++ b/src/test/java/core/FreestyleJobTest.java
@@ -33,9 +33,9 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.jenkinsci.test.acceptance.Matchers.containsRegexp;

--- a/src/test/java/core/ScriptTest.java
+++ b/src/test/java/core/ScriptTest.java
@@ -6,7 +6,7 @@ import org.jenkinsci.test.acceptance.po.Slave;
 import org.jenkinsci.test.acceptance.slave.SlaveController;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ScriptTest extends AbstractJUnitTest {

--- a/src/test/java/core/SlaveTest.java
+++ b/src/test/java/core/SlaveTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 import java.util.concurrent.ExecutionException;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**

--- a/src/test/java/org/jenkinsci/test/acceptance/recorder/HarRecorderTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/recorder/HarRecorderTest.java
@@ -10,8 +10,8 @@ import org.junit.runner.Description;
 import java.io.File;
 import java.net.InetAddress;
 
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.test.acceptance.Matchers.existingFile;
 
 public class HarRecorderTest {

--- a/src/test/java/org/jenkinsci/test/acceptance/recorder/TestRecorderRuleTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/recorder/TestRecorderRuleTest.java
@@ -8,8 +8,8 @@ import org.junit.runner.Description;
 import java.io.File;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.Is.is;
 import static org.jenkinsci.test.acceptance.Matchers.existingFile;
 
 public class TestRecorderRuleTest {

--- a/src/test/java/plugins/AntPluginTest.java
+++ b/src/test/java/plugins/AntPluginTest.java
@@ -14,7 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
 
 import java.util.regex.Pattern;

--- a/src/test/java/plugins/AntPluginTest.java
+++ b/src/test/java/plugins/AntPluginTest.java
@@ -12,7 +12,7 @@ import org.jenkinsci.test.acceptance.plugins.ant.AntInstallation;
 import org.jenkinsci.test.acceptance.po.*;
 import org.junit.Before;
 import org.junit.Test;
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/plugins/AuditTrailPluginTest.java
+++ b/src/test/java/plugins/AuditTrailPluginTest.java
@@ -11,8 +11,8 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @WithPlugins("audit-trail")

--- a/src/test/java/plugins/CoberturaPluginTest.java
+++ b/src/test/java/plugins/CoberturaPluginTest.java
@@ -8,7 +8,7 @@ import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasAction;
 

--- a/src/test/java/plugins/CopyArtifactPluginTest.java
+++ b/src/test/java/plugins/CopyArtifactPluginTest.java
@@ -35,10 +35,10 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
  * Test the Copy Artifacts plugin.

--- a/src/test/java/plugins/CopyArtifactPluginTest.java
+++ b/src/test/java/plugins/CopyArtifactPluginTest.java
@@ -35,9 +35,9 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 /**

--- a/src/test/java/plugins/CredentialsBindingTest.java
+++ b/src/test/java/plugins/CredentialsBindingTest.java
@@ -51,7 +51,7 @@ import org.openqa.selenium.WebDriver;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.utils.PipelineTestUtils.resolveScriptName;
 

--- a/src/test/java/plugins/DeclarativePipelineTest.java
+++ b/src/test/java/plugins/DeclarativePipelineTest.java
@@ -15,7 +15,7 @@ import javax.inject.Inject;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.containsRegexp;
 

--- a/src/test/java/plugins/DeployPluginTest.java
+++ b/src/test/java/plugins/DeployPluginTest.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @WithPlugins("deploy")

--- a/src/test/java/plugins/ExternalWorkspaceManagerPluginTest.java
+++ b/src/test/java/plugins/ExternalWorkspaceManagerPluginTest.java
@@ -23,8 +23,8 @@ import static org.apache.commons.io.FileUtils.listFiles;
 import static org.apache.commons.io.filefilter.FileFilterUtils.directoryFileFilter;
 import static org.apache.commons.io.filefilter.FileFilterUtils.nameFileFilter;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.core.StringContains.containsString;
 
 /**
  * Acceptance tests for External Workspace Manager Plugin.

--- a/src/test/java/plugins/GerritTriggerTest.java
+++ b/src/test/java/plugins/GerritTriggerTest.java
@@ -64,12 +64,12 @@ import java.util.regex.Pattern;
 
 import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/plugins/GitPluginTest.java
+++ b/src/test/java/plugins/GitPluginTest.java
@@ -45,8 +45,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 @WithDocker
 @Category(DockerTest.class)

--- a/src/test/java/plugins/JUnitPluginTest.java
+++ b/src/test/java/plugins/JUnitPluginTest.java
@@ -12,7 +12,7 @@ import org.openqa.selenium.WebElement;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.Matchers.hasContent;
 

--- a/src/test/java/plugins/JabberPluginTest.java
+++ b/src/test/java/plugins/JabberPluginTest.java
@@ -3,7 +3,6 @@ package plugins;
 import com.google.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
-import org.hamcrest.CoreMatchers;
 import org.jenkinsci.test.acceptance.docker.DockerContainerHolder;
 import org.jenkinsci.test.acceptance.docker.fixtures.JabberContainer;
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
@@ -26,6 +25,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 
 /**
  * This test case is set to @Ignore because the Jabber Plugin is not able to connect to conference.localhost
@@ -94,6 +94,6 @@ public class JabberPluginTest extends AbstractJUnitTest {
         j.startBuild().shouldSucceed();
         sleep(20000);
         File logfile = jabber.getLogbotLogFile();
-        assertThat(FileUtils.readFileToString(logfile, StandardCharsets.UTF_8), CoreMatchers.containsString("SUCCESS"));
+        assertThat(FileUtils.readFileToString(logfile, StandardCharsets.UTF_8), containsString("SUCCESS"));
     }
 }

--- a/src/test/java/plugins/JobDslPluginTest.java
+++ b/src/test/java/plugins/JobDslPluginTest.java
@@ -32,9 +32,9 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.jenkinsci.test.acceptance.Matchers.*;

--- a/src/test/java/plugins/LdapPluginTest.java
+++ b/src/test/java/plugins/LdapPluginTest.java
@@ -16,8 +16,8 @@ import org.jvnet.hudson.test.Issue;
 
 import javax.inject.Inject;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.jenkinsci.test.acceptance.Matchers.*;
 
 import java.io.IOException;

--- a/src/test/java/plugins/MatrixPluginTest.java
+++ b/src/test/java/plugins/MatrixPluginTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 

--- a/src/test/java/plugins/MatrixReloadedPluginTest.java
+++ b/src/test/java/plugins/MatrixReloadedPluginTest.java
@@ -33,7 +33,7 @@ import org.jenkinsci.test.acceptance.po.MatrixRun;
 import org.jenkinsci.test.acceptance.po.TextAxis;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @WithPlugins({

--- a/src/test/java/plugins/MavenPluginTest.java
+++ b/src/test/java/plugins/MavenPluginTest.java
@@ -47,8 +47,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import org.openqa.selenium.WebElement;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.jenkinsci.test.acceptance.Matchers.pageObjectExists;
 import static org.jenkinsci.test.acceptance.plugins.maven.MavenInstallation.installMaven;
 import static org.jenkinsci.test.acceptance.plugins.maven.MavenInstallation.installSomeMaven;

--- a/src/test/java/plugins/NestedViewPluginTest.java
+++ b/src/test/java/plugins/NestedViewPluginTest.java
@@ -1,7 +1,8 @@
 package plugins;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.Matchers.endsWith;
+
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.nested_view.NestedView;

--- a/src/test/java/plugins/OwnershipPluginTest.java
+++ b/src/test/java/plugins/OwnershipPluginTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assume.assumeFalse;
 
 @WithPlugins({"command-launcher", "ownership", "cloudbees-folder"})

--- a/src/test/java/plugins/PlainCredentialsBindingTest.java
+++ b/src/test/java/plugins/PlainCredentialsBindingTest.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 
 import java.net.URISyntaxException;
 
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/plugins/PostBuildScriptPluginTest.java
+++ b/src/test/java/plugins/PostBuildScriptPluginTest.java
@@ -10,7 +10,7 @@ import org.jenkinsci.test.acceptance.po.ShellBuildStep;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @WithPlugins({

--- a/src/test/java/plugins/ProjectDescriptionSetterPluginTest.java
+++ b/src/test/java/plugins/ProjectDescriptionSetterPluginTest.java
@@ -6,7 +6,7 @@ import org.jenkinsci.test.acceptance.plugins.project_description_setter.ProjectD
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @WithPlugins({

--- a/src/test/java/plugins/ScriptlerPluginTest.java
+++ b/src/test/java/plugins/ScriptlerPluginTest.java
@@ -37,8 +37,11 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 @WithPlugins("scriptler")
 public class ScriptlerPluginTest extends AbstractJUnitTest {

--- a/src/test/java/plugins/WorkflowMultibranchTest.java
+++ b/src/test/java/plugins/WorkflowMultibranchTest.java
@@ -16,9 +16,9 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.jenkinsci.test.acceptance.Matchers.hasAction;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/plugins/WsCleanupPluginTest.java
+++ b/src/test/java/plugins/WsCleanupPluginTest.java
@@ -7,7 +7,7 @@ import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.jenkinsci.test.acceptance.po.Workspace.workspaceContains;
 


### PR DESCRIPTION
With the merge of https://github.com/jenkinsci/acceptance-test-harness/pull/1182, we can migrate to the non-deprecated methods.