### PR TITLE
Use Jenkins 2.440.2 as LTS version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -770,7 +770,7 @@ and
     <profile>
       <id>lts</id>
       <properties>
-        <jenkins.version>2.426.3</jenkins.version>
+        <jenkins.version>2.440.2</jenkins.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
## Use Jenkins 2.440.2 as LTS version

Unclear why we missed 2.440.1 as LTS

https://github.com/jenkins-infra/release/issues/510 is the 2.440.2 release checklist and it references this task.

### Testing done

No testing performed.  Relying on ci.jenkins.io to do the work.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
