### PR TITLE
Use artifact caching proxy for `acceptance-test-harness`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,24 +112,26 @@ for (int i = 0; i < splits.size(); i++) {
             docker.image('jenkins/ath').inside("-v /var/run/docker.sock:/var/run/docker.sock -v '${cwd}/target/ath-reports:/reports:rw' --shm-size 2g") {
               def exclusions = splits.get(index).join('\n')
               writeFile file: 'excludes.txt', text: exclusions
-              realtimeJUnit(
-                  testResults: 'target/surefire-reports/TEST-*.xml',
-                  testDataPublishers: [[$class: 'AttachmentPublisher']],
-                  // Slow test(s) removal can causes a split to get empty which otherwise fails the build.
-                  // The build failure prevents parallel tests executor to realize the tests are gone so same
-                  // split is run to execute and report zero tests - which fails the build. Permit the test
-                  // results to be empty to break the circle: build after removal executes one empty split
-                  // but not letting the build to fail will cause next build not to try those tests again.
-                  allowEmptyResults: true
-                  ) {
-                    sh """
-                        set-java.sh ${jdk}
-                        eval \$(vnc.sh)
-                        java -version
-                        run.sh ${browser} ${jenkinsVersion} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo -Dmaven.test.failure.ignore=true -DforkCount=1 -B
-                        cp --verbose target/surefire-reports/TEST-*.xml /reports
-                        """
-                  }
+              infra.withArtifactCachingProxy {
+                realtimeJUnit(
+                    testResults: 'target/surefire-reports/TEST-*.xml',
+                    testDataPublishers: [[$class: 'AttachmentPublisher']],
+                    // Slow test(s) removal can causes a split to get empty which otherwise fails the build.
+                    // The build failure prevents parallel tests executor to realize the tests are gone so same
+                    // split is run to execute and report zero tests - which fails the build. Permit the test
+                    // results to be empty to break the circle: build after removal executes one empty split
+                    // but not letting the build to fail will cause next build not to try those tests again.
+                    allowEmptyResults: true
+                    ) {
+                      sh """
+                          set-java.sh ${jdk}
+                          eval \$(vnc.sh)
+                          java -version
+                          run.sh ${browser} ${jenkinsVersion} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo -Dmaven.test.failure.ignore=true -DforkCount=1 -B
+                          cp --verbose target/surefire-reports/TEST-*.xml /reports
+                          """
+                    }
+              }
             }
             withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {
               def sessionFile = "launchable-session-${jenkinsVersion}-${platform}-jdk${jdk}-${browser}.txt"

--- a/src/main/resources/ath-container/run.sh
+++ b/src/main/resources/ath-container/run.sh
@@ -26,7 +26,8 @@ if [[ $# -lt 2 ]]; then
 	exit 2
 fi
 
-MVN='mvn -V -e -ntp'
+# MVN='mvn -V -e -ntp'
+MVN='mvn -V -e' # debug, to be removed
 if [[ -n ${MAVEN_SETTINGS-} ]]; then
 	MVN="${MVN} -s ${MAVEN_SETTINGS}"
 fi

--- a/src/main/resources/ath-container/run.sh
+++ b/src/main/resources/ath-container/run.sh
@@ -26,8 +26,7 @@ if [[ $# -lt 2 ]]; then
 	exit 2
 fi
 
-# MVN='mvn -V -e -ntp'
-MVN='mvn -V -e' # debug, to be removed
+MVN='mvn -V -e -ntp'
 if [[ -n ${MAVEN_SETTINGS-} ]]; then
 	MVN="${MVN} -s ${MAVEN_SETTINGS}"
 fi


### PR DESCRIPTION
This PR activates the use of artifact caching proxy for this repository.

Closes https://github.com/jenkinsci/acceptance-test-harness/issues/963

Ref: https://github.com/jenkins-infra/helpdesk/issues/3481#issuecomment-1608840888 & https://github.com/jenkins-infra/helpdesk/issues/2752

### Testing done
Successfully ran a replay with the `no-tranfer-progress` option removed from `run.sh` to check the use of the artifact caching proxy: https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/PR-1279/4/
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
