### PR TITLE
Upgrade Maven from 3.8.1 to 3.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
     <selenium.version>4.25.0</selenium.version>
     <!-- aligned with selenium -->
     <guava.version>33.3.0-jre</guava.version>
-    <maven.version>3.8.1</maven.version>
-    <maven-resolver.version>1.6.2</maven-resolver.version>
+    <maven.version>3.9.6</maven.version>
+    <maven-resolver.version>1.9.18</maven-resolver.version>
     <groovy.version>3.0.22</groovy.version>
     <jffi.version>1.3.13</jffi.version>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/aether/AetherModule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/aether/AetherModule.java
@@ -9,13 +9,16 @@ import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import org.apache.maven.model.building.DefaultModelBuilderFactory;
 import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.repository.internal.DefaultArtifactDescriptorReader;
+import org.apache.maven.repository.internal.DefaultModelCacheFactory;
 import org.apache.maven.repository.internal.DefaultVersionRangeResolver;
 import org.apache.maven.repository.internal.DefaultVersionResolver;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.apache.maven.repository.internal.ModelCacheFactory;
 import org.apache.maven.repository.internal.SnapshotMetadataGeneratorFactory;
 import org.apache.maven.repository.internal.VersionsMetadataGeneratorFactory;
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -31,6 +34,7 @@ import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transfer.TransferEvent;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.transport.http.ChecksumExtractor;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.jenkinsci.test.acceptance.utils.MavenLocalRepository;
 
@@ -98,6 +102,15 @@ public class AetherModule extends AbstractModule implements ExtensionModule {
     }
 
     /**
+     * Checksum extractors (none).
+     */
+    @Provides
+    @Singleton
+    Map<String, ChecksumExtractor> provideChecksumExtractors() {
+        return Collections.emptyMap();
+    }
+
+    /**
      * Repository system connectors (needed for remote transport).
      */
     @Provides
@@ -142,5 +155,10 @@ public class AetherModule extends AbstractModule implements ExtensionModule {
     @Provides
     ModelBuilder provideModelBuilder() {
         return new DefaultModelBuilderFactory().newInstance();
+    }
+
+    @Provides
+    ModelCacheFactory provideModelCacheFactory() {
+        return new DefaultModelCacheFactory();
     }
 }


### PR DESCRIPTION
See https://github.com/jenkinsci/maven-hpi-plugin/pull/668. Adapting to https://github.com/apache/maven-resolver/pull/140 and https://github.com/apache/maven-resolver/pull/319. (Previously: #1153).