### PR TITLE
Propagate cleanup failures

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/guice/Cleaner.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/guice/Cleaner.java
@@ -2,7 +2,9 @@ package org.jenkinsci.test.acceptance.guice;
 
 import java.io.Closeable;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -66,15 +68,18 @@ public class Cleaner {
         });
     }
 
-    public void performCleanUp() {
+    public List<Throwable> performCleanUp() {
         LOGGER.info("Performing cleanup tasks in order: " + tasks);
+        List<Throwable> errors = new ArrayList<>();
         for (Statement task : tasks) {
             try {
                 task.evaluate();
             } catch (Throwable t) {
                 LOGGER.log(Level.SEVERE, task + " failed", t);
+                errors.add(t);
             }
         }
         tasks.clear();
+        return errors;
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/guice/TestCleaner.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/guice/TestCleaner.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.test.acceptance.guice;
 
 import com.google.inject.Inject;
+import java.util.List;
 
 /**
  * {@link Cleaner} at the end of each {@link TestScope}.
@@ -15,18 +16,19 @@ public class TestCleaner extends Cleaner {
     TestLifecycle lifecycle;
 
     @Override
-    public void performCleanUp() {
-        super.performCleanUp();
+    public List<Throwable> performCleanUp() {
+        List<Throwable> errors = super.performCleanUp();
         for (Object o : lifecycle.getInstances()) {
             if (o instanceof AutoCleaned) {
                 try {
                     ((AutoCleaned) o).close();
                 } catch (Throwable t) {
-                    // just log and move on so that other cleaners can run
                     System.out.println(o + " clean up failed");
                     t.printStackTrace();
+                    errors.add(t);
                 }
             }
         }
+        return errors;
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/JenkinsAcceptanceTestRule.java
@@ -53,14 +53,28 @@ public class JenkinsAcceptanceTestRule implements MethodRule { // TODO should us
 
                 injector.injectMembers(this);
 
+                Throwable throwable = null;
                 try {
                     decorateWithRules(base).evaluate();
                 } catch (AssumptionViolatedException e) {
                     System.out.printf("Skipping %s%n", description.getDisplayName());
                     e.printStackTrace();
-                    throw e;
+                    throwable = e;
+                } catch (Throwable t) {
+                    throwable = t;
                 } finally {
-                    world.endTestScope();
+                    try {
+                        world.endTestScope();
+                    } catch (Throwable t) {
+                        if (throwable == null) {
+                            throwable = t;
+                        } else {
+                            throwable.addSuppressed(t);
+                        }
+                    }
+                    if (throwable != null) {
+                        throw throwable;
+                    }
                 }
             }
 


### PR DESCRIPTION
Recently I spent quite a bit of time debugging a resource leak that would have been far more obvious if the cleanup handler propagated exceptions rather than silently swallowing them.

### Testing done

Tested a few scenarios:

- No exception
- Skipped test
- Exception in cleanup handler but not in test
- Exception in test but not in cleanup handler
- Exception in both test and cleanup handler (the latter was added as a suppressed exception)


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
