### PR TITLE
chore(Jenkinsfile) discard old builds (5/PR and 10 on primary branch)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,14 @@
 // For ci.jenkins.io
 // https://github.com/jenkins-infra/documentation/blob/master/ci.adoc
 
-properties([disableConcurrentBuilds(abortPrevious: true)])
+properties([
+  disableConcurrentBuilds(abortPrevious: true),
+  buildDiscarder(logRotator(numToKeepStr: '5')),
+])
 
 if (env.BRANCH_IS_PRIMARY) {
   properties([
-          buildDiscarder(logRotator(numToKeepStr: '50')),
+          buildDiscarder(logRotator(numToKeepStr: '10')),
           pipelineTriggers([cron('0 18 * * 2')]),
           disableConcurrentBuilds(abortPrevious: true),
   ])


### PR DESCRIPTION
Each build weight ~100 Mb (mainly due to junit-attachment which is 80 to 90 Mb per build).

This PR proposes to discard old builds: no more than 10 builds on the principal branch (~1 month during the past 6 months) instead of 50 and no more than 5 builds per PR.

The goal is to decrease the amount of storage used on ci.jenkins.io and the I/O pressure.