### PR TITLE
Install OpenJDK 21 in ATH image

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -36,6 +36,17 @@ RUN apt-get update && \
         && \
     apt-get clean all && rm -rf /var/cache/apt
 
+# JDK21 https://github.com/adoptium/temurin21-binaries/releases/download/jdk21-2023-08-09-06-56-beta/OpenJDK21U-jdk_aarch64_linux_hotspot_2023-08-09-06-56.tar.gz
+ARG JDK21_VERSION=2023-08-09-06-56-beta
+RUN curl -sSLo /tmp/jdk21.tar.gz "https://github.com/adoptium/temurin21-binaries/releases/download/jdk21-${JDK21_VERSION}/OpenJDK21U-jdk_x64_linux_hotspot_${JDK21_VERSION//-beta/}.tar.gz" \
+  && mkdir /usr/lib/jvm/java-21-openjdk-amd64 \
+  && tar -C /usr/lib/jvm/java-21-openjdk-amd64 -xzf /tmp/jdk21.tar.gz --strip-components=1 \
+  && rm -fv /tmp/jdk21.tar.gz
+RUN update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-21-openjdk-amd64/bin/java 21 \
+  && update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-21-openjdk-amd64/bin/javac 21 \
+  && update-alternatives --set java /usr/lib/jvm/java-17-openjdk-amd64/bin/java \
+  && update-alternatives --set javac /usr/lib/jvm/java-17-openjdk-amd64/bin/javac
+
 # Install a fixed firefox version that is known to work with the current selenium version, copied from https://hub.docker.com/r/selenium/node-firefox/dockerfile
 ARG FIREFOX_VERSION=108.0.2
 # hadolint: Do not pin packages as they are requirements only for firefox installation (and not ofr the rest of the ATH) and the effort required to track each version would be too huge

--- a/src/main/resources/ath-container/set-java.sh
+++ b/src/main/resources/ath-container/set-java.sh
@@ -8,6 +8,8 @@ if [[ $1 == '11' ]]; then
 	selection='11-openjdk'
 elif [[ $1 == '17' ]]; then
 	selection='17-openjdk'
+elif [[ $1 == '21' ]]; then
+	selection='21-openjdk'
 else
 	echo >&2 "Unsupported java version '${1}'"
 	exit 1


### PR DESCRIPTION
Prerequisite for #1320. Without changing the existing configuration (Java 17 as default, Java 11 available), add OpenJDK 21 to the image.

### Testing done

Verified OpenJDK 17 was still the default. Verified I could switch to OpenJDK 21 with `set-java.sh` and ran `java -version` successfully.