### PR TITLE
Add extra debuging and fix controller logs

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -273,7 +273,7 @@ public class FallbackConfig extends AbstractModule {
             // bind to the loopback to prevent exposing the proxy to the world.
             proxyAddr = InetAddress.getLoopbackAddress();
         }
-        BrowserUpProxy proxy = HarRecorder.getProxy(proxyAddr);
+        BrowserUpProxy proxy = HarRecorder.getProxy(proxyAddr, testName);
         proxy.newHar(testName);
         return ClientUtil.createSeleniumProxy(proxy, proxyAddr);
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/controller/WinstoneController.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
@@ -82,6 +83,7 @@ public class WinstoneController extends LocalController {
                 throw new IOException("Unable to parse port from " + s + ". Jenkins did not start.");
             }
         }
+        super.onReady();
     }
 
     @Override
@@ -123,6 +125,13 @@ public class WinstoneController extends LocalController {
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public String getLogId() {
+        // as we will generally start with using a port of `0` we can not use the base classes implementation
+        // as the logging id will change through the lifecycle and not be initialized from the outset
+        return String.format("master%08d",  System.identityHashCode(this));
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/test/acceptance/recorder/HarRecorderTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/recorder/HarRecorderTest.java
@@ -25,7 +25,7 @@ public class HarRecorderTest {
             Description desc = description();
             HarRecorder harRecorder = rule(desc);
             HarRecorder.CAPTURE_HAR = HarRecorder.State.FAILURES_ONLY;
-            BrowserUpProxy proxy = HarRecorder.getProxy(InetAddress.getLoopbackAddress());
+            BrowserUpProxy proxy = HarRecorder.getProxy(InetAddress.getLoopbackAddress(), "anything-here");
             proxy.newHar("jenkins");
 
             System.out.println("Good Bye World");


### PR DESCRIPTION
The controller logs just use master0000 as the logId was using the port and since we use dynamic port the value is non stable (changes during he test) and also collides (every controller will start as master0000)

Also adds diadnostic logging to HARRecprder as I have been seeing tests where firefox can not connect to Jenkins as the browser is not running and test failures where the HAR can not be gathered as the proxy has already been stopped.

```
java.lang.IllegalStateException: Proxy server is already stopped. Cannot re-stop.
	at com.browserup.bup.BrowserUpProxyServer.stop(BrowserUpProxyServer.java:514)
	at com.browserup.bup.BrowserUpProxyServer.stop(BrowserUpProxyServer.java:493)
	at org.jenkinsci.test.acceptance.recorder.HarRecorder.recordHar(HarRecorder.java:120)
	at org.jenkinsci.test.acceptance.recorder.HarRecorder.failed(HarRecorder.java:114)
	at org.junit.rules.TestWatcher.failedQuietly(TestWatcher.java:90
```

```
org.openqa.selenium.WebDriverException:
Reached error page: about:neterror?e=proxyConnectFailure&u=http%3A//mvn%3A42593/pluginManager/available&c=UTF-8&d=Firefox%20is%20configured%20to%20use%20a%20proxy%20server%20that%20is%20refusing%20connections.
Build info: version: '4.9.1', revision: 'eb2032df7f'
System info: os.name: 'Linux', os.arch: 'amd64', os.version: '5.15.0-1030-gcp', java.version: '11.0.18'
Driver info: org.openqa.selenium.remote.RemoteWebDriver
Command: [9241c692-6c94-4037-b34b-273cf4e18279, get {url=http://mvn:42593/pluginManager/available}]
Capabilities {acceptInsecureCerts: true, browserName: firefox, browserVersion: 106.0.4, moz:accessibilityChecks: false, moz:buildID: 20221102214123, moz:debuggerAddress: 127.0.0.1:20092, moz:firefoxOptions: {prefs: {dom.disable_beforeunload: false, dom.max_chrome_script_run_time: 600000, dom.max_script_run_time: 600000, intl.accept_languages: en}}, moz:geckodriverVersion: 0.32.0, moz:headless: false, moz:platformVersion: 5.15.0-1030-gcp, moz:processID: 1075, moz:profile: /tmp/rust_mozprofilerHfdHB, moz:shutdownTimeout: 60000, moz:useNonSpecCompliantPointerOrigin: false, moz:webdriverClick: true, moz:windowless: false, pageLoadStrategy: normal, platformName: linux, proxy: Proxy(manual, http=mvn:4367..., se:bidi: ws://172.18.0.2:4444/sessio..., se:cdp: ws://172.18.0.2:4444/sessio..., se:cdpVersion: 85.0, se:noVncPort: 7900, se:vnc: ws://172.18.0.2:4444/sessio..., se:vncEnabled: true, se:vncLocalAddress: ws://172.18.0.2:7900, setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify}
Session ID: 9241c692-6c94-4037-b34b-273cf4e18279
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.createException(W3CHttpResponseCodec.java:200)
	at org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:133)
	at org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:53)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:193)
	at org.openqa.selenium.remote.TracedCommandExecutor.execute(TracedCommandExecutor.java:51)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:543)
	at org.openqa.selenium.remote.RemoteWebDriver.get(RemoteWebDriver.java:297)
```

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
