### PR TITLE
Support BiDi in `RemoteWebDriver`

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -64,6 +64,7 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.GeckoDriverService;
+import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -155,7 +156,7 @@ public class FallbackConfig extends AbstractModule {
         }
     }
 
-    private RemoteWebDriver buildRemoteWebDriver(Capabilities options) throws MalformedURLException {
+    private WebDriver buildRemoteWebDriver(Capabilities options) throws MalformedURLException {
         String u = System.getenv("REMOTE_WEBDRIVER_URL");
         if (StringUtils.isBlank(u)) {
             throw new Error("remote-webdriver type browsers require REMOTE_WEBDRIVER_URL to be set");
@@ -164,7 +165,7 @@ public class FallbackConfig extends AbstractModule {
                 new URL(u), // http://192.168.99.100:4444/wd/hub
                 options);
         driver.setFileDetector(new LocalFileDetector());
-        return driver;
+        return new Augmenter().augment(driver);
     }
 
     private String getBrowser() {
@@ -264,7 +265,7 @@ public class FallbackConfig extends AbstractModule {
                 RemoteWebDriver remoteWebDriver =
                         new RemoteWebDriver(new URL("http://127.0.0.1:" + controlPort + "/wd/hub"), capabilities);
                 cleaner.addTask(cleanContainer);
-                return remoteWebDriver;
+                return new Augmenter().augment(remoteWebDriver);
             } catch (RuntimeException e) {
                 cleanContainer.close();
                 throw e;


### PR DESCRIPTION
@jtnord notes that the BiDi support added in #1657 won't work with `RemoteWebDriver`:

> `RemoteWebdriver` doesn't know if it is BiDi or not (it's a runtime thing) so it doesn't implement the interfaces. […] IIRC you will need to wrap it with a call to `Augmenter#augment`

This PR does exactly that.

### Testing done

Reproduced BiDi failures with `FormValidationTest` and `RemoteWebDriver`; could no longer reproduce after this PR.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
