### PR TITLE
another NodeLabelParameterPluginTest issue waiting for the build widget to load

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -515,9 +515,9 @@ public class Job extends TopLevelItem {
      */
     public void waitForBuildWidgetToLoad() {
         // the builds widget is asynchronously loaded/populated.
-        By by = new ByChained(By.className("app-builds-container"), By.className("jenkins-spinner"));
+        By spinnerLocator = new ByChained(By.className("app-builds-container"), By.className("jenkins-spinner"));
         waitFor(driver)
                 .withMessage("waiting for build widget to load")
-                .until(ExpectedConditions.invisibilityOfElementLocated(by));
+                .until(ExpectedConditions.invisibilityOfElementLocated(spinnerLocator));
     }
 }

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -514,7 +514,7 @@ public class Job extends TopLevelItem {
      * Population is defined as the initial async load has completed, the widget once loaded may or may not contain any build.
      */
     public void waitForBuildWidgetToLoad() {
-        // the build executor widget is asynchronously loaded/populated.
+        // the builds widget is asynchronously loaded/populated.
         By by = new ByChained(By.className("app-builds-container"), By.className("jenkins-spinner"));
         waitFor(driver)
                 .withMessage("waiting for build widget to load")

--- a/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Job.java
@@ -40,6 +40,8 @@ import org.junit.AssumptionViolatedException;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.pagefactory.ByChained;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.zeroturnaround.zip.ZipUtil;
 
 /**
@@ -505,5 +507,17 @@ public class Job extends TopLevelItem {
 
     private String xCopy(final String source, final String destination) {
         return "xcopy " + source + " " + destination + " /E /Y";
+    }
+
+    /**
+     * Waits for the build history widget to populate.
+     * Population is defined as the initial async load has completed, the widget once loaded may or may not contain any build.
+     */
+    public void waitForBuildWidgetToLoad() {
+        // the build executor widget is asynchronously loaded/populated.
+        By by = new ByChained(By.className("app-builds-container"), By.className("jenkins-spinner"));
+        waitFor(driver)
+                .withMessage("waiting for build widget to load")
+                .until(ExpectedConditions.invisibilityOfElementLocated(by));
     }
 }

--- a/src/test/java/plugins/NodeLabelParameterPluginTest.java
+++ b/src/test/java/plugins/NodeLabelParameterPluginTest.java
@@ -27,16 +27,14 @@ import org.jenkinsci.test.acceptance.plugins.textfinder.TextFinderPublisher;
 import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.jenkinsci.test.acceptance.po.JUnitPublisher;
+import org.jenkinsci.test.acceptance.po.Job;
 import org.jenkinsci.test.acceptance.po.Node;
 import org.jenkinsci.test.acceptance.po.Slave;
 import org.jenkinsci.test.acceptance.slave.SlaveController;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.pagefactory.ByChained;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 @WithPlugins({"command-launcher", "nodelabelparameter"})
 public class NodeLabelParameterPluginTest extends AbstractJUnitTest {
@@ -242,11 +240,7 @@ public class NodeLabelParameterPluginTest extends AbstractJUnitTest {
         assertThat(s1.getBuildHistory().getBuildsOf(j), contains(b));
 
         j.open();
-        // the build executor widget is asynchronously loaded/populated.
-        By by = new ByChained(By.className("app-builds-container"), By.className("jenkins-spinner"));
-        waitFor(driver)
-                .withMessage("waiting for build widget to load")
-                .until(ExpectedConditions.invisibilityOfElementLocated(by));
+        j.waitForBuildWidgetToLoad();
 
         assertThat(driver, Matchers.hasContent(s2.getName() + "\nis offline"));
 
@@ -552,11 +546,9 @@ public class NodeLabelParameterPluginTest extends AbstractJUnitTest {
     private String getPendingBuildText(Build build) {
         // ensure to be on the job's page otherwise we do not have the build history summary
         // to get their content
-        build.job.open();
-
-        // pending message comes from the queue, and queue's maintenance is asynchronous to UI threads.
-        // so if the original response doesn't contain it, we have to wait for the refresh of the build history.
-        // so give it a bigger wait.
+        Job j = build.job;
+        j.open();
+        j.waitForBuildWidgetToLoad();
         return find(by.css("#buildHistoryPage")).getText();
     }
 }


### PR DESCRIPTION
Pulled up the code waiting for the build widget into the Job PO.

checked for anything else using that may suffer the same with `rg buildHistoryPage src/` and only found one other use that is not impacted due to its use of `find` with the required classes that are only populated once the widget has loaded.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
