### PR TITLE
chore(jenkinsfile): use spot instance for the first try or falls back to on-demand

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,8 +110,15 @@ for (int i = 0; i < splits.size(); i++) {
     def name = "${jenkinsVersion}-${platform}-jdk${jdk}-${browser}-split${index}"
     branches[name] = {
       stage(name) {
+        int retryCounts = 1
         retry(count: 2, conditions: [agent(), nonresumable()]) {
-          node('docker-highmem') {
+          String nodeLabel = 'docker-highmem-nonspot'
+          if (retryCounts == 1) {
+            // use a spot instance for the first try
+            nodeLabel = 'docker-highmem'
+          }
+          retryCounts = retryCounts + 1 // increment the retry count before allocating a node in case it fails
+          node(nodeLabel) {
             checkout scm
             sh 'mkdir -p target/ath-reports && chmod a+rwx target/ath-reports'
             def cwd = pwd()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ for (int i = 0; i < splits.size(); i++) {
         retry(count: 2, conditions: [agent(), nonresumable()]) {
           String nodeLabel = 'docker-highmem-nonspot'
           if (retryCounts == 1) {
-            // use a spot instance for the first try
+            // Use a spot instance for the first try
             nodeLabel = 'docker-highmem'
           }
           retryCounts = retryCounts + 1 // increment the retry count before allocating a node in case it fails


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3673#issuecomment-1660606208

this PR select a spot instance on first try or falls back to on-demand.

spot instance ensure that most of the builds are cheap but we don't want builds to fail due to infra issues.