### PR TITLE
Use Jenkins 2.479.1 in LTS profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -823,7 +823,7 @@ and
     <profile>
       <id>lts</id>
       <properties>
-        <jenkins.version>2.462.3</jenkins.version>
+        <jenkins.version>2.479.1</jenkins.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
## Use Jenkins 2.479.1 in LTS profile

Released 30 Oct 2024.

Changelog:

* https://www.jenkins.io/changelog-stable/2.479.1/

Upgrade guide:

* https://www.jenkins.io/doc/upgrade-guide/2.479/

Release checklist:

* https://github.com/jenkins-infra/release/issues/606

### Testing done

Relying on ci.jenkins.io to perform the testing.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
