### PR TITLE
Add acceptance test coverage for parameterized pipelines

### DIFF
--- a/src/test/java/plugins/PipelineTest.java
+++ b/src/test/java/plugins/PipelineTest.java
@@ -66,9 +66,8 @@ public class PipelineTest extends AbstractPipelineTest {
 
     @Test
     public void testParameterizedPipeline() {
-        final WorkflowJob job = createPipelineJobWithScript("node {\n"
-                + "  echo \"param is ${params.MY_PARAM}\"\n"
-                + "}");
+        final WorkflowJob job =
+                createPipelineJobWithScript("node {\n" + "  echo \"param is ${params.MY_PARAM}\"\n" + "}");
 
         job.configure();
         job.addParameter(StringParameter.class).setName("MY_PARAM").setDefault("default-val");

--- a/src/test/java/plugins/PipelineTest.java
+++ b/src/test/java/plugins/PipelineTest.java
@@ -47,7 +47,6 @@ import org.junit.Test;
  * 4- Assert results have been collected
  *
  */
-@WithPlugins({"git", "junit", "javadoc"})
 public class PipelineTest extends AbstractPipelineTest {
 
     @Before
@@ -56,6 +55,7 @@ public class PipelineTest extends AbstractPipelineTest {
     }
 
     @Test
+    @WithPlugins({"git", "junit", "javadoc"})
     public void testCompletePipeline() {
         final WorkflowJob job = createPipelineJobWithScript(scriptForPipeline());
         final Build b = job.startBuild().shouldBeUnstable(); // Successful build with test failures
@@ -66,8 +66,9 @@ public class PipelineTest extends AbstractPipelineTest {
 
     @Test
     public void testParameterizedPipeline() {
-        final WorkflowJob job =
-                createPipelineJobWithScript("node {\n" + "  echo \"param is ${params.MY_PARAM}\"\n" + "}");
+        final WorkflowJob job = createPipelineJobWithScript("""
+                echo "param is ${params.MY_PARAM}"
+                """);
 
         job.configure();
         job.addParameter(StringParameter.class).setName("MY_PARAM").setDefault("default-val");

--- a/src/test/java/plugins/PipelineTest.java
+++ b/src/test/java/plugins/PipelineTest.java
@@ -23,14 +23,18 @@
  */
 package plugins;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Map;
 import org.apache.commons.lang3.SystemUtils;
 import org.jenkinsci.test.acceptance.AbstractPipelineTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
 import org.jenkinsci.test.acceptance.plugins.junit.TestReport;
 import org.jenkinsci.test.acceptance.plugins.maven.MavenInstallation;
 import org.jenkinsci.test.acceptance.po.Build;
+import org.jenkinsci.test.acceptance.po.StringParameter;
 import org.jenkinsci.test.acceptance.po.WorkflowJob;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,6 +62,20 @@ public class PipelineTest extends AbstractPipelineTest {
 
         this.assertTestResult(b);
         this.assertJavadoc(job);
+    }
+
+    @Test
+    public void testParameterizedPipeline() {
+        final WorkflowJob job = createPipelineJobWithScript("node {\n"
+                + "  echo \"param is ${params.MY_PARAM}\"\n"
+                + "}");
+
+        job.configure();
+        job.addParameter(StringParameter.class).setName("MY_PARAM").setDefault("default-val");
+        job.save();
+
+        final Build b = job.startBuild(Map.of("MY_PARAM", "custom-val")).shouldSucceed();
+        assertThat(b.getConsole(), containsString("param is custom-val"));
     }
 
     @Override


### PR DESCRIPTION
Hi,

I've added the test coverage for parameterized pipelines to cover the gap mentioned in #2690.

Fixes #2690

Earlier in Jenkins 2.560, triggering a pipeline with parameters threw a ClassCastException (JENKINS-26683), but we didn't had any test in ATH to catch it.

I added a new testcase `testParameterizedPipeline` in `PipelineTest.java`. It defines a string parameter on job, saves the configuration and then runs build with custom parameter value to check if it succeeds and prints correct value in console output.

Tested it locally and it works fine. Let me know if any change is needed.

Thanks!