### PR TITLE
Add support for Firefox 129 or newer

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -180,7 +180,8 @@ public class FallbackConfig extends AbstractModule {
         // Config screen with many plugins can cause FF to complain JS takes too long to complete - set longer timeout
         firefoxOptions.addPreference(DOM_MAX_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
         firefoxOptions.addPreference(DOM_MAX_CHROME_SCRIPT_RUN_TIME, (int)getElasticTime().seconds(600));
-        firefoxOptions.addPreference(DOM_DISABLE_BEFOREUNLOAD, false);
+        firefoxOptions.addPreference(DOM_DISABLE_BEFOREUNLOAD, false); // TODO remove when we require Firefox 129 or newer
+        firefoxOptions.enableBiDi();
         if (HarRecorder.isCaptureHarEnabled()) {
             firefoxOptions.setProxy(createSeleniumProxy(testName.get()));
         }

--- a/src/test/java/core/FormValidationTest.java
+++ b/src/test/java/core/FormValidationTest.java
@@ -32,6 +32,7 @@ import org.jenkinsci.test.acceptance.po.FormValidation;
 import org.jenkinsci.test.acceptance.po.JenkinsConfig;
 import org.jenkinsci.test.acceptance.po.ListView;
 import org.junit.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 
 public class FormValidationTest extends AbstractJUnitTest {
@@ -72,7 +73,7 @@ public class FormValidationTest extends AbstractJUnitTest {
     }
 
     private void navigateAway() {
-        jenkins.runThenConfirmAlert(() -> jenkins.open());
+        jenkins.runThenConfirmAlert(() -> driver.findElement(By.xpath("//ol[@id=\"breadcrumbs\"]/li[1]/a")).click());
         sleep(1000); // Needed for some reason
     }
 }


### PR DESCRIPTION
Without dropping support for Firefox 123 and earlier, add support for Firefox 129 or newer. Note that Firefox 124 through 128 are known to not work, as explained in https://github.com/mozilla/geckodriver/issues/2182#issuecomment-2180048632.

### Testing done

- CI build of this PR
- CI build with Firefox 129 in #1648

Fixes #1639