### PR TITLE
fix Slave.launch() race when agent auto-reconnects before button click

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/po/Slave.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/po/Slave.java
@@ -162,7 +162,14 @@ public class Slave extends Node {
     public void launch() {
         if (isOffline()) {
             open();
-            clickButton("Launch agent");
+            try {
+                clickButton("Launch agent");
+            } catch (NoSuchElementException e) {
+                // The agent may have reconnected automatically
+                if (isOffline()) {
+                    throw e;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
`Slave.launch()` checks `isOffline()`, navigates to the agent page, then calls `clickButton("Launch agent")`.

https://github.com/jenkinsci/acceptance-test-harness/blob/ba42a2586f9f0bebaf14b8878b038e957c07566c/src/main/java/org/jenkinsci/test/acceptance/po/Slave.java#L162-L167

When the agent reconnects between the `isOffline()` check and the page load, the button is absent and Selenium throws `NoSuchElementException`. 

## Why it started failing recently

This test has been flaking frequently in private-infra ATH runs. 

https://github.com/jenkinsci/acceptance-test-harness/commit/a7c5c4bfcf9ce36635e02670d4da1ea44791acba deleted `disable-sticky-elements.js`, replacing the old JS-injection approach with the cookie-based mechanism from jenkinsci/jenkins#26883. Without the JS injection overhead on every Selenium interaction, `logout()` + `login()` + `open()` complete slightly faster. The agent's reconnect (triggered by `channelClosed()`) now finishes inside that window rather than after it.

### Evidence

log from a failing run

```
2026-08-06 06:44:44.744  Jenkins is fully up and running
2026-08-06 06:44:53.970  SlaveComputer#tryReconnect: Attempting to reconnect established_wood
2026-08-06 06:44:56.854  CommandLauncher#launch: agent launched for established_wood
2026-08-06 06:44:57.467  [Selenium hits /computer/established_wood/ :agent online, button absent]
```

The agent connects 600 ms before Selenium reaches the page. The "Launch agent" button is rendered only when `it.offline AND it.launchSupported AND !it.temporarilyOffline`; once the agent is online it is absent and `clickButton` throws.

`isOffline()` is a live HTTP call; `open()` triggers a full Selenium page navigation. Between those two calls the agent state can change.


[CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-73895)




### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
