### PR TITLE
Port `vars.cmd` to Unix

### DIFF
--- a/vars.sh
+++ b/vars.sh
@@ -16,7 +16,7 @@ export INTERACTIVE=false
 export BROWSER=remote-webdriver-firefox
 export REMOTE_WEBDRIVER_URL=http://127.0.0.1:4444/wd/hub
 export JENKINS_JAVA_OPTS=-Xmx1280m
-if [ -f /usr/share/java/jenkins.war ]; then
+if [ -z "${JENKINS_WAR}" ] && [ -f /usr/share/java/jenkins.war ]; then
 	export JENKINS_WAR=/usr/share/java/jenkins.war
 fi
 

--- a/vars.sh
+++ b/vars.sh
@@ -16,7 +16,9 @@ export INTERACTIVE=false
 export BROWSER=remote-webdriver-firefox
 export REMOTE_WEBDRIVER_URL=http://127.0.0.1:4444/wd/hub
 export JENKINS_JAVA_OPTS=-Xmx1280m
-export JENKINS_WAR=/usr/share/java/jenkins.war
+if [ -f /usr/share/java/jenkins.war ]; then
+	export JENKINS_WAR=/usr/share/java/jenkins.war
+fi
 
 IP=$(ip addr show docker0 2>/dev/null | grep 'inet ' | awk '{print $2}' | cut -d'/' -f1) ||
 	die "failed to retrieve IP address of Docker interface"

--- a/vars.sh
+++ b/vars.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+die() {
+	echo "$(basename "$0"): $*" >&2
+	exit 1
+}
+
+#
+# Script for setting all the variables to run the ATH locally on Unix
+# Use config.groovy in the same folder if desired, uncomment below
+#
+
+#export CONFIG="${PWD}/config.groovy"
+export DISPLAY=:0
+export INTERACTIVE=false
+export BROWSER=remote-webdriver-firefox
+export REMOTE_WEBDRIVER_URL=http://127.0.0.1:4444/wd/hub
+export JENKINS_JAVA_OPTS=-Xmx1280m
+export JENKINS_WAR=/usr/share/java/jenkins.war
+
+IP=$(ip addr show docker0 2>/dev/null | grep 'inet ' | awk '{print $2}' | cut -d'/' -f1) ||
+	die "failed to retrieve IP address of Docker interface"
+export SELENIUM_PROXY_HOSTNAME="${IP}"
+export TESTCONTAINERS_HOST_OVERRIDE="${IP}"
+export JENKINS_LOCAL_HOSTNAME="${IP}"
+
+echo "To start the remote Firefox container, run the following command:"
+echo "docker run --shm-size=256m -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e no_proxy=localhost -e SCREEN_WIDTH=1680 -e SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.32.0"


### PR DESCRIPTION
Porting https://github.com/jenkinsci/acceptance-test-harness/blob/a429dbeab2db40df7cb5bfbc084eece035c48e1f/vars.cmd to Unix to allow for `RemoteWebDriver` testing on Unix platforms.