### PR TITLE
Switch to jenkinsci/renovate-config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":semanticCommitsDisabled",
+    "github>jenkinsci/renovate-config",
     "schedule:daily"
   ],
   "automerge": true,
@@ -42,9 +41,6 @@
         "/selenium/"
       ]
     }
-  ],
-  "labels": [
-    "dependencies"
   ],
   "customManagers": [
     {
@@ -122,6 +118,5 @@
       "defaultRegistryUrlTemplate": "https://updates.jenkins.io/stable/latestCore.txt",
       "format": "plain"
     }
-  },
-  "rebaseWhen": "conflicted"
+  }
 }


### PR DESCRIPTION
As the title says, switching to [jenkinsci/renovate-config](https://github.com/jenkinsci/renovate-config?rgh-link-date=2025-12-27T20%3A17%3A48Z), building the baseline for Jenkins' renovate config.