### PR TITLE
Dialog fix

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -422,8 +422,10 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     public void runThenHandleDialog(Runnable runnable) {
         try {
             runnable.run();
-            waitFor(by.button("Yes"));
-            clickButton("Yes");
+            WebElement button = waitFor(by.button("Yes"));
+            button.click();
+            // wait for the dialog to be dismissed
+            waitFor(button).until(CapybaraPortingLayerImpl::isStale);
         } catch (UnhandledAlertException uae) {
             runThenConfirmAlert(runnable, 2);
         }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/CapybaraPortingLayerImpl.java
@@ -440,9 +440,11 @@ public class CapybaraPortingLayerImpl implements CapybaraPortingLayer {
     public void runThenHandleInputDialog(Runnable runnable, String input, String buttonLabel) {
         try {
             runnable.run();
-            waitFor(by.button(buttonLabel));
+            WebElement button = waitFor(by.button(buttonLabel));
             find(by.css("dialog input")).sendKeys(input);
-            clickButton(buttonLabel);
+            button.click();
+            // wait for the dialog to be dismissed
+            waitFor(button).until(CapybaraPortingLayerImpl::isStale);
         } catch (UnhandledAlertException uae) {
             runThenHandleAlert(
                     runnable,


### PR DESCRIPTION
 Wait until the diaglog has been dismissed

Observed issues when settiing up matrix auth without the custom scroller
that adding a second user to the table would not always work as the
button was not clickable as the dialog was still in the process of being dismissed.

After this change the flake was no longer observed.

### Testing done

running the ATH with scroller modifications before this change failed, and passed afterwards

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
