### PR TITLE
Copying a job was flaky.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/JobsMixIn.java
@@ -86,14 +86,13 @@ public class JobsMixIn extends MixIn {
     public void copy(String from, String to) {
         visit("newJob");
 
-        // Newer versions of Jenkins have an additional radio before the 'from' input is available, so click it
-        all(by.radioButton("Duplicate an existing item")).forEach(WebElement::click);
-
-        fillIn("from", from);
-        // There is a javascript magic bound to loss of focus on 'from' field that is a pain to duplicate through
-        // selenium
-        // explicitly. Here, it is done so by setting 'to' afterwards.
         fillIn("name", to);
+
+        find(by.radioButton("Duplicate an existing item")).click();
+        fillIn("from", from);
+
+        // do not wait for the OK button to be enabled
+        // some tests check that this fails due to the job already existing.
         clickButton("OK");
     }
 


### PR DESCRIPTION
The list of job types available is loaded asynchronously, this means that whilst the page was loaded (the DOM is ready) the scripts may not have run to fetch and populate the item type list.

Create did not have this problem as it first populates the `name` which is only shown when we have a list of item types (and populating `name` uses a wait to find the element).

so follow the same route a user would which is to type the name of the job first which means the list will have populated.

 the form has also changed so that enabling OK does not need a focus
 loss, as the even fires whenever the text changes.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
