### PR TITLE
Support Fedora Linux

### DIFF
--- a/ath-container.sh
+++ b/ath-container.sh
@@ -5,7 +5,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 # Obtain the group ID to grant to access the Docker socket
 if [[ -z ${DOCKER_GID:-} ]]; then
-	DOCKER_GID=$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ubuntu:noble stat -c %g /var/run/docker.sock) || exit 1
+	DOCKER_GID=$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:Z ubuntu:noble stat -c %g /var/run/docker.sock) || exit 1
 	export DOCKER_GID
 fi
 
@@ -13,7 +13,7 @@ fi
 
 trap 'docker-compose kill && docker-compose down' EXIT
 
-docker-compose run --name mvn --rm -P -v "${HOME}/.m2/repository:/home/ath-user/.m2/repository" mvn bash -c 'set-java.sh 17; bash'
+docker-compose run --name mvn --rm -P -v "${HOME}/.m2/repository:/home/ath-user/.m2/repository:Z" mvn bash -c 'set-java.sh 17; bash'
 status=$?
 
 exit $status

--- a/build-image.sh
+++ b/build-image.sh
@@ -16,7 +16,7 @@ fi
 
 # Obtain the group ID to grant to access the Docker socket
 if [[ -z ${DOCKER_GID:-} ]]; then
-	DOCKER_GID=$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ubuntu:noble stat -c %g /var/run/docker.sock) || exit 1
+	DOCKER_GID=$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:Z ubuntu:noble stat -c %g /var/run/docker.sock) || exit 1
 	export DOCKER_GID
 fi
 

--- a/ci.sh
+++ b/ci.sh
@@ -7,13 +7,13 @@ jenkinsVersion="$3"
 
 # Obtain the group ID to grant to access the Docker socket
 if [[ -z ${DOCKER_GID:-} ]]; then
-	DOCKER_GID=$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ubuntu:noble stat -c %g /var/run/docker.sock) || exit 1
+	DOCKER_GID=$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:Z ubuntu:noble stat -c %g /var/run/docker.sock) || exit 1
 	export DOCKER_GID
 fi
 
 trap 'docker-compose kill && docker-compose down' EXIT
 
-docker-compose run -e "MAVEN_ARGS=${MAVEN_ARGS}" --name mvn -T --rm -v "${MAVEN_SETTINGS}:${MAVEN_SETTINGS}" mvn bash -s <<-INSIDE
+docker-compose run -e "MAVEN_ARGS=${MAVEN_ARGS}" --name mvn -T --rm -v "${MAVEN_SETTINGS}:${MAVEN_SETTINGS}:Z" mvn bash -s <<-INSIDE
 	set-java.sh ${jdk}
 
 	# Ensure that Jenkins node setup does not influence the container Java setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 ---
 services:
   init_video:
+    container_name: init_video
     image: ubuntu:noble
     command: >
-      sh -c "mkdir -p /tmp/videos && chmod 0777 /tmp/videos"
+      sh -c 'chown 1000:1000 /videos && chmod 0777 /videos'
+    user: root
     volumes:
-      - shared_tmp:/tmp
+      - videos:/videos:z
   firefox:
     container_name: firefox
     environment:
@@ -23,7 +25,7 @@ services:
       - 5900:5900  # VNC port
     shm_size: 2g
     volumes:
-      - shared_tmp:/tmp
+      - videos:/videos:z
   video:
     container_name: video
     depends_on:
@@ -36,12 +38,12 @@ services:
       - SE_VIDEO_FILE_NAME=auto
       - SE_VIDEO_FILE_NAME_SUFFIX=false
       - SE_VIDEO_RECORD_STANDALONE=true
-      - VIDEO_FOLDER=/tmp2/videos
+      - VIDEO_FOLDER=/videos
     image: selenium/video:ffmpeg-7.1-20250515@sha256:5e283b26b1bb14cabb03b31aaf7d88348e93e92d82b0e1704780611bef129964
     networks:
       - ath-network
     volumes:
-      - shared_tmp:/tmp2  # Avoid conflict with supervisord
+      - videos:/videos:z
   mvn:
     build:
       context: src/main/resources/ath-container
