### PR TITLE
swap gerrit-trigger for matrix-auth

### DIFF
--- a/src/test/java/core/PluginManagerTest.java
+++ b/src/test/java/core/PluginManagerTest.java
@@ -45,21 +45,22 @@ public class PluginManagerTest extends AbstractJUnitTest {
     }
 
     @Test
-    @WithPlugins("gerrit-trigger")
+    @WithPlugins("matrix-auth")
     public void uninstall_plugin() throws InterruptedException, ExecutionException {
         jenkins.getPluginManager().visit("installed");
         try {
-            WebElement uninstallButton = find(by.xpath(".//button[./@data-href = 'plugin/gerrit-trigger/doUninstall']"));
+            WebElement uninstallButton = find(by.xpath(".//button[./@data-href = 'plugin/matrix-auth/doUninstall']"));
             uninstallButton.click();
             waitFor(by.button("Yes"));
         } catch (NoSuchElementException te) {
-            WebElement form = find(by.action("plugin/gerrit-trigger/uninstall"));
+            // TODO remove this handling when Jenkins 2.415 is the lowest we support
+            WebElement form = find(by.action("plugin/matrix-auth/uninstall"));
             form.submit();
             waitFor(form).until(CapybaraPortingLayerImpl::isStale);
         }
         clickButton("Yes");
         jenkins.restart();
         jenkins.getPluginManager().visit("installed");
-        assertThrows(NoSuchElementException.class, () -> find(by.url("plugin/gerrit-trigger")));
+        assertThrows(NoSuchElementException.class, () -> find(by.url("plugin/matrix-auth")));
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

selfishly swap gerrit-trigger for `matrix-auth` in `core.PluginManagerTest#uninstall_plugin`

CloudBees' distribution contains `matrix-auth` but not `gerrit-trigger`, and as such installing the plugin will fail.
This is because we do not wait for an online update center to be available because we are wanting to test plugins inside our product and then the installation of `gerrit-trigger` will fail as it is not available.

This swap is harmless for OSS ATH.

### Testing done

ran `mvn clean test -Dtest=PluginManagerTest` 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
