### PR TITLE
Test 2.479.1 with ASM 9.7.1 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -832,7 +832,7 @@ and
     <profile>
       <id>lts</id>
       <properties>
-        <jenkins.version>2.479.1-rc35401.a_b_2349a_00cd1</jenkins.version>
+        <jenkins.version>2.479.1-rc35406.a_347514e820d</jenkins.version>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,9 @@ and
           </systemPropertyVariables>
           <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
           <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+          <environmentVariables>
+            <LOCAL_JARS>target/ldap.hpi</LOCAL_JARS>
+          </environmentVariables>
         </configuration>
       </plugin>
       <plugin>
@@ -804,6 +807,12 @@ and
                       <artifactId>jenkins-war</artifactId>
                       <version>${jenkins.version}</version>
                       <type>war</type>
+                    </artifactItem>
+                    <artifactItem>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>ldap</artifactId>
+                      <version>759.vef7f616475df</version>
+                      <type>hpi</type>
                     </artifactItem>
                   </artifactItems>
                   <outputDirectory>${project.build.directory}</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -818,7 +818,7 @@ and
     <profile>
       <id>lts</id>
       <properties>
-        <jenkins.version>2.462.1</jenkins.version>
+        <jenkins.version>2.479.1-rc35401.a_b_2349a_00cd1</jenkins.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
## Test 2.479.1 with ASM 9.7.1 upgrade

- **Test 2.479.1 pre-release**
- **Temporarily pin LDAP plugin to latest**
- **Test 2.479.1 with ASM 9.7.1 upgrade**

### Testing done

Test the 2.479.1 build with ASM 9.7.1 upgrade and the prevent premature delete backport.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
