### PR TITLE
disable surefire reuse of forks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,6 +468,7 @@ and
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <reuseForks>false</reuseForks>
           <systemPropertyVariables>
             <!-- allow large xpaths https://www.oracle.com/java/technologies/javase/11-0-15-relnotes.html#JDK-8270504 -->
             <jdk.xml.xpathExprOpLimit>200</jdk.xml.xpathExprOpLimit>


### PR DESCRIPTION
I have seen some interesting interactions and there is some static code in the test-harness, so do not attempt to reuse surefire.

this should reduce a bit of flakyness and should not be noticable given the overhead of starting a Jenkins insance for test.

This is also the setting we use for plugins in the plugin pom where the %age overhead would be more noticable than here

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
