### PR TITLE
chore(Jenkinsfile.infra.ci.jenkins.io) enable Docker image `cache-to` parameter

### DIFF
--- a/Jenkinsfile.infra.ci.jenkins.io
+++ b/Jenkinsfile.infra.ci.jenkins.io
@@ -5,4 +5,5 @@ buildDockerAndPublishImage('ath', [
   dockerfile: 'src/main/resources/ath-container/Dockerfile',
   imageDir: 'src/main/resources/ath-container/',
   registryNamespace: 'jenkins',
+  cacheTo: 'type=registry,ref=jenkins/ath:build-cache',
 ])


### PR DESCRIPTION
Ref: https://github.com/jenkinsci/acceptance-test-harness/issues/2039 (and https://github.com/jenkins-infra/helpdesk/issues/4683 for infra)

This PR tests the `cacheTo` parameter provided in the new `buildDockerAndPublishImage` pipeline library. 
Success should generate a cache export to jenkins/ath
### Testing done

- [x] Tested the make file locally with cache export successfully to dockerhub. 
- [x] https://github.com/jenkins-infra/pipeline-library/pull/940 had successful unit tests passed on infra.ci
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
