### PR TITLE
chore(pipeline) Limit Docker API rate limit when testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,10 +55,7 @@ stage('Record builds and sessions') {
       }
       axes['jenkinsVersions'].each { jenkinsVersion ->
         infra.withArtifactCachingProxy {
-          // Need to authenticate on DockerHub with a read-only account to avoid rate limit
-          infra.withDockerCredentials {
             sh "rm -rf target && DISPLAY=:0 ./run.sh firefox ${jenkinsVersion} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo -B clean process-test-resources"
-          }
         }
         def coreCommit = sh(script: './core-commit.sh', returnStdout: true).trim()
         /*
@@ -125,31 +122,34 @@ for (int i = 0; i < splits.size(); i++) {
           retryCounts = retryCounts + 1 // increment the retry count before allocating a node in case it fails
           node(nodeLabel) {
             checkout scm
-            def image = buildImage ? docker.build('jenkins/ath', '--build-arg uid="$(id -u)" --build-arg gid="$(id -g)" ./src/main/resources/ath-container/') : docker.image('jenkins/ath')
-            sh 'mkdir -p target/ath-reports && chmod a+rwx target/ath-reports'
-            def cwd = pwd()
-            image.inside("-v /var/run/docker.sock:/var/run/docker.sock -v '${cwd}/target/ath-reports:/reports:rw' --shm-size 2g") {
-              def exclusions = splits.get(index).join('\n')
-              writeFile file: 'excludes.txt', text: exclusions
-              infra.withArtifactCachingProxy {
-                realtimeJUnit(
-                    testResults: 'target/surefire-reports/TEST-*.xml',
-                    testDataPublishers: [[$class: 'AttachmentPublisher']],
-                    // Slow test(s) removal can causes a split to get empty which otherwise fails the build.
-                    // The build failure prevents parallel tests executor to realize the tests are gone so same
-                    // split is run to execute and report zero tests - which fails the build. Permit the test
-                    // results to be empty to break the circle: build after removal executes one empty split
-                    // but not letting the build to fail will cause next build not to try those tests again.
-                    allowEmptyResults: true
-                    ) {
-                      sh """
-                          set-java.sh ${jdk}
-                          eval \$(vnc.sh)
-                          java -version
-                          run.sh ${browser} ${jenkinsVersion} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo -Dmaven.test.failure.ignore=true -DforkCount=1 -B
-                          cp --verbose target/surefire-reports/TEST-*.xml /reports
-                          """
-                    }
+            // Need to authenticate on DockerHub with a read-only account to avoid rate limit
+            infra.withDockerCredentials {
+              def image = buildImage ? docker.build('jenkins/ath', '--build-arg uid="$(id -u)" --build-arg gid="$(id -g)" ./src/main/resources/ath-container/') : docker.image('jenkins/ath')
+              sh 'mkdir -p target/ath-reports && chmod a+rwx target/ath-reports'
+              def cwd = pwd()
+              image.inside("-v /var/run/docker.sock:/var/run/docker.sock -v '${cwd}/target/ath-reports:/reports:rw' --shm-size 2g") {
+                def exclusions = splits.get(index).join('\n')
+                writeFile file: 'excludes.txt', text: exclusions
+                infra.withArtifactCachingProxy {
+                  realtimeJUnit(
+                      testResults: 'target/surefire-reports/TEST-*.xml',
+                      testDataPublishers: [[$class: 'AttachmentPublisher']],
+                      // Slow test(s) removal can causes a split to get empty which otherwise fails the build.
+                      // The build failure prevents parallel tests executor to realize the tests are gone so same
+                      // split is run to execute and report zero tests - which fails the build. Permit the test
+                      // results to be empty to break the circle: build after removal executes one empty split
+                      // but not letting the build to fail will cause next build not to try those tests again.
+                      allowEmptyResults: true
+                      ) {
+                        sh """
+                            set-java.sh ${jdk}
+                            eval \$(vnc.sh)
+                            java -version
+                            run.sh ${browser} ${jenkinsVersion} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo -Dmaven.test.failure.ignore=true -DforkCount=1 -B
+                            cp --verbose target/surefire-reports/TEST-*.xml /reports
+                            """
+                      }
+                }
               }
             }
             withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {


### PR DESCRIPTION
fixup of #1634 (b1e9d055)

This PR uses the DockerHub authentication in the proper location as pointed out by @basil in https://github.com/jenkinsci/acceptance-test-harness/pull/1634#pullrequestreview-2200077460 (sorry for the noise)

The DockerHub login now happens at the beginning of each test:

<img width="1905" alt="Capture d’écran 2024-07-26 à 16 49 53" src="https://github.com/user-attachments/assets/4700e9be-5da8-46cb-bf59-65ca8aa281b0">

Note: the long term solution would be to use a local Docker cache-through proxy as per https://github.com/jenkins-infra/helpdesk/issues/4192#issuecomment-2250887939.