### PR TITLE
Validate Gradle wrapper

### DIFF
--- a/.github/workflows/verify-gradle-wrapper.yaml
+++ b/.github/workflows/verify-gradle-wrapper.yaml
@@ -1,0 +1,11 @@
+name: Validate Gradle wrapper
+on: [pull_request, push]
+jobs:
+  build_pr:
+    if: github.repository_owner == 'jenkinsci'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v2


### PR DESCRIPTION
I noticed https://github.com/jenkinsci/acceptance-test-harness/commit/865cecc01a41076b69cbc0069a953f78e00f941d and in case someone bumps the wrapper in the future, if needed, the action added validates whether the .jar is legit or not.