### PR TITLE
Enable 'Build has no changes' assertion in FreestyleJobTest

### DIFF
--- a/src/test/java/core/FreestyleJobTest.java
+++ b/src/test/java/core/FreestyleJobTest.java
@@ -100,8 +100,7 @@ public class FreestyleJobTest extends AbstractJUnitTest {
         b.open();
         assertThat("Permalink link is current URL", driver.getCurrentUrl(), is(expectedUrl));
         assertThat("Build number is correct", b.getNumber(), is(1));
-        // TODO JENKINS-73168
-        //assertThat("Build has no changes", driver, hasContent("No changes"));
+        assertThat("Build has no changes", driver, hasContent("No changes"));
         assertThat("Build is success", b.getResult(), is(Build.Result.SUCCESS.name()));
     }
 


### PR DESCRIPTION
## Enable "Build has no changes" assertion in FreestyleJobTest

Assertion was disabled due to user interface change that has been modified in Jenkins 2.459 to again report when the build has no changes.

[JENKINS-73168](https://issues.jenkins.io/browse/JENKINS-73168) fixes it in Jenkins 2.459.

Fixes #1548

This reverts part of commit 4d71d1b782a23b8eb94b914bf86771f212f3b7ed.

### Testing done

Tested by running the modified test with JENKINS_WAR set to a copy of the 2.459 Jenkins war file.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
