### PR TITLE
Remove unused parameter-separator plugin from MetricsTest

### DIFF
--- a/src/test/java/plugins/MetricsTest.java
+++ b/src/test/java/plugins/MetricsTest.java
@@ -46,7 +46,7 @@ public class MetricsTest extends AbstractPipelineTest {
     private final Logger LOGGER = Logger.getLogger(MetricsTest.class.getName());
 
     @Test
-    @WithPlugins({"metrics", "parameter-separator"})
+    @WithPlugins("metrics")
     public void testMetrics() throws IOException {
         this.checkHealthcheck();
         this.checkPing();


### PR DESCRIPTION
`parameter-separator` is not used in the test and serves no purpose.

In CloudBees proprietery suite we disable internet access to catch/reduce flakyness but as this plugin is not supported by us it can not be installed leading to a failure of the test.

Given it is not needed for the test, I am removing it.

[CloudBees internal issue](https://cloudbees.atlassian.net/browse/BEE-35376)

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
