### PR TITLE
Clean up Chrome support in `FallbackConfig`

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/FallbackConfig.java
@@ -195,6 +195,9 @@ public class FallbackConfig extends AbstractModule {
             chromeOptions.setProxy(createSeleniumProxy(testName.get()));
         }
         setDriverPropertyIfMissing("chromedriver", ChromeDriverService.CHROME_DRIVER_EXE_PROPERTY);
+        chromeOptions.setCapability("se:name", testName.get());
+        chromeOptions.setCapability(
+                "se:recordVideo", TestRecorderRule.isRecorderEnabled() && System.getenv("VIDEO_FOLDER") != null);
         return chromeOptions;
     }
 


### PR DESCRIPTION
Pending #2025, at least get the Chrome build to start by consolidating the various Chrome configuration paths into one method, like Firefox, and enabling BiDi there. This also switches us to `RemoteWebDriver.builder` which is slightly more readable and avoids the need for `org.openqa.selenium.remote.Augmenter`.

### Testing done

Extracted from #2018.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
