### PR TITLE
Cleanup suggested plugins and wait correctly

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/WizardCustomizeJenkins.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/WizardCustomizeJenkins.java
@@ -47,9 +47,9 @@ public class WizardCustomizeJenkins extends PageObject {
 
     public WizardCustomizeJenkins doInstallSuggested() {
         By suggestedButtonLocator = by.partialLinkText("Install suggested plugins");
-        waitFor(suggestedButtonLocator, 30);
-        Control installSuggested = control(suggestedButtonLocator);
+        WebElement installSuggested = waitFor(suggestedButtonLocator, 30);
         installSuggested.click();
+        waitFor(installSuggested).until(CapybaraPortingLayerImpl::isStale);
         return this;
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

it is idiotic to wait for an element and then immediately after search for it again.
We now keep the reference and we wait for the button to become stale before returning.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
