### PR TITLE
Use consistent Windows detection conditional

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Logger;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -303,13 +304,8 @@ public class FallbackConfig extends AbstractModule {
         }
     }
 
-    private boolean isWindows() {
-        // Same as hudson.Functions.isWindows()
-        return File.pathSeparatorChar == ';';
-    }
-
     private String locateDriver(final String name) {
-        String command = isWindows() ? "where" : "which";
+        String command = SystemUtils.IS_OS_WINDOWS ? "where" : "which";
         try (ProcessInputStream pis = new CommandBuilder(command, name).popen()) {
             return pis.asText().trim();
         } catch (IOException | InterruptedException exception) {


### PR DESCRIPTION
Other cases in this repository use SystemUtils.IS_OS_WINDOWS.  No need to create a private method when SystemUtils is already in use.

https://github.com/jenkinsci/acceptance-test-harness/pull/1987#discussion_r2072465477

### Testing done

Confirmed that `mvn compile` compiles successfully;

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
