### PR TITLE
Remove workaround for JENKINS-73900 in `CspRule`

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/CspRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/CspRule.java
@@ -37,7 +37,6 @@ public final class CspRule implements TestRule {
                     base.evaluate();
                 } finally {
                     // TODO enable for ArtifactoryPluginTest when JENKINS-74047 is resolved
-                    // TODO enable for SubversionPluginTest when JENKINS-73900 is resolved
                     if (isEnabled()
                             && !isSkipped()
                             && !d.getTestClass().getName().equals("plugins.ArtifactoryPluginTest")) {

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/CspRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/CspRule.java
@@ -40,8 +40,7 @@ public final class CspRule implements TestRule {
                     // TODO enable for SubversionPluginTest when JENKINS-73900 is resolved
                     if (isEnabled()
                             && !isSkipped()
-                            && !d.getTestClass().getName().equals("plugins.ArtifactoryPluginTest")
-                            && !d.getTestClass().getName().equals("plugins.SubversionPluginTest")) {
+                            && !d.getTestClass().getName().equals("plugins.ArtifactoryPluginTest")) {
                         ContentSecurityPolicyReport csp = new ContentSecurityPolicyReport(jenkins);
                         csp.open();
                         List<String> lines = csp.getReport();


### PR DESCRIPTION
Title:
Removed workaround for JENKINS-73900 in CspRule.java

Description:
This pull request addresses an outdated workaround for JENKINS-73900 within the CspRule.java file in the acceptance test harness.

Changes:
Removed the conditional code that was bypassing CSP report checks specifically for SubversionPluginTest.
With this workaround removed, SubversionPluginTest will now be subject to the same CSP checks as other tests in CspRule.java.
Issue Reference:
Fixes JENKINS-73900

Testing:
Verified that the tests run successfully after the removal.
Ran mvn test to confirm that the modification does not introduce new errors.
Additional Notes:
Maintainers may wish to ensure compatibility with other plugins, as this change affects SubversionPluginTest specifically.

Fixes #1810