### PR TITLE
Add an option to skip initialization of the fake update center

### DIFF
--- a/docs/CONTROLLER.md
+++ b/docs/CONTROLLER.md
@@ -12,13 +12,18 @@ section describes them.
 
 For more sophisticated customization, see [WIRING.md](WIRING.md).
 
+To reduce the overall startup time, you can also use a pool of JUT instances, see [PRELAUNCH.md](PRELAUNCH.md) for more details.
+
 ## Local family controllers
 All local controllers run both test harness and Jenkins under Test on the local machine. Common environment variables for local controllers:
 
 * `JENKINS_JAVA_HOME` the JVM home to use for running Jenkins. If not specified, the first of `JAVA_HOME`, or the JVM
    used to launch the tests will be used.
 * `JENKINS_JAVA_OPTS` Adds additional options to the java process like `-Xms=XXm -Xmx=XXXm`.
-* `INTERACTIVE` keep browser session opened after failed scenario for interactive investigation.
+* `INTERACTIVE` keep browser session opened after a failed scenario for interactive investigation.
+* `SKIP_UPDATES` skip Jenkins plugin updates before starting the tests. Dramatically reduces the startup time for tests.  
+   Using this option makes sense when you are running tests against a Jenkins instance that is already set up with the 
+   plugins you need (see environment variable `PLUGINS_DIR`).  
 
 You can disable the logging output of Jenkins by setting the system property `quiet` on 
 the command line.

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -24,9 +24,6 @@
 
 package org.jenkinsci.test.acceptance.update_center;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.inject.Inject;
-import com.google.inject.Injector;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -37,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.ExceptionLogger;
@@ -56,13 +54,18 @@ import org.apache.http.protocol.RequestConnControl;
 import org.apache.http.protocol.ResponseContent;
 import org.apache.http.protocol.ResponseServer;
 import org.apache.http.protocol.UriHttpRequestHandlerMapper;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
 import org.jenkinsci.test.acceptance.guice.AutoCleaned;
 import org.jenkinsci.test.acceptance.guice.TestScope;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.po.UpdateCenter;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * Serves a fake update center locally.
@@ -84,6 +87,10 @@ public class MockUpdateCenter implements AutoCleaned {
     private HttpServer server;
 
     public void ensureRunning(Jenkins jenkins) {
+        if (System.getenv("SKIP_UPDATES") != null) {
+            LOGGER.info("skipping time-consuming initialization of mock update center - make sure that all required plugins are already installed in PLUGINS_DIR");
+            return;
+        }
         if (original != null) {
             return;
         }


### PR DESCRIPTION
Add a new environment variable `SKIP_UPDATES` to skip Jenkins plugin updates before starting the tests. Dramatically reduces the startup time for tests. Using this option makes sense when you are running tests against a Jenkins instance that is already set up with the plugins you need (see environment variable `PLUGINS_DIR`).  