### PR TITLE
Fix Docker build warnings

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu:noble
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -43,7 +43,7 @@ ARG MAVEN_VERSION=3.9.9
 RUN curl -fsSLO "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
     tar -xvzf "apache-maven-${MAVEN_VERSION}-bin.tar.gz" -C /opt/ && \
     mv "/opt/apache-maven-${MAVEN_VERSION}" /opt/maven
-ENV PATH "$PATH:/opt/maven/bin"
+ENV PATH="$PATH:/opt/maven/bin"
 
 COPY run.sh /usr/bin
 COPY set-java.sh /usr/bin
@@ -60,5 +60,5 @@ RUN deluser --remove-home ubuntu \
 RUN chmod u+s "$(which update-alternatives)"
 
 USER ath-user
-ENV USER ath-user
+ENV USER=ath-user
 WORKDIR /home/ath-user


### PR DESCRIPTION
```
 => WARN: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 7)                                                                                                                0.0s
 => WARN: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 50)                                                                                                               0.0s
 => WARN: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 67)                                                                                                               0.0s
```

### Testing done

CI build

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
