### PR TITLE
[JENKINS-76483] Config File Provider plugin UI changes

### DIFF
--- a/src/test/java/plugins/ConfigFileProviderTest.java
+++ b/src/test/java/plugins/ConfigFileProviderTest.java
@@ -174,7 +174,7 @@ public class ConfigFileProviderTest extends AbstractJUnitTest {
         // We want to delete the config file and re-run the job to see it fail
         jenkins.visit("configfiles");
         // this won't age well
-        runThenHandleDialog(() -> driver.findElement(by.xpath("//td[.='%s']/parent::tr/td[2]/a[1]", mvnConfig.id()))
+        runThenHandleDialog(() -> driver.findElement(by.xpath("//td[.='%s']/parent::tr/td[6]/a[1]", mvnConfig.id()))
                 .click());
 
         jobLog = this.buildJobAndGetConsole(job, false);


### PR DESCRIPTION
This is due to https://github.com/jenkinsci/config-file-provider-plugin/pull/436.

The table listing the existing configuration files has been re-worked and the UI test for it was not able to "survive" the changes without changing itself.

### Testing done

Running `BROWSER=firefox JENKINS_VERSION=2.555.1 mvn test -Dtest=ConfigFileProviderTest` locally to validate the changes.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
