### PR TITLE
Disable HAR recording by default

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/recorder/HarRecorder.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/recorder/HarRecorder.java
@@ -69,7 +69,7 @@ public class HarRecorder extends TestWatcher {
     }
 
     static State CAPTURE_HAR = State.value(SystemEnvironmentVariables.getPropertyVariableOrEnvironment(
-            "RECORD_BROWSER_TRAFFIC", State.FAILURES_ONLY.getValue()));
+            "RECORD_BROWSER_TRAFFIC", State.OFF.getValue()));
 
     private static BrowserUpProxy proxy;
 


### PR DESCRIPTION
Pending #1998, disable HAR recording by default. In local testing I found it not to fail outright but rather to introduce instability into WebDriver BiDi builds using WebSocket, which is even worse than failing outright. When #1998 is implemented, it can be re-enabled.

### Testing done

Observed non-fatal timeouts and stack traces from the BrowserUp Proxy library when running the test suite locally against a remote Selenium Grid container without this PR; they went away after this PR.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
