### PR TITLE
[JENKINS-76483] Fix delete button selector in ConfigFileProviderTest

### DIFF
--- a/src/test/java/plugins/ConfigFileProviderTest.java
+++ b/src/test/java/plugins/ConfigFileProviderTest.java
@@ -173,8 +173,8 @@ public class ConfigFileProviderTest extends AbstractJUnitTest {
 
         // We want to delete the config file and re-run the job to see it fail
         jenkins.visit("configfiles");
-        // this won't age well
-        runThenHandleDialog(() -> driver.findElement(by.xpath("//td[.='%s']/parent::tr/td[6]/a[1]", mvnConfig.id()))
+        runThenHandleDialog(() -> driver.findElement(
+                        by.xpath("//td[.='%s']/parent::tr//a[contains(@data-url,'removeConfig')]", mvnConfig.id()))
                 .click());
 
         jobLog = this.buildJobAndGetConsole(job, false);


### PR DESCRIPTION
:wave: Hello team!

This addresses [JENKINS-76483](https://issues.jenkins.io/browse/JENKINS-76483), caused by https://github.com/jenkinsci/config-file-provider-plugin/pull/436, very sorry about it :bow: 

## Summary
- The `testConfigFileProviderWithFolders` test was failing to locate the delete button on the config files page
- Switched the XPath selector from whatever attribute was previously used to `data-url` containing `removeConfig`
- This aligns with a UI change in the Config File Provider plugin that was already addressed in the page object layer

Thanks for your review :heart: 