### PR TITLE
chore(ath-container) ensure Maven download falls back to Apache archive if not using the latest version yet

### DIFF
--- a/src/main/resources/ath-container/Dockerfile
+++ b/src/main/resources/ath-container/Dockerfile
@@ -38,15 +38,21 @@ RUN install -m 0755 -d /etc/apt/keyrings \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Maven in repo is not new enough for ATH
 ARG MAVEN_VERSION=3.9.16
-RUN curl -fsSLO "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
-    curl -fsSLO "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512" && \
-    echo "$(cat apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512)  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum --check --strict && \
-    tar -xvzf "apache-maven-${MAVEN_VERSION}-bin.tar.gz" -C /opt/ && \
-    mv "/opt/apache-maven-${MAVEN_VERSION}" /opt/maven && \
-    rm "apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
-    rm "apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512"
+# Note: falling back to Apache archive if the release is not the latest one. But defaults to mirror distribution system is good for Apache.
+# TODO: switch from checking sha512 to verify GPG signature - https://www.apache.org/info/verification.html
+RUN { \
+  curl -fsSLO "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+  || curl -fsSLO "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"; \
+  } && { \
+  curl -fsSLO "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512" \
+  || curl -fsSLO "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512"; \
+  } && \
+  echo "$(cat apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512)  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum --check --strict && \
+  tar -xvzf "apache-maven-${MAVEN_VERSION}-bin.tar.gz" -C /opt/ && \
+  mv "/opt/apache-maven-${MAVEN_VERSION}" /opt/maven && \
+  rm "apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
+  rm "apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512"
 ENV PATH="$PATH:/opt/maven/bin"
 
 COPY run.sh /usr/bin


### PR DESCRIPTION
The goal of this PR is to ensure the build of the `ath-container` image does not fail when a new Maven release is available on Apache servers.

It ensures a fallback to Apache Archive when the download from download servers fails (HTTP/404 or any other HTTP error). 
Keeping the default from Apache mirrors ensures we don't hammer too much their download infrastructure.

Same technique as for the Jenkins infra. agents: https://github.com/jenkins-infra/packer-images/blob/58e5176e8789e70a9fa0d1eedcadacb674b2f57b/provisioning/ubuntu-provision.sh#L372

### Testing done

- Building with current 3.9.16 version of Maven works (nominal case)
- Setting up the `MAVEN_VERSION` `ARG` to the `3.9.15` also works, while it failed before my change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
