### PR TITLE
Run ATH with CSP

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,6 +109,8 @@ for (int i = 0; i < splits.size(); i++) {
     if (jdk != 21 && jenkinsVersion == 'latest') {
       return
     }
+    // TODO enable on LTS line when it is based on 2.480 or later
+    def cspRule = jenkinsVersion == 'latest'
     def name = "${jenkinsVersion}-${platform}-jdk${jdk}-${browser}-split${index}"
     branches[name] = {
       stage(name) {
@@ -144,7 +146,7 @@ for (int i = 0; i < splits.size(); i++) {
                           set-java.sh ${jdk}
                           eval \$(vnc.sh)
                           java -version
-                          run.sh ${browser} ${jenkinsVersion} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo -Dmaven.test.failure.ignore=true -DforkCount=1 -B
+                          run.sh ${browser} ${jenkinsVersion} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo -Dmaven.test.failure.ignore=true -Dcsp.rule=${cspRule} -DforkCount=1 -B
                           cp --verbose target/surefire-reports/TEST-*.xml /reports
                           """
                     }

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/CspRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/CspRule.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.test.acceptance.junit;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import org.jenkinsci.test.acceptance.po.GlobalSecurityConfig;
+import org.jenkinsci.test.acceptance.po.Jenkins;
+import org.jenkinsci.test.acceptance.update_center.PluginSpec;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+@GlobalRule
+public final class CspRule implements TestRule {
+
+    @Inject
+    private Injector injector;
+
+    @Override
+    public Statement apply(final Statement base, final Description d) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                if (isEnabled()
+                        && d.getAnnotation(WithInstallWizard.class) == null
+                        && d.getTestClass().getAnnotation(WithInstallWizard.class) == null) {
+                    Jenkins jenkins = injector.getInstance(Jenkins.class);
+
+                    PluginSpec plugin = new PluginSpec("csp");
+                    jenkins.getPluginManager().installPlugins(plugin);
+
+                    GlobalSecurityConfig security = new GlobalSecurityConfig(jenkins);
+                    security.open();
+                    security.disableCspReportOnly();
+                    security.save();
+                }
+                base.evaluate();
+            }
+
+            private static boolean isEnabled() {
+                if (System.getProperty("csp.rule") == null) {
+                    return false;
+                }
+                if (System.getProperty("csp.rule").isEmpty()) {
+                    return true;
+                }
+                return Boolean.getBoolean("csp.rule");
+            }
+        };
+    }
+}

--- a/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/GlobalSecurityConfig.java
@@ -27,6 +27,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import org.jenkinsci.test.acceptance.plugins.authorize_project.BuildAccessControl;
 import org.jenkinsci.test.acceptance.plugins.git_client.ssh_host_key_verification.SshHostKeyVerificationStrategy;
+import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
@@ -81,6 +82,10 @@ public class GlobalSecurityConfig extends ContainerPageObject {
         } catch (NoSuchElementException x) {
             // JENKINS-40228, OK
         }
+    }
+
+    public void disableCspReportOnly() {
+        control(By.name("_.reportOnly")).uncheck();
     }
 
     public <T extends BuildAccessControl> T addBuildAccessControl(final Class<T> type) {


### PR DESCRIPTION
Opt-in to enable CSP in restrictive mode
Enabled on weekly line in `Jenkinsfile`
Can be enabled on LTS line when it is based on 2.480 or later
Can be enabled in CloudBees when CloudBees is ready for it
Can be enabled in plugin test suites at the convenience of plugin maintainers