### PR TITLE
Avoid using a temporary file to store screenshot after a test failure

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/DiagnosticRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/DiagnosticRule.java
@@ -1,10 +1,9 @@
 package org.jenkinsci.test.acceptance.junit;
 
 import jakarta.inject.Inject;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.logging.Logger;
-import org.apache.commons.io.FileUtils;
 import org.jenkinsci.test.acceptance.controller.JenkinsController;
 import org.jenkinsci.test.acceptance.po.CapybaraPortingLayerImpl;
 import org.junit.rules.TestWatcher;
@@ -44,10 +43,9 @@ public class DiagnosticRule extends TestWatcher {
 
     private void takeScreenshot() {
         try {
-            File file = diagnostics.touch("screenshot.png");
-            File screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
-            FileUtils.copyFile(screenshot, file);
-
+            Files.write(
+                    diagnostics.touch("screenshot.png").toPath(),
+                    ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES));
         } catch (IOException e) {
             logger.warning("An error occurred when taking screenshot");
             throw new Error(e);


### PR DESCRIPTION
Temporary files are created with permissions `600`, differing from defined umask. For the screenshot file that is later attached as diagnostic, this can cause permission issues in some environments.

Tested by arbitrary failing a test and checking permissions set on resulting `screenshot.png` that can be found under `target/diagnostics/{testName}/screenshot.png`.
In my case `644` instead of `600`.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
