### PR TITLE
Group selenium deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,12 @@
       "matchPackageNames": ["com.google.inject:guice"],
       "description": "We focus on Guice 6 until core adapts 7"
     }
+    {
+      "matchPackagePatterns": [
+        "selenium"
+      ],
+      "groupName": "Selenium"
+    },
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
see https://github.com/jenkinsci/acceptance-test-harness/pull/1174 and https://github.com/jenkinsci/acceptance-test-harness/pull/1205

they should have been grouped together
untested, but can iterate next time there's a selenium release