### PR TITLE
Correctly setup I/O for subprocesses

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
@@ -13,6 +13,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -22,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -149,30 +151,43 @@ public class GitRepo implements Closeable {
         try {
             var log = Logger.getLogger("GitRepo");
             var start = Instant.now();
-            Process p = pb.directory(dir).redirectErrorStream(true).start();
+            Process p = pb.directory(dir).start();
             long pid = p.pid();
 
             // we are not sending any input to the process so close the stream
             p.getOutputStream().close();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
-            StringBuilder builder = new StringBuilder();
-            String line;
-            while ((line = reader.readLine()) != null) {
-                builder.append(line);
-                builder.append(System.lineSeparator());
-            }
+            final StringBuilder outBuilder = new StringBuilder();
+            final StringBuilder errBuilder = new StringBuilder();
+
+            Thread outThread =
+                    new Thread(new StreamReader(p.getInputStream(), outBuilder), "git command std.out reader");
+            Thread errThread =
+                    new Thread(new StreamReader(p.getErrorStream(), errBuilder), "git command std.err reader");
+            outThread.start();
+            errThread.start();
+            outThread.join();
+            errThread.join();
 
             int r = p.waitFor();
-            log.fine(() -> "Running " + pb.command().toString() + " (pid " + pid + ") in " + dir + " took "
-                    + java.time.Duration.between(start, Instant.now()) + " and exited with " + r);
+            log.fine(() -> "Running " + processDebugString(pb, p) + " took " + Duration.between(start, Instant.now())
+                    + " and exited with " + r);
             if (r != 0) {
-                throw new AssertionError(errorMessage + " " + builder);
+                throw new AssertionError(errorMessage + System.lineSeparator() + "output: " + outBuilder.toString()
+                        + System.lineSeparator() + "error: " + errBuilder.toString());
             }
-
-            return builder.toString();
+            String error = errBuilder.toString();
+            if (!error.isBlank()) {
+                log.warning("Git command " + processDebugString(pb, p)
+                        + " error stream was not empty (but returned success): " + error);
+            }
+            return outBuilder.toString();
         } catch (InterruptedException | IOException e) {
             throw new AssertionError(errorMessage, e);
         }
+    }
+
+    private final String processDebugString(ProcessBuilder pb, Process p) {
+        return pb.command().toString() + " (pid " + p.pid() + ") in " + pb.directory();
     }
 
     /**
@@ -441,6 +456,31 @@ public class GitRepo implements Closeable {
             return Files.createDirectories(dir.toPath().resolve(path));
         } catch (IOException e) {
             throw new AssertionError(String.format("Can't created directories %s", path), e);
+        }
+    }
+
+    private static class StreamReader implements Runnable {
+        private final InputStream is;
+        private final StringBuilder output;
+
+        StreamReader(InputStream is, StringBuilder output) {
+            this.is = is;
+            this.output = output;
+        }
+
+        @Override
+        public void run() {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    output.append(line);
+                    output.append(System.lineSeparator());
+                }
+                // EOS close the stream from our side
+                is.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException("failure reading git output/error", e);
+            }
         }
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.test.acceptance.plugins.git;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.JSch;
@@ -13,7 +15,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -32,6 +33,7 @@ import java.util.Properties;
 import java.util.logging.Logger;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
+import org.hamcrest.Matchers;
 import org.jenkinsci.test.acceptance.docker.fixtures.GitContainer;
 import org.zeroturnaround.zip.ZipUtil;
 
@@ -159,14 +161,16 @@ public class GitRepo implements Closeable {
             final StringBuilder outBuilder = new StringBuilder();
             final StringBuilder errBuilder = new StringBuilder();
 
-            Thread outThread =
-                    new Thread(new StreamReader(p.getInputStream(), outBuilder), "git command std.out reader");
-            Thread errThread =
-                    new Thread(new StreamReader(p.getErrorStream(), errBuilder), "git command std.err reader");
+            StreamReader isr = new StreamReader(p.getInputStream(), outBuilder);
+            Thread outThread = new Thread(isr, "git command std.out reader");
+            StreamReader esr = new StreamReader(p.getErrorStream(), errBuilder);
+            Thread errThread = new Thread(esr, "git command std.err reader");
             outThread.start();
             errThread.start();
             outThread.join();
             errThread.join();
+            assertThat(isr.getIOException(), Matchers.nullValue());
+            assertThat(esr.getIOException(), Matchers.nullValue());
 
             int r = p.waitFor();
             log.fine(() -> "Running " + processDebugString(pb, p) + " took " + Duration.between(start, Instant.now())
@@ -462,6 +466,7 @@ public class GitRepo implements Closeable {
     private static class StreamReader implements Runnable {
         private final InputStream is;
         private final StringBuilder output;
+        private IOException e;
 
         StreamReader(InputStream is, StringBuilder output) {
             this.is = is;
@@ -477,8 +482,12 @@ public class GitRepo implements Closeable {
                     output.append(System.lineSeparator());
                 }
             } catch (IOException e) {
-                throw new UncheckedIOException("failure reading git output/error", e);
+                this.e = e;
             }
+        }
+
+        IOException getIOException() {
+            return e;
         }
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
@@ -149,12 +149,11 @@ public class GitRepo implements Closeable {
         try {
             var log = Logger.getLogger("GitRepo");
             var start = Instant.now();
-            Process p = pb.directory(dir)
-                    .redirectInput(ProcessBuilder.Redirect.INHERIT)
-                    .redirectError(ProcessBuilder.Redirect.INHERIT)
-                    .start();
+            Process p = pb.directory(dir).redirectErrorStream(true).start();
             long pid = p.pid();
 
+            // we are not sending any input to the process so close the stream
+            p.getOutputStream().close();
             BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
             StringBuilder builder = new StringBuilder();
             String line;

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/git/GitRepo.java
@@ -476,8 +476,6 @@ public class GitRepo implements Closeable {
                     output.append(line);
                     output.append(System.lineSeparator());
                 }
-                // EOS close the stream from our side
-                is.close();
             } catch (IOException e) {
                 throw new UncheckedIOException("failure reading git output/error", e);
             }

--- a/src/test/java/org/jenkinsci/test/acceptance/plugins/git/GitRepoTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/plugins/git/GitRepoTest.java
@@ -1,7 +1,9 @@
 package org.jenkinsci.test.acceptance.plugins.git;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThrows;
 
 import java.time.Duration;
 import org.junit.Test;
@@ -24,5 +26,13 @@ public class GitRepoTest {
                 "git commands should complete within 10 seconds",
                 elapsed,
                 lessThan(Duration.ofSeconds(10).toNanos()));
+    }
+
+    @Test
+    public void ensureErrorsAreClear() throws Exception {
+        try (GitRepo gr = new GitRepo()) {
+            AssertionError thrown = assertThrows(AssertionError.class, () -> gr.git("non-existing-command"));
+            assertThat(thrown.getMessage(), containsString("'non-existing-command' is not a git command."));
+        }
     }
 }

--- a/src/test/java/org/jenkinsci/test/acceptance/plugins/git/GitRepoTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/plugins/git/GitRepoTest.java
@@ -1,0 +1,28 @@
+package org.jenkinsci.test.acceptance.plugins.git;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+
+import java.time.Duration;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+public class GitRepoTest {
+
+    @Test
+    @Issue("#2701")
+    public void ensureGitCommandsExecuteQuickly() throws Exception {
+        long start = System.nanoTime();
+        try (GitRepo gr = new GitRepo()) {
+            for (int i = 0; i < 5; i++) {
+                gr.git("config", "testing.akey" + i, "" + i);
+            }
+        }
+        long elaspsed = System.nanoTime() - start;
+
+        assertThat(
+                "git commands should compelte within 10 seconds",
+                elaspsed,
+                lessThan(Duration.ofSeconds(10).toNanos()));
+    }
+}

--- a/src/test/java/org/jenkinsci/test/acceptance/plugins/git/GitRepoTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/plugins/git/GitRepoTest.java
@@ -18,11 +18,11 @@ public class GitRepoTest {
                 gr.git("config", "testing.akey" + i, "" + i);
             }
         }
-        long elaspsed = System.nanoTime() - start;
+        long elapsed = System.nanoTime() - start;
 
         assertThat(
-                "git commands should compelte within 10 seconds",
-                elaspsed,
+                "git commands should complete within 10 seconds",
+                elapsed,
                 lessThan(Duration.ofSeconds(10).toNanos()));
     }
 }

--- a/src/test/java/plugins/GitLabPluginTest.java
+++ b/src/test/java/plugins/GitLabPluginTest.java
@@ -352,12 +352,6 @@ public class GitLabPluginTest extends AbstractJUnitTest {
         }
     }
 
-    private void keepSeleniumAlive() {
-        // just enough of a call to webdriver to keep the Selenium session alive.
-        LOGGER.warning("refreshing web page to keep Selenium session alive");
-        driver.navigate().refresh();
-    }
-
     // ==================== Helper Methods ====================
 
     /**
@@ -430,12 +424,6 @@ public class GitLabPluginTest extends AbstractJUnitTest {
             repo.setAndCommitFile("Jenkinsfile", content, "Initial commit");
             repo.git("push", "-u", "origin", branchName);
         }
-        // on my windows box running `git` as invoked here takes 10s where-as running the same commands
-        // outside the project take ~0.1s
-        // this length of time all adds up to > 6 minutes at which point the selenium session has timeout out (5min)
-        // as an interim until I can find why this happens, just make some webdriver calls to keep the session
-        // alive between the calls.
-        keepSeleniumAlive();
     }
 
     private void setupBranchFromViaGit(String repoUrl, String branchName, String sourceRef, String content)
@@ -447,12 +435,6 @@ public class GitLabPluginTest extends AbstractJUnitTest {
 
             repo.git("push", "origin", branchName);
         }
-        // on my windows box running `git` as invoked here takes 10s where-as running the same commands
-        // outside the project take ~0.1s
-        // this length of time all adds up to > 6 minutes at which point the selenium session has timeout out (5min)
-        // as an interim until I can find why this happens, just make some webdriver calls to keep the session
-        // alive between the calls.
-        keepSeleniumAlive();
     }
 
     // ==================== GitLab API ====================


### PR DESCRIPTION
As we are handling the streams we must use PIPE (the default) not INHERIT.

On windows this caused delays of approx 10s, presumable waiting for surefire to read the error stream.  But we want the error stream anyway as it will contain errors, and the message is used when the process exits with non zero status.

Rather than handle the error stream specially, just redirect it to the output.

fixes: #2701

<!-- Please describe your pull request here. -->

### Testing done

ran the new test before the fix and observed it failed.  
ran the test with the fixed code 10 times and did not observe any failures
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
