### PR TITLE
Upgrade test containers to Ubuntu 24.04 and Java 17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,9 +23,6 @@ updates:
     directory: "src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "ubuntu"
-        versions: [">=22.04"]
   - package-ecosystem: "docker"
     directory: "src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JabberContainer"
     schedule:
@@ -44,9 +41,6 @@ updates:
     directory: "src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "ubuntu"
-        versions: [">=22.04"]
   - package-ecosystem: "docker"
     directory: "src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/LdapContainer"
     schedule:
@@ -74,9 +68,6 @@ updates:
     directory: "src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/Tomcat10Container"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "ubuntu"
-        versions: [">=22.04"]
   - package-ecosystem: "docker"
     directory: "src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitLabContainer"
     schedule:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ if (needSplittingFromWorkspace) {
 def axes = [
   jenkinsVersions: ['lts', 'latest'],
   platforms: ['linux'],
-  jdks: [11, 21],
+  jdks: [17, 21],
   browsers: ['firefox'],
 ]
 

--- a/ath-container.sh
+++ b/ath-container.sh
@@ -8,7 +8,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 uid=$(id -u)
 gid=$(id -g)
 tag='jenkins/ath'
-java_version="${java_version:-11}"
+java_version="${java_version:-17}"
 
 # high chance of uid / group already existing in the container
 # known to happen on macOS

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
     <dependency>
       <groupId>org.jenkins-ci.test</groupId>
       <artifactId>docker-fixtures</artifactId>
-      <version>190.vd6a_e600cb_775</version>
+      <version>200.v22a_e8766731c</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/GitContainer/Dockerfile
@@ -3,7 +3,7 @@
 # and prepares for execution of gitplugin tests.
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN mkdir -p /var/run/sshd
 

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JiraContainer/Dockerfile
@@ -3,7 +3,7 @@
 #
 #    The initial password is 'admin:admin'
 #
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Pin JIRA version to make the tests more predictable and less fragile
 # In particular, pinned to 6.X because from 7.X the SOAP API is gone, and it's
@@ -12,11 +12,11 @@ FROM ubuntu:22.04
 ENV JIRA_VERSION 6.3
 
 # base package installation
-RUN apt-get update && apt-get install -y apt-transport-https wget gnupg2 && echo "deb https://packages.atlassian.com/debian/atlassian-sdk-deb/ stable contrib" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -y apt-transport-https wget gnupg2 software-properties-common && add-apt-repository -s "deb https://packages.atlassian.com/debian/atlassian-sdk-deb/ stable contrib"
 RUN wget https://packages.atlassian.com/api/gpg/key/public
 RUN apt-key add public
 
-RUN apt-get update && apt-get install -y openjdk-8-jdk atlassian-plugin-sdk netcat
+RUN apt-get update && apt-get install -y openjdk-8-jdk atlassian-plugin-sdk netcat-openbsd
 
 # this will install the whole thing, launches Tomcat,
 # asks the user to do Ctrl+C to quit, then it shuts down presumably because it

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshAgentContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshAgentContainer/Dockerfile
@@ -1,4 +1,4 @@
 # curl -s https://raw.githubusercontent.com/jenkinsci/docker-fixtures/master/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile | sha1sum | cut -c 1-12
-FROM jenkins/java:387404da3ce7
+FROM jenkins/java:978f1af53461
 COPY *.pub /tmp
 RUN cat /tmp/*.pub >> /home/test/.ssh/authorized_keys

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/Tomcat10Container/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/Tomcat10Container/Dockerfile
@@ -1,16 +1,11 @@
 #
-# Runs Tomcat7 on Ubuntu at port 8080, with the admin app
+# Runs Tomcat10 on Ubuntu at port 8080, with the admin app
 #
 # The admin user has username 'admin' and password 'tomcat'
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y gnupg
-
-# Tomcat7 is from Universe
-RUN echo "deb http://archive.ubuntu.com/ubuntu lunar universe" >> /etc/apt/sources.list
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 40976EAF437D05B5
 RUN apt-get update && apt-get install -y tomcat10 tomcat10-admin
 
 # configure the admin user

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/XvncSlaveContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/XvncSlaveContainer/Dockerfile
@@ -1,6 +1,6 @@
 # curl -s https://raw.githubusercontent.com/jenkinsci/docker-fixtures/master/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile | sha1sum | cut -c 1-12
-FROM jenkins/java:387404da3ce7
-RUN apt-get update && apt-get install -y vnc4server imagemagick
+FROM jenkins/java:978f1af53461
+RUN apt-get update && apt-get install -y tigervnc-standalone-server imagemagick
 
 # So it is owned by root and has the permissions vncserver seems to require:
 RUN mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix/

--- a/src/test/java/plugins/AntPluginTest.java
+++ b/src/test/java/plugins/AntPluginTest.java
@@ -103,7 +103,7 @@ public class AntPluginTest extends AbstractJUnitTest {
         step.targets.set("-version");
         job.save();
 
-        String expectedVersion = "1.10.5"; // this is the version installed in the java container by the ubuntu bionic
+        String expectedVersion = "1.10.14"; // this is the version installed in the java container by the ubuntu noble
         job.startBuild().shouldSucceed().shouldContainsConsoleOutput(Pattern.quote(expectedVersion));
     }
 
@@ -118,7 +118,7 @@ public class AntPluginTest extends AbstractJUnitTest {
                 "}";
         String antHome = setUpAntInstallation();
 
-        String expectedVersion = "1.10.5"; // this is the version installed in the java container by the ubuntu bionic;
+        String expectedVersion = "1.10.14"; // this is the version installed in the java container by the ubuntu noble;
 
         WorkflowJob workflowJob = jenkins.jobs.create(WorkflowJob.class);
         workflowJob.script.set(script_pipeline_ant);

--- a/src/test/java/plugins/SshSlavesPluginTest.java
+++ b/src/test/java/plugins/SshSlavesPluginTest.java
@@ -208,15 +208,15 @@ public class SshSlavesPluginTest extends AbstractJUnitTest {
         setUp();
         SshSlaveLauncher launcher = configureDefaultSSHSlaveLauncher().pwdCredentials("test", "test");
 
-        String javaPath = "/usr/lib/jvm/java-11-openjdk-amd64/bin/java";
+        String javaPath = "/usr/lib/jvm/java-17-openjdk-amd64/bin/java";
         if (System.getProperty("os.arch").equals("aarch64")) {
-            javaPath = "/usr/lib/jvm/java-11-openjdk-arm64/bin/java";
+            javaPath = "/usr/lib/jvm/java-17-openjdk-arm64/bin/java";
         }
         launcher.setJavaPath(javaPath);
         slave.save();
     
         verify();
-        verifyLog("java-11-openjdk");
+        verifyLog("java-17-openjdk");
     }
     
     @Test public void jvmOptions() {


### PR DESCRIPTION
Updates Docker test fixtures to the new Ubuntu 24.04 and Java 17 based release, as well as upgrading a handful of container images in this repository (ones that seem to be still used) to Ubuntu 24.04 and Java 17. While I was here I also switched the default environment from 11 to 17 since we are getting close to the cutoff date.