### PR TITLE
Ensure that Jenkins node setup does not influence the container Java setup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,8 +144,11 @@ for (int i = 0; i < splits.size(); i++) {
                     ) {
                       sh """
                           set-java.sh ${jdk}
+                          JAVA_HOME="$(dirname "$(dirname "$(update-alternatives --list java | grep 17-openjdk)")")"
+                          export JAVA_HOME
                           eval \$(vnc.sh)
                           java -version
+                          mvn -v
                           run.sh ${browser} ${jenkinsVersion} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo -Dmaven.test.failure.ignore=true -Dcsp.rule=${cspRule} -DforkCount=1 -B
                           cp --verbose target/surefire-reports/TEST-*.xml /reports
                           """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,8 +144,8 @@ for (int i = 0; i < splits.size(); i++) {
                     ) {
                       sh """
                           set-java.sh ${jdk}
-                          JAVA_HOME="\$(dirname "\$(dirname "\$(update-alternatives --list java | grep ${jdk}-openjdk)")")"
-                          export JAVA_HOME
+                          # Ensure that Jenkins node setup does not influence the container java setup
+                          unset JAVA_HOME
                           eval \$(vnc.sh)
                           java -version
                           mvn -v

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,7 @@ for (int i = 0; i < splits.size(); i++) {
                     ) {
                       sh """
                           set-java.sh ${jdk}
-                          JAVA_HOME="$(dirname "$(dirname "$(update-alternatives --list java | grep 17-openjdk)")")"
+                          JAVA_HOME="\$(dirname "\$(dirname "\$(update-alternatives --list java | grep ${jdk}-openjdk)")")"
                           export JAVA_HOME
                           eval \$(vnc.sh)
                           java -version


### PR DESCRIPTION
As described in https://github.com/jenkins-infra/helpdesk/issues/4316#issuecomment-2618309804, if the [VM agent](https://github.com/jenkinsci/acceptance-test-harness/blob/ea72d04b39a3e4e9ad1d26a4010864821a923fc3/Jenkinsfile#L125) does set the `JAVA_HOME` environment variable, then it is passed to the [Docker agent container](https://github.com/jenkinsci/acceptance-test-harness/blob/ea72d04b39a3e4e9ad1d26a4010864821a923fc3/Jenkinsfile#L131) which is the default behavior of the docker workflow plugin:

```bash
docker run -t -d -u 1001:1001 --group-add 999 -v /var/run/docker.sock:/var/run/docker.sock -v /home/jenkins/agent/workspace/ath_master/target/ath-reports:/reports:rw --shm-size 2g -w /home/jenkins/agent/workspace/ath_master -v /home/jenkins/agent/workspace/ath_master:/home/jenkins/agent/workspace/ath_master:rw,z -v /home/jenkins/agent/workspace/ath_master@tmp:/home/jenkins/agent/workspace/ath_master@tmp:rw,z -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** jenkins/ath cat
``` 

=> Note the `-e ********` which are passing the env vars available in the agent (masked because they can be credentials bound to env. vars).

I've reproduce the error from https://github.com/jenkins-infra/helpdesk/issues/4316#issuecomment-2618309804 and tested the change of this PR with:

```bash
$ docker run --rm -ti --platform=linux/amd64 --entrypoint=bash jenkins/ath

# Error when JAVA_HOME is set up on the VM agent to the value /opt/jdk-17 which does not exist inside the ath container
$ export JAVA_HOME=/opt/jdk-17
$ mvn -v
The JAVA_HOME environment variable is not defined correctly,
this environment variable is needed to run this program.

# Test with JDK17
$ JAVA_HOME="$(dirname "$(dirname "$(update-alternatives --list java | grep 17-openjdk)")")"
$ export JAVA_HOME
$ mvn -v
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)
Maven home: /opt/maven
Java version: 17.0.13, vendor: Ubuntu, runtime: /usr/lib/jvm/java-17-openjdk-amd64
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "6.10.14-linuxkit", arch: "amd64", family: "unix"

# Test with JDK21
$ JAVA_HOME="$(dirname "$(dirname "$(update-alternatives --list java | grep 21-openjdk)")")"
$ export JAVA_HOME
$ mvn -v
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)
Maven home: /opt/maven
Java version: 21.0.5, vendor: Ubuntu, runtime: /usr/lib/jvm/java-21-openjdk-amd64
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "6.10.14-linuxkit", arch: "amd64", family: "unix"
```
