### PR TITLE
Enable `script-security` tests again

### DIFF
--- a/src/test/java/plugins/GroovyPluginTest.java
+++ b/src/test/java/plugins/GroovyPluginTest.java
@@ -35,7 +35,6 @@ import org.jenkinsci.test.acceptance.plugins.script_security.ScriptApproval;
 import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.jenkinsci.test.acceptance.po.ToolInstallation;
-import org.junit.Ignore;
 import org.junit.Test;
 
 @WithPlugins("groovy")
@@ -76,7 +75,6 @@ public class GroovyPluginTest extends AbstractJUnitTest {
     }
 
     @Test
-    @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/1444")
     public void run_system_groovy_from_file() {
         configureJob();
 

--- a/src/test/java/plugins/JobDslPluginTest.java
+++ b/src/test/java/plugins/JobDslPluginTest.java
@@ -37,7 +37,6 @@ import org.jenkinsci.test.acceptance.po.PluginManager;
 import org.jenkinsci.test.acceptance.po.View;
 import org.jenkinsci.test.acceptance.update_center.PluginSpec;
 import org.jenkinsci.test.acceptance.utils.IOUtil;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -655,7 +654,6 @@ public class JobDslPluginTest extends AbstractJUnitTest {
      * 'Manage Jenkins' area. Approved scripts can be executed.
      */
     @Test @WithPlugins({"matrix-auth@2.3","mock-security-realm","authorize-project"})
-    @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/1444")
     public void should_use_grooy_sandbox_no_whitelisted_content() {
         GlobalSecurityConfig sc = setUpSecurity();
         runBuildAsUserWhoTriggered(sc);

--- a/src/test/java/plugins/ScriptSecurityPluginTest.java
+++ b/src/test/java/plugins/ScriptSecurityPluginTest.java
@@ -35,7 +35,6 @@ import org.jenkinsci.test.acceptance.po.JenkinsDatabaseSecurityRealm;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 @WithPlugins({"script-security", "matrix-auth"})
@@ -116,7 +115,6 @@ public class ScriptSecurityPluginTest extends AbstractJUnitTest {
 
     @Test
     @WithPlugins("groovy-postbuild")
-    @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/1444")
     public void signatureNeedsApproval() throws Exception {
         final FreeStyleJob job = createFailedJobWithGroovyPostBuild("def h = java.lang.System.getProperties()", true);
         login(ADMIN);
@@ -143,7 +141,6 @@ public class ScriptSecurityPluginTest extends AbstractJUnitTest {
 
     @Test
     @WithPlugins({"workflow-job","workflow-cps"})
-    @Ignore("https://github.com/jenkinsci/acceptance-test-harness/issues/1444")
     public void pipelineSignatureNeedsApproval() throws Exception {
         final WorkflowJob job = createFailedPipeline("def h = java.lang.System.getProperty('java.version')", true);
         login(ADMIN);


### PR DESCRIPTION
Reverting #1444 since these should pass ~as soon as https://github.com/jenkinsci/script-security-plugin/pull/549 is deployed~ now that it is deployed.

Fixes https://github.com/jenkinsci/acceptance-test-harness/pull/1463