### PR TITLE
disable flaky gitlab test

### DIFF
--- a/src/test/java/plugins/GitLabPluginTest.java
+++ b/src/test/java/plugins/GitLabPluginTest.java
@@ -17,6 +17,7 @@ import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
 import org.jenkinsci.test.acceptance.po.WorkflowMultiBranchJob;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -158,6 +159,8 @@ public class GitLabPluginTest extends AbstractJUnitTest {
         container.deleteRepo(getPrivateTokenAdmin(), repoName);
     }
 
+    // TODO: re-enable when flaky tests have been resolved. see: https://github.com/jenkinsci/acceptance-test-harness/pull/1365
+    @Ignore("flaky test")
     @Test
     public void gitLabGroupFolderOrganization() throws GitLabApiException, IOException {
         createGroup();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
`GitLabPluginTest.gitLabGroupFolderOrganization` is being consistently "flaky". It will always fail on one of the jdk 21 tests, sometimes on jdk 11. Disabling this test until it can be fixed

See #1365 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
