### PR TITLE
only check CSP if test passes

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/junit/CspRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/junit/CspRule.java
@@ -33,16 +33,13 @@ public final class CspRule implements TestRule {
                     security.disableCspReportOnly();
                     security.save();
                 }
-                try {
-                    base.evaluate();
-                } finally {
-                    if (isEnabled() && !isSkipped()) {
-                        ContentSecurityPolicyReport csp = new ContentSecurityPolicyReport(jenkins);
-                        jenkins.runThenHandleUserPrompt(() -> csp.open());
-                        List<String> lines = csp.getReport();
-                        if (lines.size() > 2) {
-                            throw new AssertionError(String.join("\n", lines));
-                        }
+                base.evaluate();
+                if (isEnabled() && !isSkipped()) {
+                    ContentSecurityPolicyReport csp = new ContentSecurityPolicyReport(jenkins);
+                    jenkins.runThenHandleUserPrompt(() -> csp.open());
+                    List<String> lines = csp.getReport();
+                    if (lines.size() > 2) {
+                        throw new AssertionError(String.join("\n", lines));
                     }
                 }
             }


### PR DESCRIPTION
if a test fails do not attempt to check for CSP violations. Doing the check prevents the screenshot capture from capturing the screenshot of the page we where on when the test failed as the rule does navigation to obtain the results of the check.

The check could also be improved in the plugin to allow an API like access so that we do not even need to use Selenium but this change should be good enough.

<!-- Please describe your pull request here. -->

### Testing done

None.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
