### PR TITLE
better diagnostics for TestRport.assertFailureContent

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/junit/TestReport.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/junit/TestReport.java
@@ -1,9 +1,12 @@
 package org.jenkinsci.test.acceptance.plugins.junit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.jenkinsci.test.acceptance.po.Action;
 import org.jenkinsci.test.acceptance.po.ActionPageObject;
@@ -48,23 +51,28 @@ public class TestReport extends Action {
         // that at least one of the pages have the requested content
 
         final List<WebElement> rows = all(by.xpath("//tr[@data='%s']", test));
+        assertThat("No test found with name " + test, rows, not(empty()));
 
-        boolean found = false;
+        List<String> contents = new ArrayList<>();
         for (WebElement row : rows) {
             // this is a javascript expand
             WebElement link = row.findElement(By.tagName("a"));
             link.click();
             WebElement details =
                     waitFor(row).ignoring(NoSuchElementException.class).until(TestReport::getTestDetailsRow);
-            found = details.getText().contains(content);
+            String c = details.getText();
             link.click(); // hide the content
             waitFor(details).until(CapybaraPortingLayerImpl::isStale);
-            if (found) {
-                break;
+            if (c.contains(content)) {
+                // we found what we where looking for return
+                return;
             }
+            // not our needle, save for later diagnostics
+            contents.add(c);
         }
-        assertThat("No test found with name " + test, rows, not(empty()));
-        assertThat("No test found with given content", found);
+        // if we got here we know that we have failed.
+        // but still assert so that we have a better idea of what we did find
+        assertThat("No test found with given content", contents, contains(containsString(content)));
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/test/acceptance/plugins/junit/TestReport.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/plugins/junit/TestReport.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.test.acceptance.plugins.junit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
 import java.util.ArrayList;
@@ -64,7 +64,7 @@ public class TestReport extends Action {
             link.click(); // hide the content
             waitFor(details).until(CapybaraPortingLayerImpl::isStale);
             if (c.contains(content)) {
-                // we found what we where looking for return
+                // we found what we were looking for; return
                 return;
             }
             // not our needle, save for later diagnostics
@@ -72,7 +72,7 @@ public class TestReport extends Action {
         }
         // if we got here we know that we have failed.
         // but still assert so that we have a better idea of what we did find
-        assertThat("No test found with given content", contents, contains(containsString(content)));
+        assertThat("No test found with given content", contents, hasItem(containsString(content)));
     }
 
     @Override


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Observed in https://github.com/jenkinsci/acceptance-test-harness/runs/79077204013 that the expected tests output was not there, but the screenshot looked right, so add some better diagnostics.

Rather than saying we did not find X, say also what we did find.

### Testing done

ran the sporadically failing test locally, it passed before the change and after the change.  Does not proove this code is good but its not breaking the happy case.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
