### PR TITLE
Automatically update `vars.sh` with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,7 +56,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig\\.java/"
+        "/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig\\.java/",
+        "/vars.sh/"
       ],
       "matchStrings": [
         "selenium/standalone-(firefox|chrome):(?<currentValue>.*?)\""


### PR DESCRIPTION
The regex we use for Renovate happens to work with `vars.sh`, so let's keep that up-to-date with Renovate too. Updating the regex to work with `vars.cmd` is left as an exercise for the reader.