### PR TITLE
compatibility for new progressbar rendering

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/BuildHistory.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/BuildHistory.java
@@ -28,7 +28,7 @@ public class BuildHistory extends PageObject {
         open();
 
         // build history is progressively rendered so wait until that is complete
-        WebElement progressiveRendering = findIfNotVisible(by.xpath("//table[@tooltip='Computation in progress.']"));
+        WebElement progressiveRendering = findIfNotVisible(by.xpath("//*[@tooltip='Computation in progress.']"));
         waitFor(progressiveRendering).until(we -> !we.isDisplayed());
 
         LinkedHashSet<Build> builds = new LinkedHashSet<Build>();


### PR DESCRIPTION
previously it was `table`, now it is `a` (theoretically it can also be `div` but not for the build history).
See https://github.com/jenkinsci/jenkins/pull/8821

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
