### PR TITLE
Update selectors: credentials dialog, declarative migration assistant

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/Credential.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/credentials/Credential.java
@@ -4,6 +4,7 @@ import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.PageArea;
 import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 import org.jenkinsci.test.acceptance.po.PageObject;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -27,11 +28,18 @@ public abstract class Credential extends PageAreaImpl {
      * Adds this credential and close the dialog.
      */
     public void add() {
-        WebElement dialog = find(by.id("credentialsDialog"));
-        WebElement we = find(by.id("credentials-add-submit-button"));
+        WebElement dialog = find(by.id("credentials-dialog-form"));
+        WebElement we = find(submitButton());
         we.click();
         // wait for the form to be removed from the UI
         waitFor(driver).until(ExpectedConditions.invisibilityOf(dialog));
+    }
+
+    /**
+     * @return dialog submit button selector
+     */
+    public static By submitButton() {
+        return by.css(".jenkins-button[data-id='ok']");
     }
 
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshCredentialDialog.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/ssh_credentials/SshCredentialDialog.java
@@ -43,13 +43,11 @@ public class SshCredentialDialog extends PageAreaImpl {
      * Adds this credential and close the modal dialog.
      */
     public void add() {
-        final By addSubmitButton = by.id("credentials-add-submit-button");
-
-        this.findAndPerformClick(addSubmitButton);
+        this.findAndPerformClick(Credential.submitButton());
 
         waitFor().withTimeout(Duration.ofSeconds(5)).until(() -> {
             try {
-                return !find(addSubmitButton).isDisplayed();
+                return !find(Credential.submitButton()).isDisplayed();
             } catch (final NoSuchElementException | StaleElementReferenceException ex) {
                 return true;
             }

--- a/src/test/java/plugins/DeclarativeAssistantMigrationTest.java
+++ b/src/test/java/plugins/DeclarativeAssistantMigrationTest.java
@@ -53,7 +53,7 @@ public class DeclarativeAssistantMigrationTest
         assertThat(driver, hasElement( By.className( "rectangle-conversion-success")));
         assertThat(driver, hasElement(By.className("review-converted")));
         assertThat(driver, hasElement(By.id("jenkinsfile-content")));
-        String jenkinsFile =  driver.findElement(By.id("jenkinsfile-content")).getAttribute("value");
+        String jenkinsFile =  driver.findElement(By.id("jenkinsfile-content")).getText();
         assertThat(jenkinsFile, containsString( "echo 1" ));
     }
 }


### PR DESCRIPTION
* Updates selectors to match latest release of credentials dialog (follow-up for https://github.com/jenkinsci/credentials-plugin/pull/500 ) 
* Updates selector for Declarative Migration Assistant (follow-up for https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/pull/232)

### Testing done

Observed that CI passed

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
