### PR TITLE
Align JSpecify with Selenium 4.48

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - SE_SCREEN_WIDTH=1680
     extra_hosts:
       - host.docker.internal:host-gateway
-    image: selenium/standalone-firefox:4.45.0@sha256:13daa8c5e0803973e34fba9f526112717b425e2b45cd72cc218b757283023098
+    image: selenium/standalone-firefox:4.47.0@sha256:54bf6b69b790212c5dd1ae4934241d2dccd6500b14269b91e7ddfeef3f32c2a6
     networks:
       - ath-network
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <spotbugs.skip>true</spotbugs.skip>
     <jenkins.version>2.573</jenkins.version>
-    <selenium.version>4.45.0</selenium.version>
+    <selenium.version>4.48.0</selenium.version>
     <!-- aligned with selenium -->
     <guava.version>33.6.0-jre</guava.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,12 @@ and
         <artifactId>javassist</artifactId>
         <version>3.32.0-GA</version>
       </dependency>
+      <!-- RequireUpperBoundDeps between Guava and Selenium -->
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>1.0.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/vars.cmd
+++ b/vars.cmd
@@ -25,5 +25,5 @@ set TESTCONTAINERS_HOST_OVERRIDE=%IP%
 set JENKINS_LOCAL_HOSTNAME=%IP%
 @echo.
 @echo To start the remote firefox container run the following command:
-@echo docker run --shm-size=2g -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e SE_NODE_GRID_URL=http://127.0.0.1:4444 -e no_proxy=localhost -e SE_SCREEN_WIDTH=1680 -e SE_SCREEN_HEIGHT=1090 "selenium/standalone-firefox:4.45.0"
+@echo docker run --shm-size=2g -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e SE_NODE_GRID_URL=http://127.0.0.1:4444 -e no_proxy=localhost -e SE_SCREEN_WIDTH=1680 -e SE_SCREEN_HEIGHT=1090 "selenium/standalone-firefox:4.48.0"
 

--- a/vars.sh
+++ b/vars.sh
@@ -25,4 +25,4 @@ export TESTCONTAINERS_HOST_OVERRIDE="${IP}"
 export JENKINS_LOCAL_HOSTNAME="${IP}"
 
 echo "To start the remote Firefox container, run the following command:"
-echo "docker run --shm-size=2g -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e no_proxy=localhost -e SE_SCREEN_WIDTH=1680 -e SE_SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.45.0"
+echo "docker run --shm-size=2g -d -p 127.0.0.1:4444:4444 -p 127.0.0.1:5900:5900 -e no_proxy=localhost -e SE_SCREEN_WIDTH=1680 -e SE_SCREEN_HEIGHT=1090 selenium/standalone-firefox:4.48.0"


### PR DESCRIPTION
Companion fix for #2796.

Selenium 4.48.0 requires JSpecify 1.0.1, while Guava 33.6.0-jre still declares 1.0.0. Maven therefore selects 1.0.0 and the Jenkins build stops at `RequireUpperBoundDeps` before compilation.

Manage JSpecify at Selenium's required 1.0.1, following the existing dependency-management pattern for upper-bound conflicts. This changes only dependency convergence; it does not modify harness source or tests.

### Testing done

- Reproduced the failure from the exact Renovate head with `DISPLAY=:0 ./src/main/resources/ath-container/run.sh firefox lts -B clean process-test-resources` on JDK 25.
- Ran that same command after the change for both `lts` and `latest`; both passed, including Enforcer and compilation of 393 main sources.
- Ran `mvn -V -ntp -B dependency:tree -Dverbose -Dincludes=org.jspecify:jspecify`; every Guava and Selenium path converges on 1.0.1.
- Ran the Jenkins CI build command `mvn -V -e -ntp -B -Dset.changelist -DskipTests -U clean install` on JDK 25; passed, including main/test compilation, sources, Javadocs, Enforcer, and Spotless.
- Ran `mvn -V -e -ntp -B -DskipTests clean install` on JDK 21; passed, including compilation of 393 main and 93 test sources, Enforcer, and Spotless.

The high-memory browser acceptance matrix was not run locally; the repository CI matrix is expected to exercise it on this companion head.

### Submitter checklist

- [x] Opened from a topic branch.
- [x] The title represents the desired changelog entry.
- [x] Described the change and its cause.
- [x] Linked the relevant pull request: #2796.
- [x] Linked the upstream dependency update: #2796.
- [x] Provided verification that executes the changed dependency resolution and the failing build phase.

### AI assistance

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):

- `jaipilot-maintainer-intent`
- `jaipilot-fast-execution`
- `jaipilot-review-diff`

Execution profile: gpt-5.6-sol · xhigh · fast
