### PR TITLE
Revert UID/GID changes from #1645

### DIFF
--- a/ath-container.sh
+++ b/ath-container.sh
@@ -13,11 +13,11 @@ java_version="${java_version:-17}"
 # high chance of uid / group already existing in the container
 # known to happen on macOS
 if ((uid < 1000)); then
-	uid=1000
+	uid=1001
 fi
 
 if ((gid < 1000)); then
-	gid=1000
+	gid=1001
 fi
 
 docker build \

--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -77,8 +77,8 @@ COPY set-java.sh /usr/bin
 COPY vnc.sh /usr/bin
 
 # Allow injecting uid and git to match directory ownership
-ARG uid=1000
-ARG gid=1000
+ARG uid=1001
+ARG gid=1001
 
 EXPOSE 5942
 


### PR DESCRIPTION
Apparently if we don't have UID/GID set to 1001 then we can't use pre-built images in CI.