### PR TITLE
Enable Optional geckodriver tracing

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/Config.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/Config.java
@@ -61,6 +61,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxDriverLogLevel;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.GeckoDriverService;
 import org.openqa.selenium.remote.CapabilityType;
@@ -105,6 +106,10 @@ public class Config extends AbstractModule {
                 GeckoDriverService.Builder builder = new GeckoDriverService.Builder();
                 if (display != null) {
                     builder.withEnvironment(Map.of("DISPLAY", display));
+                }
+                if (System.getenv("FIREFOX_TRACE") != null) {
+                    builder.withLogLevel(FirefoxDriverLogLevel.fromString(System.getenv("FIREFOX_TRACE")));
+                    builder.withLogOutput(System.out);
                 }
                 GeckoDriverService service = builder.build();
                 return new FirefoxDriver(service, buildFirefoxOptions(testName));


### PR DESCRIPTION
By setting `FIREFOX_TRACE` you can now obrain the firefox driver logs for debugging potential firefox issues.

<!-- Please describe your pull request here. -->

### Testing done

running `mvn test-Dtest=someTest` with this PR and the environment variable `FIREFOX_TRACE=TRACE` and observing trace output from the test

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
