### PR TITLE
Do not use logo but link to home instead

### DIFF
--- a/src/test/java/core/FormValidationTest.java
+++ b/src/test/java/core/FormValidationTest.java
@@ -76,7 +76,7 @@ public class FormValidationTest extends AbstractJUnitTest {
 
     private void navigateAway() {
         jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
+                () -> driver.findElement(By.xpath("//a[@href='/']")).click());
         sleep(1000); // Needed for some reason
     }
 }

--- a/src/test/java/core/PublisherOrderTest.java
+++ b/src/test/java/core/PublisherOrderTest.java
@@ -66,7 +66,7 @@ public class PublisherOrderTest extends AbstractJUnitTest {
          * FormValidationTest).
          */
         jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
+                () -> driver.findElement(By.xpath("//a[@href='/']")).click());
         sleep(1000);
     }
 }

--- a/src/test/java/plugins/ArtifactoryPluginTest.java
+++ b/src/test/java/plugins/ArtifactoryPluginTest.java
@@ -72,7 +72,7 @@ public class ArtifactoryPluginTest extends AbstractJUnitTest {
          * FormValidationTest).
          */
         jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
+                () -> driver.findElement(By.xpath("//a[@href='/']")).click());
         sleep(1000);
     }
 

--- a/src/test/java/plugins/MailerPluginTest.java
+++ b/src/test/java/plugins/MailerPluginTest.java
@@ -48,7 +48,7 @@ public class MailerPluginTest extends AbstractJUnitTest {
          * FormValidationTest).
          */
         jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
+                () -> driver.findElement(By.xpath("//a[@href='/']")).click());
         sleep(1000);
     }
 

--- a/src/test/java/plugins/PlainCredentialsBindingTest.java
+++ b/src/test/java/plugins/PlainCredentialsBindingTest.java
@@ -76,7 +76,7 @@ public class PlainCredentialsBindingTest extends AbstractCredentialsTest {
          * FormValidationTest).
          */
         jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
+                () -> driver.findElement(By.xpath("//a[@href='/']")).click());
         sleep(1000);
     }
 
@@ -89,7 +89,7 @@ public class PlainCredentialsBindingTest extends AbstractCredentialsTest {
          * FormValidationTest).
          */
         jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
+                () -> driver.findElement(By.xpath("//a[@href='/']")).click());
         sleep(1000);
     }
 

--- a/src/test/java/plugins/SshSlavesPluginTest.java
+++ b/src/test/java/plugins/SshSlavesPluginTest.java
@@ -153,7 +153,7 @@ public class SshSlavesPluginTest extends AbstractJUnitTest {
          * FormValidationTest).
          */
         jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
+                () -> driver.findElement(By.xpath("//a[@href='/']")).click());
         sleep(1000);
     }
 


### PR DESCRIPTION
https://github.com/jenkinsci/acceptance-test-harness/pull/1917 changed the criteria to find the link to "/" after the changes in the header. Because there exists https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/views/Header.java in Jenkins it is possible to have a customised header that might not have the "jenkins-head-icon" element, so maybe it's better to use the link instead of the id. Otherwise the ATH will only work with the Jenkins OSS header.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
