### PR TITLE
Use consistent screen dimensions

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -338,8 +338,8 @@ public class FallbackConfig extends AbstractModule {
         // Make sure the window has minimal resolution set, even when out of the visible screen.
         // Note - not maximizing here any more because that doesn't do anything.
         Dimension oldSize = base.manage().window().getSize();
-        if (oldSize.height < 1050 || oldSize.width < 1680) {
-            base.manage().window().setSize(new Dimension(1680, 1050));
+        if (oldSize.height < 1090 || oldSize.width < 1680) {
+            base.manage().window().setSize(new Dimension(1680, 1090));
         }
         Scroller scroller = new Scroller(base);
         final EventFiringDecorator<WebDriver> decorator = new EventFiringDecorator<>(scroller);

--- a/vars.cmd
+++ b/vars.cmd
@@ -27,5 +27,5 @@ set TESTCONTAINERS_HOST_OVERRIDE=%IP%
 set JENKINS_LOCAL_HOSTNAME=%IP%
 @echo.
 @echo To start the remote firefox container run the following command:
-@echo docker run --shm-size=2g -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e SE_NODE_GRID_URL=http://127.0.0.1:4444 -e no_proxy=localhost -e SCREEN_WIDTH=1680 -e SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.32.0
+@echo docker run --shm-size=2g -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e SE_NODE_GRID_URL=http://127.0.0.1:4444 -e no_proxy=localhost -e SE_SCREEN_WIDTH=1680 -e SE_SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.32.0
 

--- a/vars.sh
+++ b/vars.sh
@@ -27,4 +27,4 @@ export TESTCONTAINERS_HOST_OVERRIDE="${IP}"
 export JENKINS_LOCAL_HOSTNAME="${IP}"
 
 echo "To start the remote Firefox container, run the following command:"
-echo "docker run --shm-size=2g -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e no_proxy=localhost -e SCREEN_WIDTH=1680 -e SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.32.0"
+echo "docker run --shm-size=2g -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e no_proxy=localhost -e SE_SCREEN_WIDTH=1680 -e SE_SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.32.0"


### PR DESCRIPTION
Use the correct environment variables as documented in https://github.com/SeleniumHQ/docker-selenium?tab=readme-ov-file#setting-screen-resolution and also update the Java code to match these dimensions.