### PR TITLE
Adapt the OicAuthPluginTest to the changes in the describables

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/OicAuthConfigurationMode.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/OicAuthConfigurationMode.java
@@ -1,0 +1,25 @@
+package org.jenkinsci.test.acceptance.po;
+
+/**
+ * Class representing the entry controls for the configuration mode when using the oic-auth plugin
+ */
+public abstract class OicAuthConfigurationMode extends PageAreaImpl {
+
+    protected OicAuthConfigurationMode(OicAuthSecurityRealm realm) {
+        super(realm, "serverConfiguration");
+    }
+
+    /**
+     * Class representing the entry controls for well-known endpoint when using the oic-auth plugin
+     */
+    @Describable("Discovery via well-known endpoint")
+    public static class WellKnownEndpoint extends OicAuthConfigurationMode {
+
+        public final Control wellKnownEndpoint = control("wellKnownOpenIDConfigurationUrl");
+
+        public WellKnownEndpoint(OicAuthSecurityRealm realm) {
+            super(realm);
+        }
+    }
+
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/po/OicAuthConfigurationMode.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/OicAuthConfigurationMode.java
@@ -21,5 +21,4 @@ public abstract class OicAuthConfigurationMode extends PageAreaImpl {
             super(realm);
         }
     }
-
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/OicAuthSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/OicAuthSecurityRealm.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.test.acceptance.po;
 
+import org.openqa.selenium.WebElement;
+
 /**
  * Security Realm provided by oic-auth plugin
  */
@@ -15,9 +17,10 @@ public class OicAuthSecurityRealm extends SecurityRealm {
         control("clientSecret").set(clientSecret);
     }
 
-    public void setWellKnownEndpoint(String wellKnownEndpoint) {
-        control("").select("Discovery via well-known endpoint"); // Select doesn't have the relative path, directly path=/securityRealm/
-        control("serverConfiguration/wellKnownOpenIDConfigurationUrl").set(wellKnownEndpoint);
+    public <T extends OicAuthConfigurationMode> T useConfigurationMode(Class<T> type) {
+        WebElement option = findCaption(type, caption -> getElement(by.option(caption)));
+        option.click();
+        return newInstance(type, this);
     }
 
     public void setLogoutFromOpenidProvider(boolean logout) {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/OicAuthSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/OicAuthSecurityRealm.java
@@ -15,9 +15,9 @@ public class OicAuthSecurityRealm extends SecurityRealm {
         control("clientSecret").set(clientSecret);
     }
 
-    public void setAutomaticConfiguration(String wellKnownEndpoint) {
-        control(by.radioButton("Automatic configuration")).click();
-        control("wellKnownOpenIDConfigurationUrl").set(wellKnownEndpoint);
+    public void setWellKnownEndpoint(String wellKnownEndpoint) {
+        control("").select("Discovery via well-known endpoint"); // Select doesn't have the relative path, directly path=/securityRealm/
+        control("serverConfiguration/wellKnownOpenIDConfigurationUrl").set(wellKnownEndpoint);
     }
 
     public void setLogoutFromOpenidProvider(boolean logout) {

--- a/src/test/java/plugins/OicAuthPluginTest.java
+++ b/src/test/java/plugins/OicAuthPluginTest.java
@@ -18,6 +18,7 @@ import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
 import org.jenkinsci.test.acceptance.po.LoggedInAuthorizationStrategy;
+import org.jenkinsci.test.acceptance.po.OicAuthConfigurationMode;
 import org.jenkinsci.test.acceptance.po.OicAuthSecurityRealm;
 import org.jenkinsci.test.acceptance.po.WhoAmI;
 import org.jenkinsci.test.acceptance.utils.keycloack.KeycloakUtils;
@@ -206,8 +207,9 @@ public class OicAuthPluginTest extends AbstractJUnitTest {
         sc.open();
         OicAuthSecurityRealm securityRealm = sc.useRealm(OicAuthSecurityRealm.class);
         securityRealm.configureClient(CLIENT, CLIENT);
-        securityRealm.setWellKnownEndpoint(
-                String.format("%s/realms/%s/.well-known/openid-configuration", keycloakUrl, REALM));
+        // Configuration mode
+        OicAuthConfigurationMode.WellKnownEndpoint configurationMode = securityRealm.useConfigurationMode(OicAuthConfigurationMode.WellKnownEndpoint.class);
+        configurationMode.wellKnownEndpoint.set(String.format("%s/realms/%s/.well-known/openid-configuration", keycloakUrl, REALM));
         securityRealm.setLogoutFromOpenidProvider(true);
         securityRealm.setPostLogoutUrl(jenkins.url("OicLogout").toExternalForm());
         securityRealm.setUserFields(null, null, null, "groups");

--- a/src/test/java/plugins/OicAuthPluginTest.java
+++ b/src/test/java/plugins/OicAuthPluginTest.java
@@ -208,8 +208,10 @@ public class OicAuthPluginTest extends AbstractJUnitTest {
         OicAuthSecurityRealm securityRealm = sc.useRealm(OicAuthSecurityRealm.class);
         securityRealm.configureClient(CLIENT, CLIENT);
         // Configuration mode
-        OicAuthConfigurationMode.WellKnownEndpoint configurationMode = securityRealm.useConfigurationMode(OicAuthConfigurationMode.WellKnownEndpoint.class);
-        configurationMode.wellKnownEndpoint.set(String.format("%s/realms/%s/.well-known/openid-configuration", keycloakUrl, REALM));
+        OicAuthConfigurationMode.WellKnownEndpoint configurationMode =
+                securityRealm.useConfigurationMode(OicAuthConfigurationMode.WellKnownEndpoint.class);
+        configurationMode.wellKnownEndpoint.set(
+                String.format("%s/realms/%s/.well-known/openid-configuration", keycloakUrl, REALM));
         securityRealm.setLogoutFromOpenidProvider(true);
         securityRealm.setPostLogoutUrl(jenkins.url("OicLogout").toExternalForm());
         securityRealm.setUserFields(null, null, null, "groups");

--- a/src/test/java/plugins/OicAuthPluginTest.java
+++ b/src/test/java/plugins/OicAuthPluginTest.java
@@ -206,7 +206,7 @@ public class OicAuthPluginTest extends AbstractJUnitTest {
         sc.open();
         OicAuthSecurityRealm securityRealm = sc.useRealm(OicAuthSecurityRealm.class);
         securityRealm.configureClient(CLIENT, CLIENT);
-        securityRealm.setAutomaticConfiguration(
+        securityRealm.setWellKnownEndpoint(
                 String.format("%s/realms/%s/.well-known/openid-configuration", keycloakUrl, REALM));
         securityRealm.setLogoutFromOpenidProvider(true);
         securityRealm.setPostLogoutUrl(jenkins.url("OicLogout").toExternalForm());


### PR DESCRIPTION
See https://github.com/jenkinsci/acceptance-test-harness/issues/1723

https://github.com/jenkinsci/oic-auth-plugin/pull/399 changes the describables in the plugin, so the `OicAuthPluginTest` must be adapted. As this test has been there for less than 2 weeks, I don't see any need to keep any backward compatibility checking the plugin version.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
