### PR TITLE
[JENKINS-64708] Deprecate PageObject constructor receiving the Injector as parameter

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerJob.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerJob.java
@@ -59,7 +59,7 @@ public class GerritTriggerJob extends PageObject {
             "/com-sonyericsson-hudson-plugins-gerrit-trigger-hudsontrigger-GerritTrigger/triggerOnEvents/commentAddedTriggerApprovalValue");
 
     public GerritTriggerJob(Jenkins jenkins, String jobName) {
-        super(jenkins.injector, jenkins.url("job/" + jobName + "/configure"));
+        super(jenkins, jenkins.url("job/" + jobName + "/configure"));
         this.jenkins = jenkins;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerNewServer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerNewServer.java
@@ -38,7 +38,7 @@ public class GerritTriggerNewServer extends PageObject {
     public final Control modeDefault = control("/mode[com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer]");
 
     public GerritTriggerNewServer(Jenkins jenkins) {
-        super(jenkins.injector, jenkins.url("gerrit-trigger/newServer"));
+        super(jenkins, jenkins.url("gerrit-trigger/newServer"));
         this.jenkins = jenkins;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerServer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/gerrit_trigger/GerritTriggerServer.java
@@ -59,7 +59,7 @@ public class GerritTriggerServer extends PageObject {
     private static final String serverUrl = "gerrit-trigger/server/";
 
     public GerritTriggerServer(Jenkins jenkins, String serverName) {
-        super(jenkins.injector, jenkins.url(serverUrl + serverName));
+        super(jenkins, jenkins.url(serverUrl + serverName));
         this.jenkins = jenkins;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/logparser/LogParserOutputPage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/logparser/LogParserOutputPage.java
@@ -41,7 +41,7 @@ public class LogParserOutputPage extends PageObject {
      * @param po The page of the logparser.
      */
     public LogParserOutputPage(PageObject po) {
-        super(po.injector, po.url("parsed_console"));
+        super(po, po.url("parsed_console"));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/maven/MavenModule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/maven/MavenModule.java
@@ -28,7 +28,7 @@ import org.jenkinsci.test.acceptance.po.Job;
 public class MavenModule extends Job {
 
     public MavenModule(MavenModuleSet job, String name) {
-        super(job.injector, job.url("./%s/", name), name);
+        super(job, job.url("./%s/", name), name);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Action.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Action.java
@@ -37,7 +37,7 @@ public abstract class Action extends PageObject {
     private final String linkText;
 
     public Action(ContainerPageObject parent, String relative, String linkText) {
-        super(parent.injector, parent.url(relative + "/"));
+        super(parent, parent.url(relative + "/"));
         this.parent = parent;
         this.linkText = linkText;
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Artifact.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Artifact.java
@@ -19,7 +19,7 @@ public class Artifact extends PageObject {
     private final @NonNull String path;
 
     public Artifact(@NonNull Build build, @NonNull String path) {
-        super(build.injector, build.url("artifact/%s", path));
+        super(build, build.url("artifact/%s", path));
         this.build = build;
         this.path = path;
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Build.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Build.java
@@ -38,17 +38,17 @@ public class Build extends ContainerPageObject {
     private boolean success;
 
     public Build(Job job, int buildNumber) {
-        super(job.injector, job.url("%d/", buildNumber));
+        super(job, job.url("%d/", buildNumber));
         this.job = job;
     }
 
     public Build(Job job, String permalink) {
-        super(job.injector, job.url(permalink + "/"));
+        super(job, job.url(permalink + "/"));
         this.job = job;
     }
 
     public Build(Job job, URL url) {
-        super(job.injector, url);
+        super(job, url);
         this.job = job;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/BuildHistory.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/BuildHistory.java
@@ -16,11 +16,11 @@ public class BuildHistory extends PageObject {
     private static final Pattern CONSOLE_LINK_PATTERN = Pattern.compile("/job/(.+?)/(\\d+)/console");
 
     public BuildHistory(Node parent) {
-        super(parent.injector, parent.url("builds"));
+        super(parent, parent.url("builds"));
     }
 
     public BuildHistory(View parent) {
-        super(parent.injector, parent.url("builds"));
+        super(parent, parent.url("builds"));
     }
 
     public Set<Build> getBuilds() {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JenkinsConfig.java
@@ -14,7 +14,7 @@ public class JenkinsConfig extends ConfigurablePageObject {
     public final Control quietPeriod = control("/jenkins-model-GlobalQuietPeriodConfiguration/quietPeriod");
 
     public JenkinsConfig(Jenkins jenkins) {
-        super(jenkins.injector, jenkins.url("configure"));
+        super(jenkins, jenkins.url("configure"));
         this.jenkins = jenkins;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Logout.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Logout.java
@@ -6,6 +6,6 @@ package org.jenkinsci.test.acceptance.po;
  */
 public class Logout extends PageObject {
     public Logout(Jenkins jenkins) {
-        super(jenkins.injector, jenkins.url("logout"));
+        super(jenkins, jenkins.url("logout"));
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PageObject.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PageObject.java
@@ -47,6 +47,11 @@ public abstract class PageObject extends CapybaraPortingLayerImpl {
 
     private static final RandomNameGenerator RND = new RandomNameGenerator();
 
+    /**
+     * @deprecated Use {@link #PageObject(PageObject, URL)} instead to preserve context.
+     *             This constructor should only be used for top-level objects like {@link Jenkins}.
+     */
+    @Deprecated
     public PageObject(Injector injector, URL url) {
         super(injector);
         this.url = url;

--- a/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/PluginManager.java
@@ -63,7 +63,7 @@ public class PluginManager extends ContainerPageObject {
     public MockUpdateCenter mockUpdateCenter;
 
     public PluginManager(Jenkins jenkins) {
-        super(jenkins.injector, jenkins.url("pluginManager/"));
+        super(jenkins, jenkins.url("pluginManager/"));
         this.jenkins = jenkins;
         mockUpdateCenter.ensureRunning(jenkins);
     }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/WizardCreateAdminUser.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WizardCreateAdminUser.java
@@ -49,7 +49,7 @@ public class WizardCreateAdminUser extends PageObject {
     JenkinsController controller;
 
     public WizardCreateAdminUser(Jenkins jenkins) {
-        super(jenkins.injector, jenkins.url(""));
+        super(jenkins, jenkins.url(""));
     }
 
     public WizardCreateAdminUser createAdminUser(String userName, String password, String fullName, String email) {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/WizardCustomizeJenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WizardCustomizeJenkins.java
@@ -42,7 +42,7 @@ import org.openqa.selenium.WebElement;
 public class WizardCustomizeJenkins extends PageObject {
 
     public WizardCustomizeJenkins(Jenkins jenkins) {
-        super(jenkins.injector, jenkins.url(""));
+        super(jenkins, jenkins.url(""));
     }
 
     public WizardCustomizeJenkins doInstallSuggested() {

--- a/src/main/java/org/jenkinsci/test/acceptance/po/WizardLogin.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WizardLogin.java
@@ -47,7 +47,7 @@ public class WizardLogin extends PageObject {
     private Control cLogin = control("/Continue");
 
     public WizardLogin(Jenkins jenkins) {
-        super(jenkins.injector, jenkins.url(""));
+        super(jenkins, jenkins.url(""));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/utils/pluginTests/SecurityDisabler.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/utils/pluginTests/SecurityDisabler.java
@@ -35,7 +35,7 @@ public class SecurityDisabler extends PageObject {
     public final Jenkins jenkins;
 
     public SecurityDisabler(Jenkins jenkins) {
-        super(jenkins.injector, jenkins.url("configureSecurity"));
+        super(jenkins, jenkins.url("configureSecurity"));
         this.jenkins = jenkins;
     }
 


### PR DESCRIPTION
[JENKINS-64708](https://issues.jenkins.io/browse/JENKINS-64708)

Fixes #2648 

Now,
1. The deprecated constructor now has a clearer warning message
2. The new helper constructor makes it easier to migrate existing code to use contexts correctly
3. The factory method provides a convenient migration path for existing code
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
