### PR TITLE
correctly wait when setting the admin user

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/WizardCreateAdminUser.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WizardCreateAdminUser.java
@@ -65,12 +65,8 @@ public class WizardCreateAdminUser extends PageObject {
         }
 
         driver.switchTo().defaultContent();
-        control(by.css(".btn-primary.save-first-user")).click();
+        control(by.css(".btn-primary.save-first-user")).clickAndWaitToBecomeStale(Duration.ofSeconds(time.seconds(5)));
         return this;
-    }
-
-    public void shouldCreateTheUserSuccessfully() {
-        waitFor(hasContent("Jenkins is ready!"));
     }
 
     public void confirmURLSettings() {

--- a/src/test/java/core/InstallWizardTest.java
+++ b/src/test/java/core/InstallWizardTest.java
@@ -68,7 +68,6 @@ public class InstallWizardTest extends AbstractJUnitTest {
         WizardCreateAdminUser createAdmin = new WizardCreateAdminUser(jenkins);
 
         createAdmin.createAdminUser(USERNAME, PASSWORD, FULL_NAME, EMAIL);
-        createAdmin.shouldCreateTheUserSuccessfully();
         createAdmin.confirmURLSettings();
         createAdmin.wizardShouldFinishSuccessfully();
 
@@ -105,7 +104,6 @@ public class InstallWizardTest extends AbstractJUnitTest {
         WizardCreateAdminUser createAdmin = new WizardCreateAdminUser(jenkins);
 
         createAdmin.createAdminUser(USERNAME, PASSWORD, FULL_NAME, EMAIL);
-        createAdmin.shouldCreateTheUserSuccessfully();
         createAdmin.confirmURLSettings();
         createAdmin.wizardShouldFinishSuccessfully();
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The wizard testing was flaky.  was using implicit wait of 1s (non elastic) which had been observed to randomly fail.

[Cloudbeees internal issue](https://cloudbees.atlassian.net/browse/BEE-15894)
### Testing done

extracted and tested in #2219 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
