### PR TITLE
replace dumpling with a call to jstack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,17 +106,6 @@
       <version>0.38.20</version>
     </dependency>
     <dependency>
-      <groupId>com.github.olivergondza.dumpling</groupId>
-      <artifactId>dumpling</artifactId>
-      <version>2.6</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <optional>true</optional>


### PR DESCRIPTION
with the current java11 I have not had a successful stacktrace when a test timesout.

As we do not require parsing of the stacktrace we can replace dumpling with standard calls.

jstack works on windows (without the jstack.exe).

Whilst this requires jstack to be on the path - as we are calling java to launch this should be an acceptable requirement for the ATH.

fixes #1222

<!-- Please describe your pull request here. -->

### Testing done

Tested on windows 11 with a test that is consistently timing out in a specific environment
validate that the threaddump.log is valid.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
