### PR TITLE
Use consistent SHM size

### DIFF
--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -85,7 +85,7 @@ There is a script to run VNC server and propagate the display number to the test
 
 Untested pseudo bash example
 
-    docker run --shm-size=256m -d -P selenium/standalone-firefox-debug > containerId.txt
+    docker run --shm-size=2g -d -P selenium/standalone-firefox-debug > containerId.txt
     export WEBDRIVER_CONTAINER_ID=$(cat containerId.txt)
     export BROWSER=remote-webdriver-firefox
     export REMOTE_WEBDRIVER_URL=http://$(docker port $WEBDRIVER_CONTAINER_ID 4444)/wd/hub

--- a/vars.cmd
+++ b/vars.cmd
@@ -27,5 +27,5 @@ set TESTCONTAINERS_HOST_OVERRIDE=%IP%
 set JENKINS_LOCAL_HOSTNAME=%IP%
 @echo.
 @echo To start the remote firefox container run the following command:
-@echo docker run --shm-size=256m -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e SE_NODE_GRID_URL=http://127.0.0.1:4444 -e no_proxy=localhost -e SCREEN_WIDTH=1680 -e SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.32.0
+@echo docker run --shm-size=2g -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e SE_NODE_GRID_URL=http://127.0.0.1:4444 -e no_proxy=localhost -e SCREEN_WIDTH=1680 -e SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.32.0
 

--- a/vars.sh
+++ b/vars.sh
@@ -27,4 +27,4 @@ export TESTCONTAINERS_HOST_OVERRIDE="${IP}"
 export JENKINS_LOCAL_HOSTNAME="${IP}"
 
 echo "To start the remote Firefox container, run the following command:"
-echo "docker run --shm-size=256m -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e no_proxy=localhost -e SCREEN_WIDTH=1680 -e SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.32.0"
+echo "docker run --shm-size=2g -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e no_proxy=localhost -e SCREEN_WIDTH=1680 -e SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.32.0"


### PR DESCRIPTION
Use a consistent SHM size rather than a mix of 256 MB and 2 GB. The 2 GB value is recommended here:

https://github.com/SeleniumHQ/docker-selenium?tab=readme-ov-file#--shm-size2g