### PR TITLE
improve the contract around HARRecording

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -274,7 +274,6 @@ public class FallbackConfig extends AbstractModule {
             proxyAddr = InetAddress.getLoopbackAddress();
         }
         BrowserUpProxy proxy = HarRecorder.getProxy(proxyAddr, testName);
-        proxy.newHar(testName);
         return ClientUtil.createSeleniumProxy(proxy, proxyAddr);
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/recorder/HarRecorder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/recorder/HarRecorder.java
@@ -126,11 +126,20 @@ public class HarRecorder extends TestWatcher {
         }
     }
 
+    @Override
+    protected void starting(Description description) {
+        initializeHarForTest(description.getDisplayName());
+    }
+
+    private void initializeHarForTest(String name) {
+        if (proxy != null) {
+            proxy.newHar(name);
+        }
+    }
+
     private void recordHar() {
         if (proxy != null) {
-            LOGGER.log(Level.INFO, "Stopping proxy running on on port {0}", proxy.getPort());
-            proxy.stop();
-            Har har = proxy.getHar();
+            Har har = proxy.getHar(true);
             File file = diagnostics.touch("jenkins.har");
             try {
                 har.writeTo(file);
@@ -138,7 +147,6 @@ public class HarRecorder extends TestWatcher {
                 System.err.println("Unable to write HAR file to " + file);
                 e.printStackTrace(System.err);
             }
-            proxy = null;
         }
     }
 }


### PR DESCRIPTION
Tidy up the contract around the HAR being recorded and the proxy being created

The proxy was created on the first call to getProxy and every call after
when the har had been recorded for the previous test.

the Fallback config was responsible for updating the proxy with the test
name

This spread the responsibility for the HAR recording between FallbackConfig
and the HarRecorder.

This change moves the initialisation of the har from the FallbackConfig to
the HarRecorder itself, and no longer shuts down the proxy if a test causes
the har to be recorded.

Whilst the Proxy would not be closed, this is the status quo today and it is
terminated when the surefire JVM exists.
So now we will start the proxy only once per surefire JVM.

This could be a candidate for auto-wiring but that is left for a future
change

amends #1227

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
