### PR TITLE
Replace 'additionalparam' with doclint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -447,13 +447,13 @@ and
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <doclint>none</doclint>
         </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>
             <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
+              <doclint>none</doclint>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
>  [WARNING] Parameter 'additionalparam' is unknown for plugin 'maven-javadoc-plugin:3.5.0:jar (attach-javadocs)'
