### PR TITLE
Fix `UselessFileDetectorReplacement`

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/audit_trail/AuditTrailLogger.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/audit_trail/AuditTrailLogger.java
@@ -32,6 +32,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.test.acceptance.po.Jenkins;
 import org.jenkinsci.test.acceptance.po.JenkinsLogger;
+import org.jenkinsci.test.acceptance.selenium.UselessFileDetectorReplacement;
 
 public abstract class AuditTrailLogger extends JenkinsLogger {
 
@@ -64,7 +65,9 @@ public abstract class AuditTrailLogger extends JenkinsLogger {
             AuditTrailGlobalConfiguration area = new AuditTrailGlobalConfiguration(jenkins.getConfigPage());
             area.addLogger.selectDropdownMenu("Log file");
 
-            area.control("loggers/log").set(logfile);
+            try (UselessFileDetectorReplacement ufd = new UselessFileDetectorReplacement(driver)) {
+                area.control("loggers/log").set(logfile);
+            }
             area.control("loggers/limit").set(10);
             area.control("loggers/count").set(1);
             jenkins.save();

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/logparser/LogParserGlobalConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/logparser/LogParserGlobalConfig.java
@@ -4,6 +4,7 @@ import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.JenkinsConfig;
 import org.jenkinsci.test.acceptance.po.PageAreaImpl;
 import org.jenkinsci.test.acceptance.po.PageObject;
+import org.jenkinsci.test.acceptance.selenium.UselessFileDetectorReplacement;
 
 /**
  * Helper class for configuring global settings of LogParser.
@@ -37,7 +38,9 @@ public class LogParserGlobalConfig extends PageAreaImpl {
         String rulePath = createPageArea(rulePrefix, addButton::click);
         Rule rule = new Rule(getPage(), rulePath);
         rule.description.set(description);
-        rule.path.set(path);
+        try (UselessFileDetectorReplacement ufd = new UselessFileDetectorReplacement(driver)) {
+            rule.path.set(path);
+        }
     }
 
     /**

--- a/src/main/java/org/jenkinsci/test/acceptance/selenium/UselessFileDetectorReplacement.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/selenium/UselessFileDetectorReplacement.java
@@ -2,6 +2,8 @@ package org.jenkinsci.test.acceptance.selenium;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WrapsDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.remote.FileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.UselessFileDetector;
@@ -29,9 +31,8 @@ public class UselessFileDetectorReplacement implements AutoCloseable {
      */
     public UselessFileDetectorReplacement(WebDriver driver) {
         driver = getNonWrappedDriver(driver);
-        if (driver.getClass().equals(RemoteWebDriver.class)) {
-            // we test the explicit class not instanceof as the local FirefoxDriver and others
-            // are also RemoteWebDriver but can not be configured with a FileDetector
+        if (driver instanceof RemoteWebDriver && !(driver instanceof FirefoxDriver || driver instanceof ChromeDriver)) {
+            // The local FirefoxDriver and others are also RemoteWebDriver but cannot be configured with a FileDetector.
             remoteDriver = (RemoteWebDriver) driver;
             previous = remoteDriver.getFileDetector();
             remoteDriver.setFileDetector(new UselessFileDetector());


### PR DESCRIPTION
Extracted from #2010. Fixes two problems:

1. We were using `UselessFileDetectorReplacement` in one place where it was needed, but not two other places where it was also needed. Fixed by using it in those two other places.
2. Even in the place where we were using it, it wasn't actually working, because the `RemoteWebDriver` instance was an anonymous ByteBuddy wrapper subclass, not the actual `RemoteWebDriver` class itself. Fixed by using `instanceof`.

### Testing done

#2010 is now passing.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
