### PR TITLE
Use 2.426.1 in lts profile instead of 2.414.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -769,7 +769,7 @@ and
     <profile>
       <id>lts</id>
       <properties>
-        <jenkins.version>2.414.3</jenkins.version>
+        <jenkins.version>2.426.1</jenkins.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
## Use 2.426.1 in lts profile instead of 2.414.3

Jenkins 2.426.1 has been released and is being used on ci.jenkins.io and in many other configurations.  Let's use it for acceptance testing as well.

### Testing done

Rely on ci.jenkins.io to do the testing.  2.426.1 pre-release testing with ATH was successful.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
