### PR TITLE
NodeLabelParameterPluginTest is flaky

### DIFF
--- a/src/test/java/plugins/NodeLabelParameterPluginTest.java
+++ b/src/test/java/plugins/NodeLabelParameterPluginTest.java
@@ -33,7 +33,10 @@ import org.jenkinsci.test.acceptance.slave.SlaveController;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.pagefactory.ByChained;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 @WithPlugins({"command-launcher", "nodelabelparameter"})
 public class NodeLabelParameterPluginTest extends AbstractJUnitTest {
@@ -238,11 +241,14 @@ public class NodeLabelParameterPluginTest extends AbstractJUnitTest {
         assertThat(j.getLastBuild().waitUntilFinished().getNumber(), is(equalTo(1)));
         assertThat(s1.getBuildHistory().getBuildsOf(j), contains(b));
 
-        try {
-            assertThat(j.open(), Matchers.hasContent(s2.getName() + "\nis offline"));
-        } catch (AssertionError e) {
-            assertThat(j.open(), Matchers.hasContent(s2.getName() + " is offline"));
-        }
+        j.open();
+        // the build executor widget is asynchronously loaded/populated.
+        By by = new ByChained(By.className("app-builds-container"), By.className("jenkins-spinner"));
+        waitFor(driver)
+                .withMessage("waiting for build widget to load")
+                .until(ExpectedConditions.invisibilityOfElementLocated(by));
+
+        assertThat(driver, Matchers.hasContent(s2.getName() + "\nis offline"));
 
         // bring second slave online again
         s2.markOnline();


### PR DESCRIPTION
the test blindly got attempted to check the contents of the builds container which is populated asynchronously.

we now wait until the widget has loaded (the spinner is hidden) before trying to check the page content

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
