### PR TITLE
(Placeholder) Use Java 21 container in SshAgentContainer

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshAgentContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshAgentContainer/Dockerfile
@@ -1,4 +1,4 @@
 # curl -s https://raw.githubusercontent.com/jenkinsci/docker-fixtures/master/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile | sha1sum | cut -c 1-12
-FROM jenkins/java:978f1af53461
+FROM jenkins/java:132f41d4b1a9
 COPY *.pub /tmp
 RUN cat /tmp/*.pub >> /home/test/.ssh/authorized_keys


### PR DESCRIPTION
The tests in `SshSlavesPluginTest` are failing when running with controller compiled for java 21 due agent being still Java 17.
Will be using the image from https://github.com/jenkinsci/docker-fixtures/pull/138


PR should be in draft until the `docker-fixtures` has a release and need to bump https://github.com/jenkinsci/acceptance-test-harness/blob/7b8c43086a6f28acb2b83f57abae9410b5b57eab/pom.xml#L357-L361 

### Testing done

TBU

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
