### PR TITLE
[JENKINS-74005] Obtaining login button via href instead of text

### DIFF
--- a/src/test/java/plugins/OicAuthPluginTest.java
+++ b/src/test/java/plugins/OicAuthPluginTest.java
@@ -36,6 +36,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
 
 @WithPlugins("oic-auth")
 public class OicAuthPluginTest extends AbstractJUnitTest {
@@ -234,7 +235,7 @@ public class OicAuthPluginTest extends AbstractJUnitTest {
                 new KeycloakUtils.User(userJohnKeycloakId, "john", "john@jenkins-ath.test", "John", "Smith");
         jenkins.open();
 
-        jenkins.clickLink("log in");
+        getLogin().click();
         keycloakUtils.login(bob.getUserName());
         assertLoggedUser(bob, "jenkinsAdmin");
 
@@ -246,7 +247,7 @@ public class OicAuthPluginTest extends AbstractJUnitTest {
         // so the login page will appear again
         jenkins.open();
 
-        clickLink("log in");
+        getLogin().click();
         keycloakUtils.login(john.getUserName());
         assertLoggedUser(john, "jenkinsRead");
     }
@@ -268,7 +269,7 @@ public class OicAuthPluginTest extends AbstractJUnitTest {
 
         keycloakUtils.login(bob.getUserName());
         jenkins.open();
-        jenkins.clickLink("log in"); // won't request a login, but log in directly with user from
+        getLogin().click(); // won't request a login, but log in directly with user from
 
         assertLoggedUser(bob, "jenkinsAdmin");
 
@@ -279,9 +280,13 @@ public class OicAuthPluginTest extends AbstractJUnitTest {
 
         // Once logged out, we can change the user
         jenkins.open();
-        jenkins.clickLink("log in");
+        getLogin().click();
         keycloakUtils.login(john.getUserName());
         assertLoggedUser(john, "jenkinsRead");
+    }
+
+    private WebElement getLogin() {
+        return getElement(by.href("/securityRealm/commenceLogin?from=%2F"));
     }
 
     private void assertLoggedOut() {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74005
Switched how Log in link was obtained, so now it looks for the href attribute, which will always be the same regardless the button text changes.

### Testing done
Runned ATHs with no problem

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
