### PR TITLE
Migrate from deprecated `org.eclipse.aether.impl.guice.AetherModule` to Sisu

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,9 +13,13 @@
   "ignoreDeps": [
     "org.apache.maven:maven-resolver-provider",
     "org.apache.maven:maven-settings-builder",
+    "org.apache.maven.resolver:maven-resolver-api",
     "org.apache.maven.resolver:maven-resolver-connector-basic",
+    "org.apache.maven.resolver:maven-resolver-impl",
     "org.apache.maven.resolver:maven-resolver-transport-file",
-    "org.apache.maven.resolver:maven-resolver-transport-http"
+    "org.apache.maven.resolver:maven-resolver-transport-http",
+    "org.apache.maven.resolver:maven-resolver-util",
+    "org.eclipse.sisu:org.eclipse.sisu.inject"
   ],
   "packageRules": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,12 @@
     <selenium.version>4.25.0</selenium.version>
     <!-- aligned with selenium -->
     <guava.version>33.3.0-jre</guava.version>
+
+    <!-- Keep them aligned to Maven version -->
     <maven.version>3.9.6</maven.version>
+    <maven-sisu.version>0.9.0.M3</maven-sisu.version>
     <maven-resolver.version>1.9.18</maven-resolver.version>
+
     <groovy.version>3.0.22</groovy.version>
     <jffi.version>1.3.13</jffi.version>
     <spotless.check.skip>false</spotless.check.skip>
@@ -61,6 +65,13 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-bom</artifactId>
         <version>2.0.16</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-bom</artifactId>
