### PR TITLE
Test JUnit upgrade in war and git client plugin 6.5.0 pre-release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -493,6 +493,9 @@ and
           </systemPropertyVariables>
           <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
           <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+          <environmentVariables>
+            <LOCAL_JARS>target/git-client.hpi</LOCAL_JARS>
+          </environmentVariables>
         </configuration>
       </plugin>
       <plugin>
@@ -765,6 +768,14 @@ and
                       <artifactId>jenkins-war</artifactId>
                       <version>${jenkins.version}</version>
                       <type>war</type>
+                    </artifactItem>
+                    <!-- TODO: Git client plugin 6.5.0 pre-release -->
+                    <!-- Updates to JGit 7.5.0 -->
+                    <artifactItem>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>git-client</artifactId>
+                      <version>6.5.0-rc3823.cd347714f0e2</version>
+                      <type>hpi</type>
                     </artifactItem>
                   </artifactItems>
                   <outputDirectory>${project.build.directory}</outputDirectory>


### PR DESCRIPTION
## Test JUnit upgrade and git client plugin 6.5.0 pre-release

Check that the addition of prism-api to the Jenkins war file does not cause issues in the acceptance test harness.

Check that the upgrade from JGit 7.4.0 to JGit 7.5.0 does not cause issues.

Pull requests include:

* https://github.com/jenkinsci/bom/pull/6084
* https://github.com/jenkinsci/git-client-plugin/pull/1367
* https://github.com/jenkinsci/git-client-plugin/pull/1706

### Testing done

None.  Rely on ci.jenkins.io

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~Link to relevant issues in GitHub or Jira~
- ~Ensure you have provided tests that demonstrate the feature works or the issue is fixed~
