### PR TITLE
Record videos with Selenium instead of Monte

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -11,15 +11,9 @@ if [[ -z ${DOCKER_GID:-} ]]; then
 	export DOCKER_GID
 fi
 
-RECORDER=failuresOnly
-if ((jdk == 17)); then
-	# Crashes Monte when used with a remote X11 display
-	RECORDER=off
-fi
-
 trap 'docker-compose kill && docker-compose down' EXIT
 
-docker-compose run -e "MAVEN_ARGS=${MAVEN_ARGS}" -e "RECORDER=${RECORDER}" --name mvn -T --rm -v "${MAVEN_SETTINGS}:${MAVEN_SETTINGS}" mvn bash -s <<-INSIDE
+docker-compose run -e "MAVEN_ARGS=${MAVEN_ARGS}" --name mvn -T --rm -v "${MAVEN_SETTINGS}:${MAVEN_SETTINGS}" mvn bash -s <<-INSIDE
 	set-java.sh ${jdk}
 
 	# Ensure that Jenkins node setup does not influence the container Java setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   init_video:
-    image: alpine:latest
+    image: ubuntu:noble
     command: >
       sh -c "mkdir -p /tmp/videos && chmod 0777 /tmp/videos"
     volumes:
@@ -36,12 +36,12 @@ services:
       - SE_VIDEO_FILE_NAME=auto
       - SE_VIDEO_FILE_NAME_SUFFIX=false
       - SE_VIDEO_RECORD_STANDALONE=true
-      - VIDEO_FOLDER=/tmp2/videos  # Avoid conflict with supervisord
+      - VIDEO_FOLDER=/tmp2/videos
     image: selenium/video:ffmpeg-7.1-20250515@sha256:5e283b26b1bb14cabb03b31aaf7d88348e93e92d82b0e1704780611bef129964
     networks:
       - ath-network
     volumes:
-      - shared_tmp:/tmp2
+      - shared_tmp:/tmp2  # Avoid conflict with supervisord
   mvn:
     build:
       context: src/main/resources/ath-container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,11 @@
 ---
 services:
+  init_video:
+    image: alpine:latest
+    command: >
+      sh -c "mkdir -p /tmp/videos && chmod 0777 /tmp/videos"
+    volumes:
+      - shared_tmp:/tmp
   firefox:
     container_name: firefox
     environment:
@@ -18,6 +24,24 @@ services:
     shm_size: 2g
     volumes:
       - shared_tmp:/tmp
+  video:
+    container_name: video
+    depends_on:
+      - firefox
+      - init_video
+    environment:
+      - DISPLAY_CONTAINER_NAME=firefox
+      - SE_NODE_GRID_URL=http://firefox:4444
+      - SE_NODE_PORT=4444
+      - SE_VIDEO_FILE_NAME=auto
+      - SE_VIDEO_FILE_NAME_SUFFIX=false
+      - SE_VIDEO_RECORD_STANDALONE=true
+      - VIDEO_FOLDER=/tmp2/videos  # Avoid conflict with supervisord
+    image: selenium/video:ffmpeg-7.1-20250515@sha256:5e283b26b1bb14cabb03b31aaf7d88348e93e92d82b0e1704780611bef129964
+    networks:
+      - ath-network
+    volumes:
+      - shared_tmp:/tmp2
   mvn:
     build:
       context: src/main/resources/ath-container
@@ -27,6 +51,7 @@ services:
     container_name: mvn
     depends_on:
       - firefox
+      - video
     environment:
       - DISPLAY=firefox:99.0
       - DOCKER_FIXTURES_NETWORK=ath-network
@@ -35,6 +60,7 @@ services:
       - SELENIUM_PROXY_HOSTNAME=mvn
       - SHARED_DOCKER_SERVICE=true
       - TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
+      - VIDEO_FOLDER=/tmp/videos
     extra_hosts:
       - host.docker.internal:host-gateway
     group_add:

