### PR TITLE
Remove workaround added in #457

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -51,7 +51,6 @@ import org.jenkinsci.test.acceptance.utils.pluginreporter.TextFileExercisedPlugi
 import org.jenkinsci.utils.process.CommandBuilder;
 import org.jenkinsci.utils.process.ProcessInputStream;
 import org.junit.runners.model.Statement;
-import org.openqa.selenium.Alert;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.MutableCapabilities;
@@ -70,7 +69,6 @@ import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.support.events.EventFiringDecorator;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 /**
  * The default configuration for running tests.
@@ -357,20 +355,6 @@ public class FallbackConfig extends AbstractModule {
         cleaner.addTask(new Statement() {
             @Override
             public void evaluate() {
-                switch (getBrowser()) {
-                    case "firefox":
-                    case "saucelabs-firefox":
-                    case "remote-webdriver-firefox":
-                        // https://github.com/mozilla/geckodriver/issues/1151
-                        // https://bugzilla.mozilla.org/show_bug.cgi?id=1264259
-                        // https://bugzilla.mozilla.org/show_bug.cgi?id=1434872
-                        d.navigate().to("about:mozilla");
-                        Alert alert = ExpectedConditions.alertIsPresent().apply(d);
-                        if (alert != null) {
-                            alert.accept();
-                            d.navigate().refresh();
-                        }
-                }
                 d.quit();
             }
 


### PR DESCRIPTION
#457 added a workaround. I wonder if it is still necessary or if it can be deleted.

### Testing done

CI build, which does include `CspRule`.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
