### PR TITLE
Wait for 'Build Now' link visibility before clicking

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -362,6 +362,8 @@ public class Job extends TopLevelItem {
         open();
         int nb = getJson().get("nextBuildNumber").intValue();
         if (parameters.isEmpty()) {
+            // Wait for "Build Now" link to become visible (JS shows it after page load)
+            waitFor(by.link("Build Now"));
             clickLink("Build Now");
             // the notification bar can place itslef over other elements
             // so wait for it to be added and then disappear


### PR DESCRIPTION
The Jenkins core race condition fix hides the 'Build Now' button (display: none) until JavaScript loads. This caused ATH tests to time out because clickLink('Build Now') couldn't find the hidden element.

This fix adds `waitFor(by.link('Build Now'))` before clicking, which polls until the element is visible (with ATH's default 120s timeout).

Fixes timeouts in:
- core.FreestyleJobTest.doNotDiscardSuccessfulBuilds
- core.FreestyleJobTest.archiveArtifacts
- core.TriggerRemoteBuildsTest.triggerBuildRemotely

### Testing done

The fix was tested by reviewing the CI failure logs which showed all 3 tests failing at `Job.scheduleBuild(Job.java:368)` when calling `clickLink("Build Now")`. The tests timed out after 120 seconds waiting for an element that was hidden.

The `waitFor(by.link("Build Now"))` method polls until the element becomes visible, using ATH's existing wait infrastructure. This is the same pattern already used elsewhere in the codebase (e.g., the notification-bar wait on the following line).

Related upstream change: https://github.com/jenkinsci/jenkins/pull/26124 (Jenkins core race condition fix)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

Desired revierwe
@timja @mawinter69 @MarkEWaite 