--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -355,6 +355,7 @@ public class FallbackConfig extends AbstractModule {
             @Override
             public void evaluate() throws Throwable {
                 Throwable error = null;
+
                 try {
                     d.quit();
                 } catch (Throwable t) {
@@ -387,8 +388,7 @@ public class FallbackConfig extends AbstractModule {
                     return;
                 }
 
-                String normalized = normalize(testNameStr);
-                Path src = Paths.get(videoFolder).resolve(normalized);
+                Path src = Paths.get(videoFolder).resolve(normalize(testNameStr));
                 if (!Files.exists(src)) {
                     return;
                 }

--- a/src/main/java/org/jenkinsci/test/acceptance/recorder/TestRecorderRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/recorder/TestRecorderRule.java
@@ -57,6 +57,10 @@ public class TestRecorderRule extends TestWatcher {
 
     @Override
     protected void starting(Description description) {
+        if (System.getenv("VIDEO_FOLDER") != null) {
+            // Handled by Selenium in FallbackConfig
+            return;
+        }
         if (isRecorderEnabled()) {
             startRecording(description);
         }
@@ -101,6 +105,10 @@ public class TestRecorderRule extends TestWatcher {
 
     @Override
     protected void succeeded(Description description) {
+        if (System.getenv("VIDEO_FOLDER") != null) {
+            // Handled by Selenium in FallbackConfig
+            return;
+        }
         if (this.screenRecorder != null && !this.headless) {
             if (saveAllExecutions()) {
                 stopRecordingWithFinalWaiting();
@@ -113,14 +121,18 @@ public class TestRecorderRule extends TestWatcher {
 
     @Override
     protected void finished(Description description) {
+        if (System.getenv("VIDEO_FOLDER") != null) {
+            // Handled by Selenium in FallbackConfig
+            return;
+        }
         stopRecordingWithFinalWaiting();
     }
 
-    private boolean isRecorderEnabled() {
+    public static boolean isRecorderEnabled() {
         return !OFF.equals(RECORDER_OPTION);
     }
 
-    private boolean saveAllExecutions() {
+    public static boolean saveAllExecutions() {
         return ALWAYS.equals(RECORDER_OPTION);
     }
 

--- a/src/test/java/org/jenkinsci/test/acceptance/recorder/TestRecorderRuleTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/recorder/TestRecorderRuleTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.jenkinsci.test.acceptance.Matchers.existingFile;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import org.jenkinsci.test.acceptance.guice.TestName;
@@ -15,6 +16,7 @@ public class TestRecorderRuleTest {
 
     @Test
     public void shouldNotRecordSuccessTestExecutionByDefault() {
+        assumeTrue(System.getenv("VIDEO_FOLDER") == null);
 
         final String oldMode = updateRecorderToDefaultOption();
 
@@ -40,6 +42,7 @@ public class TestRecorderRuleTest {
 
     @Test
     public void shouldRecordFailingTestExecutionByDefault() {
+        assumeTrue(System.getenv("VIDEO_FOLDER") == null);
 
         final String oldValue = updateRecorderToDefaultOption();
 
@@ -65,6 +68,7 @@ public class TestRecorderRuleTest {
 
     @Test
     public void shouldRecordSuccessTestExecutionWhenSaveAll() {
+        assumeTrue(System.getenv("VIDEO_FOLDER") == null);
 
         final String oldValue = updateRecorderToDefaultOption();
         try {
@@ -92,6 +96,7 @@ public class TestRecorderRuleTest {
 
     @Test
     public void shouldNotRecordWhenRecorderIsDisabled() {
+        assumeTrue(System.getenv("VIDEO_FOLDER") == null);
 
         try {
             // Since configured recorder option is static we need to set it manually in each test.


### PR DESCRIPTION
Fixes #1041

In #2010 we observed that Monte was crashing Selenium on Java 17, so we turned off recording there. This PR removes that workaround and re-enables recording everywhere by moving from Monte to Selenium's native recording system. This also fixes #1041.

See the docs here: https://github.com/SeleniumHQ/docker-selenium?tab=readme-ov-file#video-recording

This PR does not remove Monte, since CloudBees is still using it. But when `VIDEO_FOLDER` is set we now use the native Selenium system. This triggers writing out a recording when the Selenium WebDriver is closed, which we then fish out and move to where Monte would have placed it. Once CloudBees switches to this new system, the Monte code can be deleted.

### Testing done

Ensured that the videos could be opened on a macOS system.
Tested with failing tests in #2018

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
