### PR TITLE
JENKINS-74974 - Adapt Scriptler test to use preferred terminology

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/scriptler/ScriptResult.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/scriptler/ScriptResult.java
@@ -23,12 +23,15 @@
  */
 package org.jenkinsci.test.acceptance.plugins.scriptler;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.po.Node;
 
 public class ScriptResult {
+    private static final List<String> BUILT_IN_NODE_NAMES = List.of("built-in", "controller", "master");
     private final String result;
 
     public ScriptResult(String result) {
@@ -37,8 +40,15 @@ public class ScriptResult {
 
     public String output(Node node) {
         String name = node.getName();
-        if (node instanceof Jenkins && "(master)".equals(name)) {
-            name = "(controller)";
+        if (node instanceof Jenkins) {
+            // TODO: use the below code once Scriptler versions 390 and up are the only ones tested
+            // return "(" + node + ")";
+            return BUILT_IN_NODE_NAMES.stream()
+                    .map(nodeName -> "(" + nodeName + ")")
+                    .map(this::output)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
         }
         return output(name);
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Jenkins.java
@@ -216,7 +216,7 @@ public class Jenkins extends Node implements Container {
 
     @Override
     public String getName() {
-        return "(master)";
+        return "built-in";
     }
 
     @Override


### PR DESCRIPTION
## JENKINS-74974 - Adapt to Scriptler 390+

Scriptler 390 and above use "(built-in)" to refer to the built-in node instead of "(controller)" or "(master)" (jenkinsci/scriptler-plugin#128). Update the test harness to check for any of these terms.

The adaptation code can be simplified once older versions of the Scriptler plugin are no longer being tested.

<!-- Please describe your pull request here. -->

### Testing done

Tested the Scriptler unit tests locally.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
