### PR TITLE
Save job before copying

### DIFF
--- a/src/test/java/core/FreestyleJobTest.java
+++ b/src/test/java/core/FreestyleJobTest.java
@@ -335,6 +335,7 @@ public class FreestyleJobTest extends AbstractJUnitTest {
     @Test
     public void copy_a_simple_job() {
         FreeStyleJob j = jenkins.jobs.create(FreeStyleJob.class, "simple-job");
+        j.save();
         jenkins.jobs.copy(j, "simple-job-copy");
         assertThat(driver, hasContent("simple-job-copy"));
 


### PR DESCRIPTION
The behavior change in https://github.com/jenkinsci/jenkins/commit/037c2c30cd26b926ec9df3d1b60e16b80608edb4 seems just enough to make this test fall over (`<actions/>` is [basically initialized randomly](https://github.com/jenkinsci/jenkins/blob/ad6da6a27530aae33b48369fb559d38d4b8a86bc/core/src/main/java/hudson/model/Actionable.java#L68-L98)), but in my testing adding this explicit call makes it pass again.

### Testing done

Locally executed the test

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
