### PR TITLE
Clean up `beforeunload` user prompt handling

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -87,7 +87,6 @@ public class FallbackConfig extends AbstractModule {
 
     public static final String DOM_MAX_SCRIPT_RUN_TIME = "dom.max_script_run_time";
     public static final String DOM_MAX_CHROME_SCRIPT_RUN_TIME = "dom.max_chrome_script_run_time";
-    public static final String DOM_DISABLE_BEFOREUNLOAD = "dom.disable_beforeunload";
     public static final int PAGE_LOAD_TIMEOUT = 30;
     public static final int IMPLICIT_WAIT_TIMEOUT = 1;
 
@@ -184,8 +183,6 @@ public class FallbackConfig extends AbstractModule {
                 DOM_MAX_SCRIPT_RUN_TIME, (int) getElasticTime().seconds(600));
         firefoxOptions.addPreference(
                 DOM_MAX_CHROME_SCRIPT_RUN_TIME, (int) getElasticTime().seconds(600));
-        firefoxOptions.addPreference(
-                DOM_DISABLE_BEFOREUNLOAD, false); // TODO remove when we require Firefox 129 or newer
         firefoxOptions.enableBiDi();
         if (HarRecorder.isCaptureHarEnabled()) {
             firefoxOptions.setProxy(createSeleniumProxy(testName.get()));

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/CspRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/CspRule.java
@@ -41,7 +41,7 @@ public final class CspRule implements TestRule {
                             && !isSkipped()
                             && !d.getTestClass().getName().equals("plugins.ArtifactoryPluginTest")) {
                         ContentSecurityPolicyReport csp = new ContentSecurityPolicyReport(jenkins);
-                        csp.open();
+                        jenkins.runThenHandleUserPrompt(() -> csp.open());
                         List<String> lines = csp.getReport();
                         if (lines.size() > 2) {
                             throw new AssertionError(String.join("\n", lines));

--- a/src/test/java/core/FormValidationTest.java
+++ b/src/test/java/core/FormValidationTest.java
@@ -34,7 +34,6 @@ import org.jenkinsci.test.acceptance.po.FormValidation;
 import org.jenkinsci.test.acceptance.po.JenkinsConfig;
 import org.jenkinsci.test.acceptance.po.ListView;
 import org.junit.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 
 public class FormValidationTest extends AbstractJUnitTest {
@@ -75,8 +74,7 @@ public class FormValidationTest extends AbstractJUnitTest {
     }
 
     private void navigateAway() {
-        jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
+        jenkins.runThenHandleUserPrompt(() -> jenkins.open());
         sleep(1000); // Needed for some reason
     }
 }

--- a/src/test/java/core/PublisherOrderTest.java
+++ b/src/test/java/core/PublisherOrderTest.java
@@ -10,7 +10,6 @@ import org.jenkinsci.test.acceptance.po.Fingerprint;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.jenkinsci.test.acceptance.po.JUnitPublisher;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
 @WithPlugins("junit")
 public class PublisherOrderTest extends AbstractJUnitTest {
@@ -60,13 +59,5 @@ public class PublisherOrderTest extends AbstractJUnitTest {
         archiver.includes("another.txt");
         JUnitPublisher junit = upstream.addPublisher(JUnitPublisher.class);
         fingerprint.targets.set("yetanother");
-
-        /*
-         * Navigate back to the dashboard first to dismiss the alert so that CspRule can check for violations (see
-         * FormValidationTest).
-         */
-        jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
-        sleep(1000);
     }
 }

--- a/src/test/java/plugins/ArtifactoryPluginTest.java
+++ b/src/test/java/plugins/ArtifactoryPluginTest.java
@@ -32,7 +32,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Issue;
-import org.openqa.selenium.By;
 
 /**
  * Checks the successful integration of Artifactory plugin.
@@ -66,14 +65,6 @@ public class ArtifactoryPluginTest extends AbstractJUnitTest {
                 hasContent(
                         Pattern.compile(
                                 "Error occurred while requesting version information: Connection( to http://localhost:4898)* refused")));
-
-        /*
-         * Navigate back to the dashboard first to dismiss the alert so that CspRule can check for violations (see
-         * FormValidationTest).
-         */
-        jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
-        sleep(1000);
     }
 
     @Test

--- a/src/test/java/plugins/MailerPluginTest.java
+++ b/src/test/java/plugins/MailerPluginTest.java
@@ -15,7 +15,6 @@ import org.jenkinsci.test.acceptance.utils.mail.MailhogProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.openqa.selenium.By;
 
 @WithPlugins("mailer")
 @Category(DockerTest.class)
@@ -42,14 +41,6 @@ public class MailerPluginTest extends AbstractJUnitTest {
                 Pattern.compile("Test email #1"),
                 "admin@example.com",
                 Pattern.compile("This is test email #1 sent from Jenkins"));
-
-        /*
-         * Navigate back to the dashboard first to dismiss the alert so that CspRule can check for violations (see
-         * FormValidationTest).
-         */
-        jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
-        sleep(1000);
     }
 
     @Test

--- a/src/test/java/plugins/PlainCredentialsBindingTest.java
+++ b/src/test/java/plugins/PlainCredentialsBindingTest.java
@@ -46,7 +46,6 @@ import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.jenkinsci.test.acceptance.po.ShellBuildStep;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
 /**
  * Tests the plain-credentials and credentials-binding plugins together.
@@ -70,27 +69,11 @@ public class PlainCredentialsBindingTest extends AbstractCredentialsTest {
     @Test
     public void systemSecretFileCredentialTest() throws URISyntaxException {
         createAndUseCredential(SYSTEM_SCOPE, FileCredentials.class);
-
-        /*
-         * Navigate back to the dashboard first to dismiss the alert so that CspRule can check for violations (see
-         * FormValidationTest).
-         */
-        jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
-        sleep(1000);
     }
 
     @Test
     public void systemSecretTextCredentialTest() throws URISyntaxException {
         createAndUseCredential(SYSTEM_SCOPE, StringCredentials.class);
-
-        /*
-         * Navigate back to the dashboard first to dismiss the alert so that CspRule can check for violations (see
-         * FormValidationTest).
-         */
-        jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
-        sleep(1000);
     }
 
     @Test

--- a/src/test/java/plugins/SshSlavesPluginTest.java
+++ b/src/test/java/plugins/SshSlavesPluginTest.java
@@ -50,7 +50,6 @@ import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Issue;
-import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 
 @WithPlugins({"ssh-slaves", "credentials", "ssh-credentials"})
@@ -147,14 +146,6 @@ public class SshSlavesPluginTest extends AbstractJUnitTest {
         l.host.set("127.0.0.1");
 
         l.credentialsId.select(String.format("%s (%s)", username, description));
-
-        /*
-         * Navigate back to the dashboard first to dismiss the alert so that CspRule can check for violations (see
-         * FormValidationTest).
-         */
-        jenkins.runThenConfirmAlert(
-                () -> driver.findElement(By.id("jenkins-head-icon")).click());
-        sleep(1000);
     }
 
     private void verifyValueForCredential(CredentialsPage cp, Control element, String expected) {


### PR DESCRIPTION
#1657 introduced a fragile workaround in `FormValidationTest` (moving from `jenkins.open()` to clicking on a breadcrumb link), and that fragile workaround was copied and pasted in more places in #1749. That code was then adjusted even further in #1917, which is still causing some problems for OEMs that have not adopted the Jenkins header change. This PR does some code cleanup:

- Restores `FormValidationTest` to the less fragile way it was before #1657, effectively reimplementing #1657 to use BiDi to dismiss the alert. This removes the fragility associated with `#jenkins-head-icon`.
- Adds this new BiDi implementation to `CspRule`, avoiding the need for copypasta in a bunch of tests and saving test execution time when `CspRule` is disabled.

The net result is a strict improvement over the status quo: less copypasta and less fragility because the codebase now has no references to `#jenkins-head-icon`.

There is likely still more cleanup that can be done; for example, https://github.com/jenkinsci/acceptance-test-harness/blob/40f6a5807ddebb81591aedcbb9d8992b7d88b1a2/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java#L364-L372 still looks suspicious, and the sleep statement in `FormValidationTest` (which has been there for many, many years) is probably suspicious as well. I am explicitly not tackling these additional cleanups in this PR.

### Testing done

PR build (which has `CspRule` enabled)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
