### PR TITLE
Test compress-artifacts with commons-compress-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,10 @@ and
           </systemPropertyVariables>
           <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
           <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+          <environmentVariables>
+            <!-- Use local version of the plugin over the released one ATH would otherwise use -->
+            <LOCAL_JARS>target/compress-artifacts.hpi</LOCAL_JARS>
+          </environmentVariables>
         </configuration>
       </plugin>
       <plugin>
@@ -809,6 +813,13 @@ and
                       <artifactId>jenkins-war</artifactId>
                       <version>${jenkins.version}</version>
                       <type>war</type>
+                    </artifactItem>
+                    <!-- TODO https://github.com/jenkinsci/compress-artifacts-plugin/pull/30 -->
+                    <artifactItem>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>compress-artifacts</artifactId>
+                      <version>111.vc48158612994</version>
+                      <type>hpi</type>
                     </artifactItem>
                   </artifactItems>
                   <outputDirectory>${project.build.directory}</outputDirectory>


### PR DESCRIPTION
## Test compress-artifacts with commons-compress-api dependency

The pull request that generated this incremental build:

* https://github.com/jenkinsci/compress-artifacts-plugin/pull/30

The pull request that discovered the issue:

* https://github.com/jenkinsci/acceptance-test-harness/pull/1860

Pull request that removed commons compress from Jenkins weekly 2.489.

* https://github.com/jenkinsci/jenkins/pull/9958

### Testing done

None.  Relying on ci.jenkins.io to run the tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
