### PR TITLE
Use guava 33.4.7-jre instead of the android version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <jenkins.version>2.504</jenkins.version>
     <selenium.version>4.31.0</selenium.version>
     <!-- aligned with selenium -->
-    <guava.version>33.4.7-android</guava.version>
+    <guava.version>33.4.7-jre</guava.version>
 
     <!-- Keep them aligned to Maven version -->
     <maven.version>3.9.6</maven.version>


### PR DESCRIPTION
## Use guava 33.4.7-jre instead of the android version

Fixes 6104383882a417c420913370d57bb60e79e95a14

Amends https://github.com/jenkinsci/acceptance-test-harness/pull/1958

### Testing done

Confirmed that a test passes from the Maven command line after the change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
