### PR TITLE
Adapt to Apache Maven Javadoc Plugin 3.10.0

### DIFF
--- a/src/test/java/plugins/JavadocPluginTest.java
+++ b/src/test/java/plugins/JavadocPluginTest.java
@@ -71,7 +71,7 @@ public class JavadocPluginTest extends AbstractJUnitTest {
         m.targets.set("javadoc:javadoc -f my-app/pom.xml");
 
         JavadocPublisher jd = job.addPublisher(JavadocPublisher.class);
-        jd.javadocDir.set("my-app/target/site/apidocs/");
+        jd.javadocDir.set("my-app/target/reports/apidocs/");
         job.save();
     }
 

--- a/src/test/java/plugins/PipelineTest.java
+++ b/src/test/java/plugins/PipelineTest.java
@@ -75,7 +75,7 @@ public class PipelineTest extends AbstractPipelineTest {
                     "      junit 'target/surefire-reports/TEST-io.jenkins.tools.MainTest.xml'\n" +
                     "      \n" +
                     "      sh \"mvn javadoc:javadoc -f pom.xml\"\n" +
-                    "      step([$class: 'JavadocArchiver', javadocDir: 'target/site/apidocs', keepAll: false])\n" +
+                    "      step([$class: 'JavadocArchiver', javadocDir: 'target/reports/apidocs', keepAll: false])\n" +
                     "  }" +
                     "}";
         } else {
@@ -90,7 +90,7 @@ public class PipelineTest extends AbstractPipelineTest {
                     "      junit 'target/surefire-reports/TEST-io.jenkins.tools.MainTest.xml'\n" +
                     "      \n" +
                     "      bat \"mvn javadoc:javadoc -f pom.xml\"\n" +
-                    "      step([$class: 'JavadocArchiver', javadocDir: 'target/site/apidocs', keepAll: false])\n" +
+                    "      step([$class: 'JavadocArchiver', javadocDir: 'target/reports/apidocs', keepAll: false])\n" +
                     "  }" +
                     "}";
         }


### PR DESCRIPTION
Javadoc tests appear to be broken on the main branch, apparently because version 3.10.0 of the Apache Maven Javadoc Plugin was just released and stores HTML files in a new directory.