### PR TITLE
Test JGit 7.3.0 as part of git client 6.2.0 pre-release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,9 @@ and
           </systemPropertyVariables>
           <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
           <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+          <environmentVariables>
+            <LOCAL_JARS>target/git-client.hpi</LOCAL_JARS>
+          </environmentVariables>
           <runOrder>alphabetical</runOrder>
         </configuration>
       </plugin>
@@ -790,6 +793,13 @@ and
                       <artifactId>jenkins-war</artifactId>
                       <version>${jenkins.version}</version>
                       <type>war</type>
+                    </artifactItem>
+                    <!-- https://github.com/jenkinsci/git-client-plugin/pull/1262 -->
+                    <artifactItem>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>git-client</artifactId>
+                      <version>6.2.0-rc3800.2128f546d212</version>
+                      <type>hpi</type>
                     </artifactItem>
                   </artifactItems>
                   <outputDirectory>${project.build.directory}</outputDirectory>


### PR DESCRIPTION
## Test JGit 7.3.0 as part of git client 6.2.0 pre-release

JGit 7.0.0 is currently included in git client plugin 6.1.3.  JGit 7.2.0 had a file leak that I was unable to resolve before the release of JGIt 7.3.0.  The Gradle developers found a workaround that has been applied in a pre-release build of the Git Client Plugin 6.2.0.  Test that pre-release build in the acceptance test harness.

* https://github.com/jenkinsci/git-client-plugin/pull/1262
* https://github.com/jenkinsci/bom/pull/5199

### Testing done

None.  Relying on ci.jenkins.io to perform the tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
