### PR TITLE
Use Apache Maven 3.9.9 instead of 3.9.8

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -64,8 +64,8 @@ RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
   fi
 
 # Maven in repo is not new enough for ATH
-ARG MAVEN_VERSION=3.9.8
-RUN curl -fsSLO "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
+ARG MAVEN_VERSION=3.9.9
+RUN curl -fsSLO "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
     tar -xvzf "apache-maven-${MAVEN_VERSION}-bin.tar.gz" -C /opt/ && \
     mv "/opt/apache-maven-${MAVEN_VERSION}" /opt/maven
 ENV PATH "$PATH:/opt/maven/bin"


### PR DESCRIPTION
## Use Apache Maven 3.9.9 instead of 3.9.8

Apache Maven 3.9.9 released a day or two ago and is available from https://maven.apache.org/download.cgi .  Let's update to use that most recent release of Apache Maven.

Also updates the download URL to use the current URL from

    https://maven.apache.org/download.cgi

That URL uses the content delivery network of the Apache project

The [ASF blog](https://news.apache.org/foundation/entry/apache-software-foundation-moves)- describes their transition to a content delivery network.

### Testing done

Apache Maven 3.9.9 is successfully building and testing the plugins that I maintain and I'm using it on all my development machines, controllers, and agents.
No issues detected since installing it a day ago.

I also tested the `curl` command from my RHEL 8 computer and confirmed that it downloaded the correct file

Will rely on ci.jenkins.io to confirm that the tests run as expected with Maven 3.9.9.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
