### PR TITLE
prevent spam when setting size to -1

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -74,6 +74,7 @@ import org.jenkinsci.test.acceptance.po.UpdateCenter;
 public class MockUpdateCenter implements AutoCleaned {
 
     private static final Logger LOGGER = Logger.getLogger(MockUpdateCenter.class.getName());
+    private static final Integer MINUS_ONE = Integer.valueOf(-1);
 
     @Inject
     public Injector injector;
@@ -227,7 +228,11 @@ public class MockUpdateCenter implements AutoCleaned {
         Object old = plugin.opt(key);
         plugin.put(key, val);
         if (!String.valueOf(val).equals(String.valueOf(old))) {
-            LOGGER.log(Level.INFO, "for {0} updating {1} from {2} to {3}", new Object[] {plugin.getString("name"), key, old, val});
+            if (MINUS_ONE == val && "size".equals(key)) {
+                LOGGER.log(Level.FINE, "for {0} updating {1} from {2} to {3}", new Object[] {plugin.getString("name"), key, old, val});
+            } else {
+                LOGGER.log(Level.INFO, "for {0} updating {1} from {2} to {3}", new Object[] {plugin.getString("name"), key, old, val});
+            }
         }
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/update_center/MockUpdateCenter.java
@@ -74,7 +74,7 @@ import org.jenkinsci.test.acceptance.po.UpdateCenter;
 public class MockUpdateCenter implements AutoCleaned {
 
     private static final Logger LOGGER = Logger.getLogger(MockUpdateCenter.class.getName());
-    private static final Integer MINUS_ONE = Integer.valueOf(-1);
+    private static final String MINUS_ONE_STRING = "-1";
 
     @Inject
     public Injector injector;
@@ -130,7 +130,7 @@ public class MockUpdateCenter implements AutoCleaned {
                 plugin.put("url", name + ".hpi");
                 updating(plugin, "version", version);
                 // "Avoid IOException: Inconsistent file length" from hudson.model.UpdateCenter
-                updating(plugin, "size", "-1");
+                updating(plugin, "size", MINUS_ONE_STRING);
                 updating(plugin, "gav", meta.gav);
                 updating(plugin, "requiredCore", meta.requiredCore().toString());
                 updating(plugin, "dependencies", new JSONArray(meta.getDependencies().stream().map(d -> {
@@ -228,7 +228,9 @@ public class MockUpdateCenter implements AutoCleaned {
         Object old = plugin.opt(key);
         plugin.put(key, val);
         if (!String.valueOf(val).equals(String.valueOf(old))) {
-            if (MINUS_ONE == val && "size".equals(key)) {
+            // "-1" and "size" are both string literals in the caller,
+            // so only check their identity to prevent a fallback to checking characters which is unneeded.
+            if (MINUS_ONE_STRING == val && "size" == key) {
                 LOGGER.log(Level.FINE, "for {0} updating {1} from {2} to {3}", new Object[] {plugin.getString("name"), key, old, val});
             } else {
                 LOGGER.log(Level.INFO, "for {0} updating {1} from {2} to {3}", new Object[] {plugin.getString("name"), key, old, val});


### PR DESCRIPTION
the size for every plugin is set to `-1` which creates excessive spam when running.

prevents spam like the following
```
Apr 12, 2024 11:02:22 AM org.jenkinsci.test.acceptance.update_center.MockUpdateCenter updating
INFO: for SBuild updating size from 19,704 to -1
Apr 12, 2024 11:02:22 AM org.jenkinsci.test.acceptance.update_center.MockUpdateCenter updating
INFO: for SSSCM updating size from 11,287 to -1
Apr 12, 2024 11:02:22 AM org.jenkinsci.test.acceptance.update_center.MockUpdateCenter updating
INFO: for StashBranchParameter updating size from 1,206,570 to -1
Apr 12, 2024 11:02:22 AM org.jenkinsci.test.acceptance.update_center.MockUpdateCenter updating
INFO: for Surround-SCM-plugin updating size from 41,279 to -1
Apr 12, 2024 11:02:22 AM org.jenkinsci.test.acceptance.update_center.MockUpdateCenter updating
INFO: for TestComplete updating size from 105,057 to -1
Apr 12, 2024 11:02:22 AM org.jenkinsci.test.acceptance.update_center.MockUpdateCenter updating
INFO: for TestFairy updating size from 2,277,975 to -1
Apr 12, 2024 11:02:22 AM org.jenkinsci.test.acceptance.update_center.MockUpdateCenter updating
INFO: for TwilioNotifier updating size from 2,146,774 to -1
Apr 12, 2024 11:02:22 AM org.jenkinsci.test.acceptance.update_center.MockUpdateCenter updating
INFO: for URLSCM updating size from 16,977 to -1
Apr 12, 2024 11:02:22 AM org.jenkinsci.test.acceptance.update_center.MockUpdateCenter updating
INFO: for abap-ci updating size from 347,171 to -1
Apr 12, 2024 11:02:22 AM org.jenkinsci.test.acceptance.update_center.MockUpdateCenter updating
INFO: for absint-a3 updating size from 36,542 to -1
```

log these at FINE level, log all other updates and INFO level



<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