+        <version>9.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -199,6 +210,7 @@ and
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <version>6.0.0</version>
+      <classifier>classes</classifier>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>
@@ -245,11 +257,32 @@ and
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-resolver-provider</artifactId>
       <version>${maven.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings-builder</artifactId>
       <version>${maven.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${maven-resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>${maven-resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+      <version>${maven-resolver.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
@@ -265,6 +298,12 @@ and
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-transport-http</artifactId>
       <version>${maven-resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+      <version>${maven-sisu.version}</version>
+      <classifier>no_asm</classifier>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <selenium.version>4.25.0</selenium.version>
     <!-- aligned with selenium -->
     <guava.version>33.3.1-jre</guava.version>
+
     <!-- Keep them aligned to Maven version -->
     <maven.version>3.9.6</maven.version>
     <maven-sisu.version>0.9.0.M3</maven-sisu.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,16 +62,16 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-bom</artifactId>
-        <version>2.0.16</version>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-bom</artifactId>
+        <version>9.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm-bom</artifactId>
-        <version>9.7</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-bom</artifactId>
+        <version>2.0.16</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -276,17 +276,12 @@ and
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-util</artifactId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
       <version>${maven-resolver.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-impl</artifactId>
-      <version>${maven-resolver.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-connector-basic</artifactId>
       <version>${maven-resolver.version}</version>
     </dependency>
     <dependency>
@@ -300,10 +295,9 @@ and
       <version>${maven-resolver.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.sisu</groupId>
-      <artifactId>org.eclipse.sisu.inject</artifactId>
-      <version>${maven-sisu.version}</version>
-      <classifier>no_asm</classifier>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>${maven-resolver.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -319,6 +313,12 @@ and
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-console</artifactId>
       <version>${groovy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+      <version>${maven-sisu.version}</version>
+      <classifier>no_asm</classifier>
     </dependency>
     <dependency>
       <groupId>org.gitlab4j</groupId>

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/aether/AetherModule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/aether/AetherModule.java
@@ -3,81 +3,47 @@ package org.jenkinsci.test.acceptance.utils.aether;
 import com.cloudbees.sdk.extensibility.Extension;
 import com.cloudbees.sdk.extensibility.ExtensionModule;
 import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Key;
 import com.google.inject.Provides;
-import com.google.inject.name.Names;
-import jakarta.inject.Named;
-import jakarta.inject.Singleton;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import org.apache.maven.model.building.DefaultModelBuilderFactory;
-import org.apache.maven.model.building.ModelBuilder;
-import org.apache.maven.repository.internal.DefaultArtifactDescriptorReader;
-import org.apache.maven.repository.internal.DefaultModelCacheFactory;
-import org.apache.maven.repository.internal.DefaultVersionRangeResolver;
-import org.apache.maven.repository.internal.DefaultVersionResolver;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
-import org.apache.maven.repository.internal.ModelCacheFactory;
-import org.apache.maven.repository.internal.SnapshotMetadataGeneratorFactory;
-import org.apache.maven.repository.internal.VersionsMetadataGeneratorFactory;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
-import org.eclipse.aether.impl.ArtifactDescriptorReader;
-import org.eclipse.aether.impl.MetadataGeneratorFactory;
-import org.eclipse.aether.impl.VersionRangeResolver;
-import org.eclipse.aether.impl.VersionResolver;
 import org.eclipse.aether.repository.LocalRepository;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
-import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transfer.TransferEvent;
-import org.eclipse.aether.transport.file.FileTransporterFactory;
-import org.eclipse.aether.transport.http.ChecksumExtractor;
-import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.sisu.inject.BeanLocator;
+import org.eclipse.sisu.inject.MutableBeanLocator;
+import org.eclipse.sisu.launch.SisuExtensions;
+import org.eclipse.sisu.space.BeanScanning;
+import org.eclipse.sisu.space.ClassSpace;
+import org.eclipse.sisu.space.SpaceModule;
+import org.eclipse.sisu.space.URLClassSpace;
+import org.eclipse.sisu.wire.WireModule;
 import org.jenkinsci.test.acceptance.utils.MavenLocalRepository;
 
 /**
  * Hook up Aether resolver.
  * <p>
  * To resolve components, inject {@link RepositorySystem} and {@link RepositorySystemSession}.
- * <p>
- * Here, we assemble a complete module by using {@link org.eclipse.aether.impl.guice.AetherModule} (see its Javadoc)
- * and adding bits from Maven itself (binding those components that complete the repository system).
  *
  * @author Kohsuke Kawaguchi
  */
 @Extension
 public class AetherModule extends AbstractModule implements ExtensionModule {
+
+    private RepositorySystem repositorySystem;
+
     @Override
     protected void configure() {
-        // NOTE: see org.eclipse.aether.impl.guice.AetherModule Javadoc:
-        // org.eclipse.aether.impl.guice.AetherModule alone is "ready-made" but incomplete.
-        // To have a complete resolver, we actually need to bind the missing components making the module complete.
-        install(new org.eclipse.aether.impl.guice.AetherModule());
+        ClassSpace space = new URLClassSpace(RepositorySystem.class.getClassLoader());
+        BeanLocator beanLocator = Guice.createInjector(new WireModule(new SpaceModule(space, BeanScanning.INDEX, false)).with(SisuExtensions.local(space))).getInstance(MutableBeanLocator.class);
+        repositorySystem = beanLocator.locate(Key.get(RepositorySystem.class)).iterator().next().getValue();
+    }
 
-        // make module "complete" by binding things not bound by org.eclipse.aether.impl.guice.AetherModule
-        bind(ArtifactDescriptorReader.class)
-                .to(DefaultArtifactDescriptorReader.class)
-                .in(Singleton.class);
-        bind(VersionResolver.class).to(DefaultVersionResolver.class).in(Singleton.class);
-        bind(VersionRangeResolver.class).to(DefaultVersionRangeResolver.class).in(Singleton.class);
-        bind(MetadataGeneratorFactory.class)
-                .annotatedWith(Names.named("snapshot"))
-                .to(SnapshotMetadataGeneratorFactory.class)
-                .in(Singleton.class);
-
-        bind(MetadataGeneratorFactory.class)
-                .annotatedWith(Names.named("versions"))
-                .to(VersionsMetadataGeneratorFactory.class)
-                .in(Singleton.class);
-
-        bind(RepositoryConnectorFactory.class)
-                .annotatedWith(Names.named("basic"))
-                .to(BasicRepositoryConnectorFactory.class);
-        bind(TransporterFactory.class).annotatedWith(Names.named("file")).to(FileTransporterFactory.class);
-        bind(TransporterFactory.class).annotatedWith(Names.named("http")).to(HttpTransporterFactory.class);
+    @Provides
+    public RepositorySystem newRepositorySystem() {
+        return repositorySystem;
     }
 
     @Provides
@@ -99,66 +65,5 @@ public class AetherModule extends AbstractModule implements ExtensionModule {
         // session.setDependencyGraphTransformer( null );
 
         return session;
-    }
-
-    /**
-     * Checksum extractors (none).
-     */
-    @Provides
-    @Singleton
-    Map<String, ChecksumExtractor> provideChecksumExtractors() {
-        return Collections.emptyMap();
-    }
-
-    /**
-     * Repository system connectors (needed for remote transport).
-     */
-    @Provides
-    @Singleton
-    Set<RepositoryConnectorFactory> provideRepositoryConnectorFactories(
-            @Named("basic") RepositoryConnectorFactory basic) {
-        Set<RepositoryConnectorFactory> factories = new HashSet<>();
-        factories.add(basic);
-        return Collections.unmodifiableSet(factories);
-    }
-
-    /**
-     * Repository system transporters (needed for remote transport).
-     */
-    @Provides
-    @Singleton
-    Set<TransporterFactory> provideTransporterFactories(
-            @Named("file") TransporterFactory file, @Named("http") TransporterFactory http) {
-        Set<TransporterFactory> factories = new HashSet<>();
-        factories.add(file);
-        factories.add(http);
-        return Collections.unmodifiableSet(factories);
-    }
-
-    /**
-     * Repository metadata generators (needed for remote transport).
-     */
-    @Provides
-    @Singleton
-    Set<MetadataGeneratorFactory> provideMetadataGeneratorFactories(
-            @Named("snapshot") MetadataGeneratorFactory snapshot,
-            @Named("versions") MetadataGeneratorFactory versions) {
-        Set<MetadataGeneratorFactory> factories = new HashSet<>(2);
-        factories.add(snapshot);
-        factories.add(versions);
-        return Collections.unmodifiableSet(factories);
-    }
-
-    /**
-     * Simple instance provider for model builder factory.
-     */
-    @Provides
-    ModelBuilder provideModelBuilder() {
-        return new DefaultModelBuilderFactory().newInstance();
-    }
-
-    @Provides
-    ModelCacheFactory provideModelCacheFactory() {
-        return new DefaultModelCacheFactory();
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/aether/AetherModule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/aether/AetherModule.java
@@ -37,8 +37,14 @@ public class AetherModule extends AbstractModule implements ExtensionModule {
     @Override
     protected void configure() {
         ClassSpace space = new URLClassSpace(RepositorySystem.class.getClassLoader());
-        BeanLocator beanLocator = Guice.createInjector(new WireModule(new SpaceModule(space, BeanScanning.INDEX, false)).with(SisuExtensions.local(space))).getInstance(MutableBeanLocator.class);
-        repositorySystem = beanLocator.locate(Key.get(RepositorySystem.class)).iterator().next().getValue();
+        BeanLocator beanLocator = Guice.createInjector(new WireModule(new SpaceModule(space, BeanScanning.INDEX, false))
+                        .with(SisuExtensions.local(space)))
+                .getInstance(MutableBeanLocator.class);
+        repositorySystem = beanLocator
+                .locate(Key.get(RepositorySystem.class))
+                .iterator()
+                .next()
+                .getValue();
     }
 
     @Provides


### PR DESCRIPTION
Migrate to Sisu and drop use of deprecated AetherModule (is removed in Resolver 2.x).

This PR uses "fully fledged" Sisu to create `RepositorySystem` instance, and will discover (using sisu index) dynamically any JSR330 component that is present on classpath at the moment `AetherModule` is being constructed.

Also, Guice and Sisu are changed (by exclusion from transitive dep and explicit addition as direct dependency) to "no asm" versions (these have no shaded in ASM), and since ASM was already on path (was 9.2) updated to latest 9.7. Now Guice and Sisu and that something (that pulled ASM in orginally) all use same ASM version 9.7.

<!-- Please describe your pull request here. -->

### Testing done

CI build

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

Fixes #1730