### PR TITLE
Deflake SnippetGeneratorTest

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/ArtifactArchiver.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/ArtifactArchiver.java
@@ -3,7 +3,7 @@ package org.jenkinsci.test.acceptance.po;
 /**
  * @author Kohsuke Kawaguchi
  */
-@Describable("Archive the artifacts")
+@Describable({"Archive the artifacts", "archiveArtifacts: Archive the artifacts"})
 public class ArtifactArchiver extends AbstractStep implements PostBuildStep {
     public ArtifactArchiver(Job parent, String path) {
         super(parent, path);

--- a/src/main/java/org/jenkinsci/test/acceptance/po/SnippetGenerator.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/SnippetGenerator.java
@@ -25,6 +25,11 @@ public class SnippetGenerator extends PageObject {
         return (WorkflowJob) super.getContext();
     }
 
+    public <T extends Step> T selectStep(Class<T> stepDescriptor) {
+        control("/").select(stepDescriptor);
+        return newInstance(stepDescriptor, getContext(), "/prototype");
+    }
+
     /**
      * Generates the sample pipeline script.
      *

--- a/src/test/java/org/jenkinsci/test/acceptance/po/SnippetGeneratorTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/po/SnippetGeneratorTest.java
@@ -17,7 +17,7 @@ public class SnippetGeneratorTest extends AbstractJUnitTest {
         SnippetGenerator snippetGenerator = new SnippetGenerator(job);
         snippetGenerator.open();
         ArtifactArchiver aa = snippetGenerator.selectStep(ArtifactArchiver.class);
-        aa.includes(null);
-        assertThat(snippetGenerator.generateScript(), is("archiveArtifacts artifacts: '', followSymlinks: false"));
+        aa.includes("*.bin");
+assertThat(snippetGenerator.generateScript(), is("archiveArtifacts artifacts: '*.bin', followSymlinks: false"));
     }
 }

--- a/src/test/java/org/jenkinsci/test/acceptance/po/SnippetGeneratorTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/po/SnippetGeneratorTest.java
@@ -16,7 +16,8 @@ public class SnippetGeneratorTest extends AbstractJUnitTest {
 
         SnippetGenerator snippetGenerator = new SnippetGenerator(job);
         snippetGenerator.open();
-
+        ArtifactArchiver aa = snippetGenerator.selectStep(ArtifactArchiver.class);
+        aa.includes(null);
         assertThat(snippetGenerator.generateScript(), is("archiveArtifacts artifacts: '', followSymlinks: false"));
     }
 }

--- a/src/test/java/org/jenkinsci/test/acceptance/po/SnippetGeneratorTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/po/SnippetGeneratorTest.java
@@ -18,6 +18,6 @@ public class SnippetGeneratorTest extends AbstractJUnitTest {
         snippetGenerator.open();
         ArtifactArchiver aa = snippetGenerator.selectStep(ArtifactArchiver.class);
         aa.includes("*.bin");
-assertThat(snippetGenerator.generateScript(), is("archiveArtifacts artifacts: '*.bin', followSymlinks: false"));
+        assertThat(snippetGenerator.generateScript(), is("archiveArtifacts artifacts: '*.bin', followSymlinks: false"));
     }
 }


### PR DESCRIPTION
loading of the describables HTML is asynchronous to the page load, so sometimes clicking on "generate snippet" would occur before the describables FORM had been injected into the page, which would mean the form submitted would be empty of all fields, and then the test would fail because

```
Expected: is "archiveArtifacts artifacts: '', followSymlinks: false"
     but: was "java.lang.NullPointerException: Cannot invoke \"String.trim()\" because \"artifacts\" is null
        at hudson.tasks.ArtifactArchiver.<init>(ArtifactArchiver.java:122)
        at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:483)
        at org.kohsuke.stapler.RequestImpl.invokeConstructor(RequestImpl.java:686)
        at org.kohsuke.stapler.RequestImpl.instantiate(RequestImpl.java:1015)
        at org.kohsuke.stapler.RequestImpl$TypePair.convertJSON(RequestImpl.java:866)
        at org.kohsuke.stapler.RequestImpl.bindJSON(RequestImpl.java:633)
        at org.kohsuke.stapler.RequestImpl.bindJSON(RequestImpl.java:628)
        at hudson.tasks.ArtifactArchiver$DescriptorImpl.newInstance(ArtifactArchiver.java:371)
        at hudson.tasks.ArtifactArchiver$DescriptorImpl.newInstance(ArtifactArchiver.java:340)
        at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.Snippetizer.doGenerateSnippet(Snippetizer.java:523)
        ..."
```

We now obtain the Step PageArea and forcibly interact with it.  This inturn calls `resolve()` on the control which waits until it is visible.

<!-- Please describe your pull request here. -->

### Testing done

extracted from #2713 where the test was reliably observed to fail (both locally and In CI).
rann 10 times with the fix and observed no failures.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
