### PR TITLE
Update maven URL to be more robust for maven updates

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -64,8 +64,8 @@ RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
 
 # Maven in repo is not new enough for ATH
 ENV MAVEN_VERSION=3.9.2
-RUN curl -ffSLO https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
-    tar -xvzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt/ && \
+RUN curl -ffSLO https://archive.apache.org/dist/maven/maven-3/"${MAVEN_VERSION}"/binaries/apache-maven-"${MAVEN_VERSION}"-bin.tar.gz && \
+    tar -xvzf apache-maven-"${MAVEN_VERSION}"-bin.tar.gz -C /opt/ && \
     mv /opt/apache-maven-* /opt/maven
 ENV PATH="$PATH:/opt/maven/bin"
 

--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -64,7 +64,7 @@ RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
 
 # Maven in repo is not new enough for ATH
 ENV MAVEN_VERSION=3.9.2
-RUN curl -ffSLO https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+RUN curl -ffSLO https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     tar -xvzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt/ && \
     mv /opt/apache-maven-* /opt/maven
 ENV PATH="$PATH:/opt/maven/bin"

--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -64,8 +64,8 @@ RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
 
 # Maven in repo is not new enough for ATH
 ENV MAVEN_VERSION=3.9.2
-RUN curl -ffSLO https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-"$MAVEN_VERSION"-bin.tar.gz && \
-    tar -xvzf apache-maven-"$MAVEN_VERSION"-bin.tar.gz -C /opt/ && \
+RUN curl -ffSLO https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    tar -xvzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt/ && \
     mv /opt/apache-maven-* /opt/maven
 ENV PATH="$PATH:/opt/maven/bin"
 


### PR DESCRIPTION
https://github.com/jenkinsci/acceptance-test-harness/pull/1262 fails on infra.ci because of:
```
21:18:13  #11 ERROR: process "/bin/bash -o pipefail -c curl -ffSLO [https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-\"$MAVEN_VERSION\"-bin.tar.gz](https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-/%22$MAVEN_VERSION/%22-bin.tar.gz) &&     tar -xvzf apache-maven-\"$MAVEN_VERSION\"-bin.tar.gz -C /opt/ &&     mv /opt/apache-maven-* /opt/maven" did not complete successfully: exit code: 22
```
a new version has been released and the old one is no longer available on the mirror specified. The change proposed uses a generic dl URL, being more robust for future updates.