@@ -60,7 +62,7 @@ services:
       - SELENIUM_PROXY_HOSTNAME=mvn
       - SHARED_DOCKER_SERVICE=true
       - TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
-      - VIDEO_FOLDER=/tmp/videos
+      - VIDEO_FOLDER=/videos
     extra_hosts:
       - host.docker.internal:host-gateway
     group_add:
@@ -73,16 +75,16 @@ services:
     shm_size: 2g
     user: ath-user
     volumes:
-      - ${PWD}:/home/ath-user/sources
-      - shared_tmp:/tmp
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${PWD}:/home/ath-user/sources:Z
+      - videos:/videos:z
+      - /var/run/docker.sock:/var/run/docker.sock:Z
     working_dir: /home/ath-user/sources
 networks:
   ath-network:
     name: ath-network
     attachable: true
 volumes:
-  shared_tmp:
+  videos:
     driver: local
     driver_opts:
       type: tmpfs

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/logparser/LogParserPublisher.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/logparser/LogParserPublisher.java
@@ -6,6 +6,7 @@ import org.jenkinsci.test.acceptance.po.Control;
 import org.jenkinsci.test.acceptance.po.Describable;
 import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.PostBuildStep;
+import org.jenkinsci.test.acceptance.selenium.UselessFileDetectorReplacement;
 
 /**
  * Helperclass for configuring the logparser plugin.
@@ -97,6 +98,8 @@ public class LogParserPublisher extends AbstractStep implements PostBuildStep {
      * @param resource The {@link Resource} object of a rule file.
      */
     public void setRule(Resource resource) {
-        setRule(RuleType.PROJECT, resource.url.getPath());
+        try (UselessFileDetectorReplacement ufd = new UselessFileDetectorReplacement(driver)) {
+            setRule(RuleType.PROJECT, resource.url.getPath());
+        }
     }
 }

--- a/src/test/java/plugins/ConfigurationAsCodeTest.java
+++ b/src/test/java/plugins/ConfigurationAsCodeTest.java
@@ -31,6 +31,7 @@ import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.configuration_as_code.JcascManage;
 import org.jenkinsci.test.acceptance.po.JenkinsConfig;
+import org.jenkinsci.test.acceptance.selenium.UselessFileDetectorReplacement;
 import org.junit.Test;
 
 @WithPlugins("configuration-as-code")
@@ -41,7 +42,10 @@ public class ConfigurationAsCodeTest extends AbstractJUnitTest {
 
         JcascManage jm = new JcascManage(jenkins);
         jm.open();
-        jm.configure(resource("/configuration_as_code/trivial.yaml").asFile().getAbsolutePath());
+        try (UselessFileDetectorReplacement ufd = new UselessFileDetectorReplacement(driver)) {
+            jm.configure(
+                    resource("/configuration_as_code/trivial.yaml").asFile().getAbsolutePath());
+        }
 
         assertThat(jenkins.open(), hasContent(EXPECTED_DESC));
 


### PR DESCRIPTION
Unlike Ubuntu Linux, Fedora uses SELinux instead of AppArmor, which requires the ":Z" option when bind-mounting local volumes into the container. From the man page:

> To change a label in the container context, you can add either of two suffixes :z or :Z to the volume mount. These suffixes tell Docker to relabel file objects on the shared volumes. The z option tells Docker that two containers share the volume content. As a result, Docker labels the content with a shared content label. Shared volume labels allow all containers to read/write content.  The Z option tells Docker to label the content with a private unshared label. Only the current container can use a private volume.

Using the :Z option on an Ubuntu system with Docker does not cause harm, but it is effectively ignored since SELinux is not active. Docker will still process the bind mount, and the container should function as expected, provided the AppArmor profile (if any) allows the necessary access. By default, Docker on Ubuntu ships with AppArmor profiles that are permissive enough for most bind-mount use cases.

### Implementation notes

I also had to remove the shared temporary directory, as it was not compatible with SELinux either. Fortunately it does not appear to be needed.

### Testing done

Ran `./ath-container.sh` on Fedora.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
